### PR TITLE
chore: scaffold FastAPI backend/ folder for monorepo setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,12 @@ CLAUDE.md
 
 # Private PM docs (internal only, do not push)
 pm_docs/
+
+# Python / FastAPI (backend/)
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+backend/.env
+backend/venv/
+backend/.venv/

--- a/README.md
+++ b/README.md
@@ -174,10 +174,13 @@ Frontend (Next.js — Vercel)
 │       ├── attendances    → profile_id, session_id, checked_at
 │       └── announcements  → author_id, title, content, created_at
 │
-└── FastAPI (Railway)
-    ├── /execute           → proxy to Piston API (code execution)
-    └── /attendance/verify → QR token validation logic
+└── FastAPI (Railway)                  ← lives in backend/ subfolder
+    ├── /health            → service health check
+    ├── /execute           → proxy to Piston API (code execution)      [W3]
+    └── /attendance/verify → QR token validation logic                 [W4]
 ```
+
+> **Monorepo structure:** Next.js runs from repo root (Vercel), FastAPI lives in `backend/` subfolder (Railway root directory = `backend/`).
 
 ---
 
@@ -228,6 +231,11 @@ codexperts-web/
 │   ├── guidelines/          # code-conventions.md, git-workflow.md, github-issues.md, design.md
 │   ├── specs/               # Feature overview and weekly sprint specs (w1–w6)
 │   └── schema/              # Database schema definitions (schema.sql + per-table .sql files)
+├── backend/
+│   ├── main.py              # FastAPI entry point (/health, /execute, /attendance/verify)
+│   ├── requirements.txt     # Python dependencies
+│   ├── .env.example         # Backend env vars template
+│   └── routers/             # Route modules (added per sprint)
 ├── package.json
 └── README.md
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+# Backend environment variables
+# Copy this file to .env and fill in values
+
+# Add backend-specific env vars here as needed
+# PISTON_API_URL=https://emkc.org/api/v2/piston

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(title="codeXperts API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:3000",
+        # Add Vercel preview URL here once available
+    ],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+# Routers added in later sprints:
+# from routers import execute, attendance
+# app.include_router(execute.router)     # W3: /execute
+# app.include_router(attendance.router)  # W4: /attendance/verify

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+python-dotenv

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,0 +1,3 @@
+# Route modules added in later sprints:
+# execute.py   — W3: POST /execute (Piston API proxy)
+# attendance.py — W4: POST /attendance/verify (QR check-in)


### PR DESCRIPTION
## Summary
- Adds `backend/` subfolder to the repo — monorepo approach, Next.js stays at root
- FastAPI app with `/health` endpoint and CORS configured for localhost
- `routers/` folder stubbed out for W3 (`/execute`) and W4 (`/attendance/verify`)
- `.gitignore` updated with Python patterns (`__pycache__`, `venv/`, `backend/.env`)
- README updated with monorepo structure note and `backend/` folder entry

## Railway Setup (for Dave)
- Root Directory: `backend/`
- Start command: `uvicorn main:app --host 0.0.0.0 --port $PORT`
- Add Vercel preview URL to `allow_origins` in `main.py` once available

## Test plan
- [ ] `cd backend && pip install -r requirements.txt`
- [ ] `uvicorn main:app --reload`
- [ ] `curl http://localhost:8000/health` returns `{"status": "ok"}`
- [ ] Next.js still runs normally from root: `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)