### PR TITLE
feat: Schedule page with Google Calendar integration and 3-Layer Depth UI (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ backend/venv/
 backend/.venv/
 backend/__pycache__/
 backend/.pytest_cache/
+
+# Local MCP config (contains personal API tokens)
+.mcp.json

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -79,7 +79,67 @@
 
 ---
 
-## 4. Component Specs
+## 4. 3-Layer Depth System
+
+Used on surfaces that need visual hierarchy without color or border overload. Applied first on the Schedule page event list and modal.
+
+### Color Layers (-15 RGB step from base surface)
+
+| Layer | Hex | RGB | Use |
+|-------|-----|-----|-----|
+| Layer 0 | `#F9F9F9` | 249 | Section background (bg-surface token) |
+| Layer 1 | `#EAEAEA` | 234 | Container card (wraps a grouped set of rows) |
+| Layer 2 | `#DBDBDB` | 219 | Individual row / pill (interactive element) |
+| Layer 2 hover | `#CFCFCF` | 207 | Row / pill hover state |
+
+Each step subtracts ~15 from all RGB channels, creating a consistent, perceptible depth without needing borders.
+
+### Shadow System (two-layer: dark sharp + soft spread)
+
+Each layer adds a shadow composed of two `box-shadow` values:
+
+```
+Layer 1 container:
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12),
+              0 2px 6px rgba(0,0,0,0.06);
+
+Layer 2 row (default):
+  box-shadow: 0 1px 2px rgba(0,0,0,0.19),
+              0 2px 4px rgba(0,0,0,0.08);
+
+Layer 2 row (hover):
+  box-shadow: 0 2px 4px rgba(0,0,0,0.22),
+              0 4px 8px rgba(0,0,0,0.10);
+```
+
+- **First value** — tight, dark shadow for a defined edge (high opacity, small blur/spread)
+- **Second value** — soft ambient shadow for perceived lift (low opacity, larger blur)
+
+### Usage Rules
+
+- Layer 0 is always the section background (`#F9F9F9`). Do not apply shadow here.
+- Layer 1 wraps a logical group (e.g., the entire event list card, a modal card).
+- Layer 2 is each individual interactive item within Layer 1 (pill, row, detail block).
+- Use `border-radius: 1rem` (Tailwind `rounded-2xl`) on Layer 1 containers and modal cards.
+- Use `border-radius: 9999px` (Tailwind `rounded-full`) on full-width row pills.
+- Use `border-radius: 1rem` (Tailwind `rounded-2xl`) on detail pills inside a modal.
+- Do NOT add a border to any layer — shadow provides the depth signal.
+- This system replaces the standard card border (`1px solid #E5E5E5`) on these surfaces.
+
+### When to Use
+
+Apply the 3-Layer Depth System when:
+- A section has a list of interactive items grouped under a heading card
+- A modal contains detail fields that should feel like nested elements
+- You want tactile depth (clickable rows) without accent color or border noise
+
+Do NOT apply to standard content cards, input fields, or navigation — use the existing Card / Input specs for those.
+
+---
+
+## 5. Component Specs
+
+> Standard reusable components. For surface-level grouped interactions, see Section 4 (3-Layer Depth System).
 
 ### Buttons
 
@@ -166,7 +226,7 @@ Style:
 
 ---
 
-## 5. Navigation Bar
+## 6. Navigation Bar
 
 ```
 [codeXperts logo]  Home  About▾  Updates▾  Events  |  (Practice▾)  (Members)  Join Us  [LinkedIn] [Email] [Instagram▾] ([Discord▾]) ({⚙})  [Log In]
@@ -216,7 +276,7 @@ Practice dropdown (member only):
 
 ---
 
-## 6. Footer
+## 7. Footer
 
 ```
 [codeXperts logo + tagline]
@@ -232,7 +292,7 @@ Events                    [Instagram icon ▾]
 
 ---
 
-## 7. Page Index
+## 8. Page Index
 
 | # | Page | Route | Visibility | Stitch File |
 |---|------|-------|------------|-------------|
@@ -253,7 +313,7 @@ Events                    [Instagram icon ▾]
 
 ---
 
-## 8. Page Layouts (Stitch Reference)
+## 9. Page Layouts (Stitch Reference)
 
 ### Page 1: `/` Home (public)
 
@@ -445,7 +505,7 @@ text-align: center
 
 ---
 
-## 8. Spacing & Responsive
+## 10. Spacing & Responsive
 
 ```
 Base unit: 4px multiples (8, 12, 16, 24, 32, 48)
@@ -456,7 +516,7 @@ Card grid: repeat(auto-fit, minmax(280px, 1fr))
 
 ---
 
-## 9. Monaco Editor Config (Problems page)
+## 11. Monaco Editor Config (Problems page)
 
 ```javascript
 theme: "vs"               // light theme — white background
@@ -468,7 +528,7 @@ minimap: { enabled: false }
 
 ---
 
-## 10. Usage Guide (How to Use in Code)
+## 12. Usage Guide (How to Use in Code)
 
 ### Colors
 Use Tailwind custom tokens instead of hardcoded hex values.

--- a/docs/design/page-specs/schedule.md
+++ b/docs/design/page-specs/schedule.md
@@ -1,27 +1,33 @@
 # Page: Schedule `/schedule`
 > Visibility: public
 
-## Design Tokens (summary)
-- BG: `#FFFFFF` / Surface: `#F9F9F9`
-- Accent: `#C0392B` (event dots on calendar)
-- Text: `#1A1A1A` / `#555555`
-- Font: Montserrat (headings) / Inter (body)
+## Design Tokens
+
+| Token | Value | Use |
+|-------|-------|-----|
+| BG Base | `#FFFFFF` | Calendar section background |
+| BG Surface | `#F9F9F9` | Page header + monthly event list section |
+| Layer 1 | `#EAEAEA` | Event list container card |
+| Layer 2 | `#DBDBDB` | Event row pill (normal) |
+| Layer 2 hover | `#CFCFCF` | Event row pill (hover) |
+| Accent | `#C0392B` | MapPin icon in event detail modal |
+| Text Primary | `#1A1A1A` | H1, H3, event date label |
+| Text Secondary | `#555555` | Subtitle, event title, modal fields |
+| Text Hint | `#999999` | Empty state / loading / error messages |
+| Font Heading | Montserrat | H1 (700), H3 (600) |
+| Font Body | Inter | All other text |
 
 ---
 
-## Stitch Instructions
+## Data Source
 
-**FOLLOW THIS SPEC EXACTLY. Do not add, remove, or rearrange any element.**
-
-- Background: `#FFFFFF` for calendar section, `#F9F9F9` for monthly event list. Do NOT change.
-- Font: Montserrat for H1/H3. Inter for event list items and buttons. Do NOT use any other font.
-- Accent `#C0392B` used ONLY on event dots in the monthly list. Nowhere else.
-- The Google Calendar embed is a GRAY PLACEHOLDER BOX: width 100% (max 1000px), height 600px, bg `#F3F3F3`, centered label "Google Calendar Embed". Do NOT try to render an actual calendar UI.
-- The two action buttons ([📅 Subscribe] and [⬇ Download .ics]) are side by side, BELOW the calendar embed. Both are secondary outline style — border 1px `#CCCCCC`, text `#555555`, radius 6px. Do NOT make either button red.
-- The monthly event list section is BELOW the two buttons, separated by a section bg change to `#F9F9F9`. It shows H3 "April 2026 Events" and a vertical list of events (red dot · date · title). Do NOT skip this section.
-- Monthly event list items: red dot (8px circle `#C0392B`) · date (Inter 500 14px `#1A1A1A`) · event title (Inter 400 14px `#555555`).
-- Do NOT add a list view toggle, week view, or any calendar alternative layout.
-- Do NOT add admin controls on this page.
+- **Calendar ID:** `codexperts2024@gmail.com` (public Google Calendar)
+- **iCal feed:** `https://calendar.google.com/calendar/ical/codexperts2024%40gmail.com/public/basic.ics`
+- **Subscribe URL:** `https://calendar.google.com/calendar/r?cid=codexperts2024@gmail.com`
+- **No Google Calendar API key required** — uses the public `.ics` feed parsed server-side
+- API route: `/api/calendar?year=YYYY&month=M`
+- Returns: `{ events: [{ date, title, location, description }] }`
+- Supports recurring events (RRULE: DAILY / WEEKLY / MONTHLY / YEARLY, BYDAY, INTERVAL, UNTIL, COUNT, EXDATE)
 
 ---
 
@@ -32,62 +38,55 @@
 │ NAVBAR                                    [Log In]  │
 ├─────────────────────────────────────────────────────┤
 │                                                     │
-│  PAGE HEADER  (bg: #F9F9F9, padding: 32px 0)        │
-│  H1: "Schedule"                                     │
+│  PAGE HEADER  (bg: #F9F9F9, py-12)                  │
+│  H1: "Schedule"  (Montserrat 700 36px #1A1A1A)      │
 │  Subtitle: "Stay up to date with codeXperts         │
 │             meetings, events, and deadlines."        │
+│  (Inter 400 16px #555555)                           │
 │                                                     │
 ├─────────────────────────────────────────────────────┤
 │                                                     │
-│  GOOGLE CALENDAR EMBED  (bg: #FFFFFF, padding: 48px)│
+│  CALENDAR SECTION  (bg: #FFFFFF, py-12)             │
 │  max-width: 1000px, centered                        │
 │                                                     │
-│  ┌─────────────────────────────────────────────┐    │
-│  │  ← April 2026 →                             │    │
-│  │  Su  Mo  Tu  We  Th  Fr  Sa                 │    │
-│  │   -   -   -   1   2   3   4                 │    │
-│  │   5   6   7  [8]  9  10  11  ← event dot    │    │
-│  │  12  13  14  15  16  17  18                 │    │
-│  │  19  20  21 [22] 23  24  25  ← event dot    │    │
-│  │  26  27  28  29  30   -   -                 │    │
-│  └─────────────────────────────────────────────┘    │
-│                                                     │
-│  Embed config: Google Calendar public iframe         │
-│  Height: 600px, responsive width                    │
-│                                                     │
-├─────────────────────────────────────────────────────┤
-│                                                     │
-│  CALENDAR ACTIONS  (padding: 24px 0)                │
-│  max-width: 1000px, centered, flex row              │
-│                                                     │
-│  [📅 Subscribe]       [⬇ Download .ics]             │
-│   Secondary outline    Secondary outline            │
-│                                                     │
-│  · [Subscribe]: Opens Google Calendar "Add to       │
-│    calendar" link (webcal:// or Google Calendar URL)│
-│  · [Download .ics]: Downloads the .ics file for     │
-│    import into Apple Calendar, Outlook, etc.        │
-│                                                     │
-├─────────────────────────────────────────────────────┤
-│                                                     │
-│  MONTHLY EVENT LIST  (bg: #F9F9F9, padding: 48px 0) │
-│  Dynamically updates when month changes in calendar │
-│  Pulled from Google Calendar API                    │
-│                                                     │
-│  H3: "April 2026 Events"  (updates with month)      │
+│  Month navigation row:                              │
+│    [←]  May 2026  [→]                               │
+│    ChevronLeft/Right icon buttons (20px)            │
+│    hover: bg #F3F3F3, color #1A1A1A                 │
+│    Month label: Montserrat 600 16px, min-w 140px    │
 │                                                     │
 │  ┌──────────────────────────────────────────────┐   │
-│  │ [red dot] Apr 5   Weekly Coding Session      │   │
-│  │ [red dot] Apr 12  Problem Submission Deadline│   │
-│  │ [red dot] Apr 20  Spring Coding Competition  │   │
-│  │ [red dot] Apr 27  Weekly Coding Session      │   │
+│  │  Google Calendar embed (iframe)              │   │
+│  │  height: 600px, width: 100%                  │   │
+│  │  border: 1px solid #E5E5E5, rounded           │   │
+│  │  src updates dynamically with month/year     │   │
 │  └──────────────────────────────────────────────┘   │
 │                                                     │
-│  · Event dot: 8px circle, color #C0392B             │
-│  · Date: Inter 500 14px, color #1A1A1A              │
-│  · Event title: Inter 400 14px, color #555555       │
-│  · Empty state: "No events this month."             │
-│  · Row hover: bg #FFFFFF, cursor default            │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  ACTION BUTTONS  (bg: #FFFFFF, pb-8)                │
+│  max-width: 1000px, flex row, gap-3                 │
+│                                                     │
+│  [📅 Subscribe]     [⬇ Download .ics]              │
+│   Secondary outline  Secondary outline              │
+│   → Google Calendar  → Downloads .ics file         │
+│     Add to calendar    (codexperts-schedule.ics)    │
+│                                                     │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  MONTHLY EVENT LIST  (bg: #F9F9F9, py-12)           │
+│  max-width: 1000px, centered                        │
+│                                                     │
+│  ┌── Layer 1: #EAEAEA rounded-2xl p-6 ─────────┐   │
+│  │  H3: "May 2026 Events" (Montserrat 600 20px) │   │
+│  │                                               │   │
+│  │  ┌── Layer 2: #DBDBDB rounded-full px-4 py-2┐│   │
+│  │  │  [May 3]  Weekly Coding Session           ││   │
+│  │  └──────────────────────────────────────────┘│   │
+│  │  ┌── Layer 2 ────────────────────────────────┐│   │
+│  │  │  [May 10]  Problem Submission Deadline    ││   │
+│  │  └──────────────────────────────────────────┘│   │
+│  └───────────────────────────────────────────────┘   │
 │                                                     │
 ├─────────────────────────────────────────────────────┤
 │ FOOTER                                              │
@@ -96,41 +95,154 @@
 
 ---
 
-## Button Specs
+## Month Navigation
 
-### [📅 Subscribe]
-```
-Style: Secondary outline — border 1px #CCCCCC, color #555555, radius 6px
-Icon: calendar icon (Lucide CalendarPlus), 16px, left of label
-Action: Opens webcal:// link OR Google Calendar "Add to my calendar" URL
-        in new tab
-```
+- **State:** `year` (number) + `month` (number, 1–12) stored in React state
+- **Prev / Next buttons** update state, which simultaneously:
+  1. Rebuilds the Google Calendar iframe `src` via `buildCalendarSrc(year, month)`
+  2. Triggers a new `fetch('/api/calendar?year=Y&month=M')` call for the event list
+- **iframe key:** set to `calendarSrc` so React unmounts/remounts when the URL changes
+- **Label:** `"May 2026"` format, centered, `min-width: 140px`
 
-### [⬇ Download .ics]
+---
+
+## Google Calendar Embed
+
 ```
-Style: Secondary outline — same as Subscribe
-Icon: download icon (Lucide Download), 16px, left of label
-Action: Triggers download of .ics file for the codeXperts calendar
-        Compatible with: Apple Calendar, Outlook, Google Calendar import
+src format:
+  https://calendar.google.com/calendar/embed
+  ?src=codexperts2024%40gmail.com
+  &ctz=America%2FToronto
+  &mode=MONTH
+  &dates=YYYYMM01%2FYYYYMM01
+
+iframe attributes:
+  width: 100%
+  height: 600px
+  border: 0
+  scrolling: no
+  frameBorder: 0
 ```
 
 ---
 
-## Monthly Event List — Behavior
+## Monthly Event List — 3-Layer Depth System
+
+| Layer | Element | Color | Shadow |
+|-------|---------|-------|--------|
+| Layer 0 | Section background | `#F9F9F9` | — |
+| Layer 1 | Event list container card | `#EAEAEA` | `0 1px 3px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06)` |
+| Layer 2 | Event row pill (button) | `#DBDBDB` | `0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)` |
+| Layer 2 hover | Event row pill hover | `#CFCFCF` | `0 2px 4px rgba(0,0,0,0.22), 0 4px 8px rgba(0,0,0,0.10)` |
+
+**Event row pill layout:**
 ```
-- Synced with the calendar embed's currently displayed month
-- When user clicks ← / → to change month in the Google Calendar embed,
-  the event list below updates to show that month's events
-- Data source: Google Calendar API (public calendar)
-- Events sorted by date ascending
-- If no events in the selected month: show "No events this month." in #999999
+[  Apr 8  ]  [  Weekly Coding Session  ]
+  date label      event title
+  Inter 700 xs    Inter 400 sm
+  #1A1A1A         #555555
+  shrink-0 w-12
 ```
+
+**States:**
+- Loading: `"Loading events..."` in `#999999`
+- Error: `"Unable to load events. Please try again later."` in `#999999`
+- Empty: `"No events this month."` in `#999999`
+
+---
+
+## Event Detail Modal
+
+Clicking any event row pill opens a modal overlay (no page navigation).
+
+```
+┌── Backdrop: rgba(0,0,0,0.30) ─────────────────────┐
+│                                                    │
+│  ┌── Layer 1: #EAEAEA rounded-2xl p-6 ──────────┐ │
+│  │                              [X] close button │ │
+│  │  Event Title   (Montserrat 600 18px #1A1A1A)  │ │
+│  │  Full date     (Inter 400 14px #555555)       │ │
+│  │                                               │ │
+│  │  ┌── Layer 2 pill (if location) ───────────┐  │ │
+│  │  │ 📍 Location text (underlined)           │  │ │
+│  │  │    → links to Google Maps search        │  │ │
+│  │  └─────────────────────────────────────────┘  │ │
+│  │                                               │ │
+│  │  ┌── Layer 2 pill (if description) ────────┐  │ │
+│  │  │ ≡ Description text                      │  │ │
+│  │  └─────────────────────────────────────────┘  │ │
+│  │                                               │ │
+│  │  (if neither: "No additional details.")       │ │
+│  └───────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────┘
+```
+
+**Modal behavior:**
+- Close: click backdrop / press Escape / click X button
+- Location pill: `<a>` to `https://www.google.com/maps/search/?api=1&query=ENCODED_LOCATION`
+  - Opens in new tab, `rel="noopener noreferrer"`
+  - MapPin icon: `#C0392B`, text underlined
+  - Hover: bg `#CFCFCF`, stronger shadow
+- Description pill: plain text, AlignLeft icon `#555555`
+
+---
+
+## Action Buttons
+
+### Subscribe
+```
+Label: "Subscribe"
+Icon: CalendarPlus (Lucide, 16px)
+Style: Secondary outline — border 1px #CCCCCC, color #555555, radius 6px, px-4 py-2
+Hover: border-color #1A1A1A, color #1A1A1A
+Action: Opens https://calendar.google.com/calendar/r?cid=codexperts2024@gmail.com in new tab
+```
+
+### Download .ics
+```
+Label: "Download .ics"
+Icon: Download (Lucide, 16px)
+Style: Secondary outline — same as Subscribe
+Action: Downloads .ics file from Google Calendar public feed
+        download attribute: "codexperts-schedule.ics"
+```
+
+---
+
+## API Route: `/api/calendar`
+
+**File:** `src/app/api/calendar/route.js`
+
+**Request:** `GET /api/calendar?year=2026&month=5`
+
+**Response:**
+```json
+{
+  "events": [
+    {
+      "date": "2026-05-04T18:00:00.000Z",
+      "title": "Weekly Coding Session",
+      "location": "Room A1234, Seneca@York",
+      "description": "Bring your laptop."
+    }
+  ]
+}
+```
+
+**iCal parsing features:**
+- Line unfolding (CRLF + space/tab continuation)
+- Text cleaning (escaped `\n`, `\,`, `\\`)
+- DTSTART formats: date-only (`20260504`), datetime local, datetime UTC
+- RRULE expansion: FREQ (DAILY/WEEKLY/MONTHLY/YEARLY), BYDAY, INTERVAL, UNTIL, COUNT
+- EXDATE support (cancelled occurrences)
+- Events sorted ascending by date
 
 ---
 
 ## Notes
-- Google Calendar iframe must be set to public visibility
-- Calendar embed: use Google Calendar's embeddable URL with minimal UI
-- Subscribe / Download buttons reference the same public Google Calendar
-- Monthly event list is a separate component below the embed (not part of iframe)
-- No admin controls on this page — schedule is managed via Google Calendar directly
+
+- Google Calendar must be set to **public** visibility for the iCal feed to be accessible
+- No Google API key required — public `.ics` feed is sufficient
+- Month navigation is controlled client-side; the iframe reloads via `key` prop change
+- The event list is a completely separate React-rendered section (not part of the iframe)
+- No admin controls on this page — all schedule management is done via Google Calendar

--- a/docs/sprints/w3.md
+++ b/docs/sprints/w3.md
@@ -1,13 +1,23 @@
-# Week 3 — Member Features & Coding Problems
+# Week 3 — Member Features & Coding Problems + Schedule Page
 
 ## Goals
 
 Build all member-only features and the full coding problem flow end-to-end.
 A member should be able to browse problems, write code, run it, and submit — all in the browser.
 
+Also carried over from Week 2: **Schedule page** (Issue #18) — Google Calendar integration with live event list.
+
 ---
 
 ## Deliverables
+
+### Schedule Page (Issue #18) — Completed
+- **Google Calendar embed** — public iframe with dynamic month/year src, custom `[ ← ] Month [ → ]` navigation
+- **Monthly event list** — auto-synced with the displayed month via `/api/calendar` route (server-side iCal parse, no API key)
+- **RRULE support** — recurring events (DAILY/WEEKLY/MONTHLY/YEARLY, BYDAY, INTERVAL, UNTIL, COUNT, EXDATE)
+- **Event detail modal** — in-page overlay with title, full date, location (Google Maps link), description
+- **3-Layer Depth UI** — `#F9F9F9` → `#EAEAEA` → `#DBDBDB` depth system with two-layer box-shadow
+- **Action buttons** — Subscribe (→ Google Calendar add link) + Download .ics (public feed)
 
 ### Backend
 - **FastAPI `/execute` endpoint** — receives code + language, proxies to Piston API, returns stdout/stderr
@@ -39,6 +49,13 @@ A member should be able to browse problems, write code, run it, and submit — a
 
 ## Done When
 
+- [x] Schedule page renders Google Calendar embed with month navigation
+- [x] Monthly event list auto-fetches and displays events for the selected month
+- [x] Recurring events (RRULE) expand correctly into the event list
+- [x] Clicking an event row opens a detail modal (title, date, location, description)
+- [x] Location in modal links to Google Maps
+- [x] Subscribe and Download .ics action buttons work
+- [x] 3-Layer Depth UI applied to event list section and modal
 - [ ] Problem list page loads all active problems
 - [ ] Monaco Editor renders and accepts code input
 - [ ] Run button executes code and displays output (stdout / stderr)

--- a/docs/sprints/w3.md
+++ b/docs/sprints/w3.md
@@ -15,9 +15,17 @@ Also carried over from Week 2: **Schedule page** (Issue #18) — Google Calendar
 - **Google Calendar embed** — public iframe with dynamic month/year src, custom `[ ← ] Month [ → ]` navigation
 - **Monthly event list** — auto-synced with the displayed month via `/api/calendar` route (server-side iCal parse, no API key)
 - **RRULE support** — recurring events (DAILY/WEEKLY/MONTHLY/YEARLY, BYDAY, INTERVAL, UNTIL, COUNT, EXDATE)
-- **Event detail modal** — in-page overlay with title, full date, location (Google Maps link), description
-- **3-Layer Depth UI** — `#F9F9F9` → `#EAEAEA` → `#DBDBDB` depth system with two-layer box-shadow
+- **Event detail modal** — in-page overlay with title, full date, time, location (Google Maps link), description
+- **3-Layer Depth UI** — Tailwind custom tokens (`bg-bg-layer1/2/2Hover`); `#F9F9F9` → `#EAEAEA` → `#DBDBDB` depth system with two-layer box-shadow
 - **Action buttons** — Subscribe (→ Google Calendar add link) + Download .ics (public feed)
+- **Event start/end time** — displayed in list pill and modal; UTC events converted to `America/Toronto` via Intl API (DST-aware)
+- **Bug fixes (post-review)**
+  - EXDATE `VALUE=DATE` timezone bug: date-only strings parsed as local midnight (`new Date(y,m,d)`) instead of UTC midnight to prevent day-shift in UTC-N timezones
+  - UTC time display: `formatIcsTime` now branches on `Z` suffix — UTC events converted to Toronto via `toLocaleTimeString({ timeZone: 'America/Toronto' })`, TZID-local events extracted directly
+  - WEEKLY+BYDAY UNTIL guard: per-candidate check added inside inner loop to prevent occurrences past the recurrence end date
+  - Race condition: `fetchEvents` wrapped in `useCallback` + `AbortController`; aborted requests silently ignored
+  - Stable React key: `key={event.date+event.title}` replaces array index
+  - Body scroll lock while modal is open
 
 ### Backend
 - **FastAPI `/execute` endpoint** — receives code + language, proxies to Piston API, returns stdout/stderr
@@ -52,10 +60,13 @@ Also carried over from Week 2: **Schedule page** (Issue #18) — Google Calendar
 - [x] Schedule page renders Google Calendar embed with month navigation
 - [x] Monthly event list auto-fetches and displays events for the selected month
 - [x] Recurring events (RRULE) expand correctly into the event list
-- [x] Clicking an event row opens a detail modal (title, date, location, description)
+- [x] Deleted recurring occurrences (EXDATE) correctly excluded from the list
+- [x] Clicking an event row opens a detail modal (title, date, time, location, description)
 - [x] Location in modal links to Google Maps
 - [x] Subscribe and Download .ics action buttons work
-- [x] 3-Layer Depth UI applied to event list section and modal
+- [x] 3-Layer Depth UI applied to event list section and modal; Tailwind custom tokens added
+- [x] Event start/end time shown in pill and modal, correct in America/Toronto timezone
+- [x] Race condition on fast month navigation resolved (AbortController)
 - [ ] Problem list page loads all active problems
 - [ ] Monaco Editor renders and accepts code input
 - [ ] Run button executes code and displays output (stdout / stderr)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^13.5.0",
+        "lucide-react": "^1.14.0",
         "next": "^16.2.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -862,7 +863,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1122,7 +1122,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1510,7 +1509,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -1540,6 +1538,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lucide-react": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
@@ -1797,7 +1804,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1981,7 +1987,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1991,7 +1996,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2344,7 +2348,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^13.5.0",
+    "lucide-react": "^1.14.0",
     "next": "^16.2.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/app/api/calendar/route.js
+++ b/src/app/api/calendar/route.js
@@ -1,0 +1,219 @@
+import { NextResponse } from 'next/server';
+
+const ICS_URL =
+  'https://calendar.google.com/calendar/ical/codexperts2024%40gmail.com/public/basic.ics';
+
+const DAY_ABBR = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
+
+// Parse a raw DTSTART / DTEND / UNTIL value into a JS Date.
+// Handles: 20260408T180000Z  |  20260408T180000  |  20260408
+const parseIcsDate = (raw) => {
+  if (!raw) return null;
+  // Strip any TZID=... prefix before the colon
+  const clean = raw.includes(':') ? raw.split(':').pop().trim() : raw.trim();
+  if (clean.length === 8) {
+    return new Date(`${clean.slice(0, 4)}-${clean.slice(4, 6)}-${clean.slice(6, 8)}`);
+  }
+  return new Date(
+    `${clean.slice(0, 4)}-${clean.slice(4, 6)}-${clean.slice(6, 8)}T` +
+      `${clean.slice(9, 11)}:${clean.slice(11, 13)}:${clean.slice(13, 15)}` +
+      (clean.endsWith('Z') ? 'Z' : '')
+  );
+};
+
+// Unfold iCal line continuations (CRLF + space/tab)
+const unfoldLines = (text) =>
+  text.replace(/\r\n[ \t]/g, '').replace(/\n[ \t]/g, '');
+
+// Clean escaped characters from a summary string
+const cleanText = (s) =>
+  s.replace(/\\n/g, ' ').replace(/\\,/g, ',').replace(/\\/g, '');
+
+// Build a Google Calendar day-view URL for a given date
+const buildDayUrl = (date) => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `https://calendar.google.com/calendar/r/day/${y}/${m}/${d}`;
+};
+
+// Parse RRULE string into a key-value object
+// e.g. "FREQ=WEEKLY;BYDAY=MO,WE;INTERVAL=2" → { FREQ:'WEEKLY', BYDAY:'MO,WE', INTERVAL:'2' }
+const parseRRule = (rruleStr) => {
+  const rule = {};
+  rruleStr.split(';').forEach((part) => {
+    const idx = part.indexOf('=');
+    if (idx !== -1) rule[part.slice(0, idx)] = part.slice(idx + 1);
+  });
+  return rule;
+};
+
+// Add N days to a Date (returns a new Date)
+const addDays = (d, n) => new Date(d.getTime() + n * 86400000);
+
+// Add N months to a Date (returns a new Date, preserving time-of-day)
+const addMonths = (d, n) => {
+  const result = new Date(d);
+  result.setMonth(result.getMonth() + n);
+  return result;
+};
+
+// Expand a recurring VEVENT into concrete dates that fall within [rangeStart, rangeEnd]
+const expandRRule = (dtstart, rruleStr, exdates, rangeStart, rangeEnd) => {
+  const rule = parseRRule(rruleStr);
+  const freq = rule.FREQ;
+  const interval = parseInt(rule.INTERVAL ?? '1', 10);
+  const until = rule.UNTIL ? parseIcsDate(rule.UNTIL) : null;
+  const count = rule.COUNT ? parseInt(rule.COUNT, 10) : Infinity;
+
+  // Days of week for WEEKLY+BYDAY (e.g. ["MO","WE"])
+  const byDays = rule.BYDAY
+    ? rule.BYDAY.split(',').map((d) => d.replace(/^[+-]?\d+/, ''))
+    : null;
+
+  const occurrences = [];
+  let current = new Date(dtstart);
+  let totalGenerated = 0;
+  const MAX_ITER = 2000; // safety cap
+
+  for (let iter = 0; iter < MAX_ITER; iter++) {
+    // Termination checks
+    if (until && current > until) break;
+    if (totalGenerated >= count) break;
+    if (current > rangeEnd) break;
+
+    if (freq === 'WEEKLY' && byDays) {
+      // Emit all matching days within the current week
+      const weekStart = new Date(current);
+      for (let di = 0; di < 7; di++) {
+        const candidate = addDays(weekStart, di);
+        const abbr = Object.keys(DAY_ABBR).find(
+          (k) => DAY_ABBR[k] === candidate.getDay()
+        );
+        if (byDays.includes(abbr)) {
+          totalGenerated++;
+          const isExdate = exdates.some(
+            (ex) => ex.toDateString() === candidate.toDateString()
+          );
+          if (!isExdate && candidate >= rangeStart && candidate <= rangeEnd) {
+            occurrences.push(new Date(candidate));
+          }
+          if (totalGenerated >= count) break;
+        }
+      }
+      // Advance by INTERVAL weeks
+      current = addDays(current, 7 * interval);
+    } else {
+      // DAILY / MONTHLY / YEARLY  (or WEEKLY without BYDAY)
+      const isExdate = exdates.some(
+        (ex) => ex.toDateString() === current.toDateString()
+      );
+      if (!isExdate && current >= rangeStart) {
+        occurrences.push(new Date(current));
+      }
+      totalGenerated++;
+
+      switch (freq) {
+        case 'DAILY':
+          current = addDays(current, interval);
+          break;
+        case 'WEEKLY':
+          current = addDays(current, 7 * interval);
+          break;
+        case 'MONTHLY':
+          current = addMonths(current, interval);
+          break;
+        case 'YEARLY':
+          current = addMonths(current, 12 * interval);
+          break;
+        default:
+          return occurrences; // unsupported FREQ — bail out
+      }
+    }
+  }
+
+  return occurrences;
+};
+
+// Parse all VEVENT blocks and return events for the requested month
+const parseEvents = (icsText, year, month) => {
+  const text = unfoldLines(icsText);
+  const blocks = text.split('BEGIN:VEVENT').slice(1);
+
+  const rangeStart = new Date(year, month - 1, 1, 0, 0, 0);
+  const rangeEnd = new Date(year, month, 0, 23, 59, 59);
+
+  const events = [];
+
+  for (const block of blocks) {
+    const get = (key) => {
+      // Match KEY or KEY;param=value: value
+      const re = new RegExp(`^${key}(?:;[^:]*)?:(.+)`, 'm');
+      const m = block.match(re);
+      return m ? m[1].trim() : null;
+    };
+
+    const rawStart = get('DTSTART');
+    const summary = get('SUMMARY') || 'Untitled Event';
+    const rrule = get('RRULE');
+
+    if (!rawStart) continue;
+
+    const dtstart = parseIcsDate(rawStart);
+    if (!dtstart || isNaN(dtstart)) continue;
+
+    const title = cleanText(summary);
+
+    // Extract additional event fields
+    const location = get('LOCATION') ? cleanText(get('LOCATION')) : null;
+    const description = get('DESCRIPTION') ? cleanText(get('DESCRIPTION')) : null;
+
+    if (rrule) {
+      // --- Recurring event ---
+      const exdates = [];
+      const exdateRe = /^EXDATE(?:;[^:]*)?:(.+)/gm;
+      let exMatch;
+      while ((exMatch = exdateRe.exec(block)) !== null) {
+        exMatch[1].split(',').forEach((raw) => {
+          const d = parseIcsDate(raw.trim());
+          if (d && !isNaN(d)) exdates.push(d);
+        });
+      }
+
+      const occurrences = expandRRule(dtstart, rrule, exdates, rangeStart, rangeEnd);
+      for (const occ of occurrences) {
+        events.push({ date: occ.toISOString(), title, location, description });
+      }
+    } else {
+      // --- One-time event ---
+      if (dtstart >= rangeStart && dtstart <= rangeEnd) {
+        events.push({ date: dtstart.toISOString(), title, location, description });
+      }
+    }
+  }
+
+  events.sort((a, b) => new Date(a.date) - new Date(b.date));
+  return events;
+};
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const year = parseInt(searchParams.get('year'), 10);
+    const month = parseInt(searchParams.get('month'), 10);
+
+    if (!year || !month || month < 1 || month > 12) {
+      return NextResponse.json({ error: 'Invalid year or month' }, { status: 400 });
+    }
+
+    const res = await fetch(ICS_URL, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`Failed to fetch calendar: ${res.status}`);
+
+    const icsText = await res.text();
+    const events = parseEvents(icsText, year, month);
+
+    return NextResponse.json({ events });
+  } catch {
+    return NextResponse.json({ error: 'Failed to load calendar events' }, { status: 500 });
+  }
+}

--- a/src/app/api/calendar/route.js
+++ b/src/app/api/calendar/route.js
@@ -49,11 +49,31 @@ const cleanText = (s) =>
 const cleanRaw = (raw) =>
   raw ? (raw.includes(':') ? raw.split(':').pop().trim() : raw.trim()) : '';
 
-// Format a bare iCal datetime string as "h:mm AM/PM".
-// Returns null for date-only strings (no time component).
-// Time is extracted as a string operation — no Date object, no timezone conversion.
+// Format a bare iCal datetime string as "h:mm AM/PM" in America/Toronto time.
+// Returns null for date-only strings (no time component, length < 15).
+//
+// Two formats exist in the wild:
+//   "20260513T013000Z"   — UTC (Z suffix) → convert to Toronto via Intl API
+//   "20260525T180000"    — local/TZID-stripped → treat as Toronto wall-clock time
 const formatIcsTime = (clean) => {
   if (!clean || clean.length < 15) return null;
+
+  if (clean.endsWith('Z')) {
+    // UTC datetime — convert to America/Toronto using the Intl API (handles DST correctly)
+    const utcDate = new Date(
+      `${clean.slice(0, 4)}-${clean.slice(4, 6)}-${clean.slice(6, 8)}T` +
+      `${clean.slice(9, 11)}:${clean.slice(11, 13)}:${clean.slice(13, 15)}Z`
+    );
+    return utcDate.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+      timeZone: 'America/Toronto',
+    });
+  }
+
+  // TZID-stripped local time (e.g. TZID=America/Toronto:20260525T180000 → "20260525T180000")
+  // The wall-clock digits are already Toronto time — extract directly.
   const h = parseInt(clean.slice(9, 11), 10);
   const m = parseInt(clean.slice(11, 13), 10);
   const period = h >= 12 ? 'PM' : 'AM';

--- a/src/app/api/calendar/route.js
+++ b/src/app/api/calendar/route.js
@@ -44,14 +44,6 @@ const unfoldLines = (text) =>
 const cleanText = (s) =>
   s.replace(/\\n/g, ' ').replace(/\\,/g, ',').replace(/\\/g, '');
 
-// Build a Google Calendar day-view URL for a given date
-const buildDayUrl = (date) => {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `https://calendar.google.com/calendar/r/day/${y}/${m}/${d}`;
-};
-
 // Parse RRULE string into a key-value object
 // e.g. "FREQ=WEEKLY;BYDAY=MO,WE;INTERVAL=2" → { FREQ:'WEEKLY', BYDAY:'MO,WE', INTERVAL:'2' }
 const parseRRule = (rruleStr) => {
@@ -106,6 +98,7 @@ const expandRRule = (dtstart, rruleStr, exdates, rangeStart, rangeEnd) => {
           (k) => DAY_ABBR[k] === candidate.getDay()
         );
         if (byDays.includes(abbr)) {
+          if (until && candidate > until) break; // candidate exceeds UNTIL — end of recurrence
           totalGenerated++;
           const isExdate = exdates.some(
             (ex) => ex.toDateString() === candidate.toDateString()

--- a/src/app/api/calendar/route.js
+++ b/src/app/api/calendar/route.js
@@ -44,6 +44,23 @@ const unfoldLines = (text) =>
 const cleanText = (s) =>
   s.replace(/\\n/g, ' ').replace(/\\,/g, ',').replace(/\\/g, '');
 
+// Strip TZID/VALUE prefix and return the bare datetime string
+// e.g. "America/Toronto:20260525T180000" → "20260525T180000"
+const cleanRaw = (raw) =>
+  raw ? (raw.includes(':') ? raw.split(':').pop().trim() : raw.trim()) : '';
+
+// Format a bare iCal datetime string as "h:mm AM/PM".
+// Returns null for date-only strings (no time component).
+// Time is extracted as a string operation — no Date object, no timezone conversion.
+const formatIcsTime = (clean) => {
+  if (!clean || clean.length < 15) return null;
+  const h = parseInt(clean.slice(9, 11), 10);
+  const m = parseInt(clean.slice(11, 13), 10);
+  const period = h >= 12 ? 'PM' : 'AM';
+  const h12 = h % 12 || 12;
+  return `${h12}:${m.toString().padStart(2, '0')} ${period}`;
+};
+
 // Parse RRULE string into a key-value object
 // e.g. "FREQ=WEEKLY;BYDAY=MO,WE;INTERVAL=2" → { FREQ:'WEEKLY', BYDAY:'MO,WE', INTERVAL:'2' }
 const parseRRule = (rruleStr) => {
@@ -162,6 +179,7 @@ const parseEvents = (icsText, year, month) => {
     };
 
     const rawStart = get('DTSTART');
+    const rawEnd = get('DTEND');
     const summary = get('SUMMARY') || 'Untitled Event';
     const rrule = get('RRULE');
 
@@ -175,6 +193,12 @@ const parseEvents = (icsText, year, month) => {
     // Extract additional event fields
     const location = get('LOCATION') ? cleanText(get('LOCATION')) : null;
     const description = get('DESCRIPTION') ? cleanText(get('DESCRIPTION')) : null;
+
+    // Extract start/end times directly from raw iCal strings to avoid timezone conversion.
+    // All occurrences of a recurring event share the same clock time, so we derive
+    // the time once from DTSTART/DTEND and reuse it for every occurrence.
+    const startTime = formatIcsTime(cleanRaw(rawStart));
+    const endTime = rawEnd ? formatIcsTime(cleanRaw(rawEnd)) : null;
 
     if (rrule) {
       // --- Recurring event ---
@@ -190,12 +214,12 @@ const parseEvents = (icsText, year, month) => {
 
       const occurrences = expandRRule(dtstart, rrule, exdates, rangeStart, rangeEnd);
       for (const occ of occurrences) {
-        events.push({ date: occ.toISOString(), title, location, description });
+        events.push({ date: occ.toISOString(), title, location, description, startTime, endTime });
       }
     } else {
       // --- One-time event ---
       if (dtstart >= rangeStart && dtstart <= rangeEnd) {
-        events.push({ date: dtstart.toISOString(), title, location, description });
+        events.push({ date: dtstart.toISOString(), title, location, description, startTime, endTime });
       }
     }
   }

--- a/src/app/api/calendar/route.js
+++ b/src/app/api/calendar/route.js
@@ -1,18 +1,33 @@
 import { NextResponse } from 'next/server';
 
+// Force this route to be dynamic so Next.js never caches the response
+export const dynamic = 'force-dynamic';
+
 const ICS_URL =
   'https://calendar.google.com/calendar/ical/codexperts2024%40gmail.com/public/basic.ics';
 
 const DAY_ABBR = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
 
-// Parse a raw DTSTART / DTEND / UNTIL value into a JS Date.
-// Handles: 20260408T180000Z  |  20260408T180000  |  20260408
+// Parse a raw DTSTART / DTEND / UNTIL / EXDATE value into a JS Date.
+// Handles:
+//   20260408T180000Z  — datetime UTC
+//   20260408T180000   — datetime local (no tz)
+//   20260408          — date-only (VALUE=DATE)
+//
+// IMPORTANT: date-only values must be constructed with new Date(y, m, d) so
+// that they land at LOCAL midnight. Using new Date("2026-06-08") instead
+// produces UTC midnight, which in western timezones (UTC-N) resolves to the
+// previous calendar day and breaks EXDATE comparisons.
 const parseIcsDate = (raw) => {
   if (!raw) return null;
-  // Strip any TZID=... prefix before the colon
+  // Strip any TZID=... or VALUE=DATE prefix before the colon
   const clean = raw.includes(':') ? raw.split(':').pop().trim() : raw.trim();
   if (clean.length === 8) {
-    return new Date(`${clean.slice(0, 4)}-${clean.slice(4, 6)}-${clean.slice(6, 8)}`);
+    // Date-only: parse as local midnight to avoid UTC-offset day-shift
+    const y = parseInt(clean.slice(0, 4), 10);
+    const m = parseInt(clean.slice(4, 6), 10) - 1; // 0-indexed month
+    const d = parseInt(clean.slice(6, 8), 10);
+    return new Date(y, m, d);
   }
   return new Date(
     `${clean.slice(0, 4)}-${clean.slice(4, 6)}-${clean.slice(6, 8)}T` +
@@ -212,7 +227,9 @@ export async function GET(request) {
     const icsText = await res.text();
     const events = parseEvents(icsText, year, month);
 
-    return NextResponse.json({ events });
+    return NextResponse.json({ events }, {
+      headers: { 'Cache-Control': 'no-store' },
+    });
   } catch {
     return NextResponse.json({ error: 'Failed to load calendar events' }, { status: 500 });
   }

--- a/src/app/schedule/page.js
+++ b/src/app/schedule/page.js
@@ -23,7 +23,6 @@ const formatEventDate = (isoString) => {
 
 // Build the Google Calendar embed src for a given month
 const buildCalendarSrc = (year, month) => {
-  // First day of the month in YYYYMMDD format
   const pad = (n) => String(n).padStart(2, '0');
   const dateStr = `${year}${pad(month)}01`;
   return (
@@ -60,79 +59,68 @@ const EventModal = ({ event, onClose }) => {
       style={{ backgroundColor: 'rgba(0,0,0,0.30)' }}
       onClick={onClose}
     >
-      {/* Modal card — Layer 1 */}
+      {/* Modal card — Layer 1 (#EAEAEA) */}
       <div
-        className="relative w-full max-w-md rounded-2xl p-6"
-        style={{
-          backgroundColor: '#EAEAEA',
-          boxShadow: '0 8px 24px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.10)',
-        }}
+        className="relative w-full max-w-md rounded-2xl p-6 bg-bg-layer1"
+        style={{ boxShadow: '0 8px 24px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.10)' }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 p-1 rounded-full hover:bg-[#DBDBDB] transition-colors text-[#555555]"
+          className="absolute top-4 right-4 p-1 rounded-full hover:bg-bg-layer2 transition-colors text-text-secondary"
           aria-label="Close"
         >
           <X size={18} />
         </button>
 
         {/* Title */}
-        <h4 className="font-montserrat text-lg font-semibold text-[#1A1A1A] pr-8 mb-1">
+        <h4 className="font-montserrat text-lg font-semibold text-text-primary pr-8 mb-1">
           {event.title}
         </h4>
         {/* Date */}
-        <p className="font-inter text-sm text-[#555555] mb-1">{fullDate}</p>
-        {/* Time (only for timed events) */}
-        {event.startTime && (
-          <p className="font-inter text-sm text-[#555555] mb-4">
-            {event.startTime}{event.endTime ? ` – ${event.endTime}` : ''}
-          </p>
-        )}
-        {!event.startTime && <div className="mb-4" />}
+        <p className="font-inter text-sm text-text-secondary mb-1">{fullDate}</p>
+        {/* Time — shown only for timed events (startTime + endTime both present) */}
+        {event.startTime && event.endTime
+          ? <p className="font-inter text-sm text-text-secondary mb-4">{event.startTime} – {event.endTime}</p>
+          : <div className="mb-4" />
+        }
 
-        {/* Details — Layer 2 pills */}
+        {/* Details — Layer 2 pills (#DBDBDB) */}
         <div className="space-y-3">
           {event.location && (
             <a
               href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-start gap-3 rounded-2xl px-4 py-3 transition-all"
-              style={{
-                backgroundColor: '#DBDBDB',
-                boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)',
-              }}
+              className="flex items-start gap-3 rounded-2xl px-4 py-3 transition-all bg-bg-layer2"
+              style={{ boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)' }}
               onMouseEnter={(e) => {
-                e.currentTarget.style.backgroundColor = '#CFCFCF';
+                e.currentTarget.style.backgroundColor = '#CFCFCF'; /* bg-bg-layer2Hover */
                 e.currentTarget.style.boxShadow = '0 2px 4px rgba(0,0,0,0.22), 0 4px 8px rgba(0,0,0,0.10)';
               }}
               onMouseLeave={(e) => {
-                e.currentTarget.style.backgroundColor = '#DBDBDB';
+                e.currentTarget.style.backgroundColor = ''; // restore bg-bg-layer2
                 e.currentTarget.style.boxShadow = '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)';
               }}
             >
-              <MapPin size={15} className="shrink-0 mt-0.5 text-[#C0392B]" />
-              <span className="font-inter text-sm text-[#555555] underline underline-offset-2">
+              <MapPin size={15} className="shrink-0 mt-0.5 text-accent" />
+              <span className="font-inter text-sm text-text-secondary underline underline-offset-2">
                 {event.location}
               </span>
             </a>
           )}
           {event.description && (
             <div
-              className="flex items-start gap-3 rounded-2xl px-4 py-3"
-              style={{
-                backgroundColor: '#DBDBDB',
-                boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)',
-              }}
+              className="flex items-start gap-3 rounded-2xl px-4 py-3 bg-bg-layer2"
+              style={{ boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)' }}
             >
-              <AlignLeft size={15} className="shrink-0 mt-0.5 text-[#555555]" />
-              <span className="font-inter text-sm text-[#555555]">{event.description}</span>
+              <AlignLeft size={15} className="shrink-0 mt-0.5 text-text-secondary" />
+              <span className="font-inter text-sm text-text-secondary">{event.description}</span>
             </div>
           )}
           {!event.location && !event.description && (
-            <p className="font-inter text-sm text-[#999999]">No additional details.</p>
+            <p className="font-inter text-sm text-text-hint">No additional details.</p>
           )}
         </div>
       </div>
@@ -199,46 +187,47 @@ export default function SchedulePage() {
   const monthLabel = `${MONTH_NAMES[month - 1]} ${year}`;
 
   return (
-    <main className="min-h-screen bg-white">
+    <main className="min-h-screen bg-bg-base">
       {selectedEvent && (
         <EventModal event={selectedEvent} onClose={handleCloseModal} />
       )}
+
       {/* Page Header */}
-      <section className="bg-[#F9F9F9] py-12">
+      <section className="bg-bg-surface py-12">
         <div className="max-w-[1000px] mx-auto px-6">
-          <h1 className="font-montserrat text-4xl font-bold text-[#1A1A1A]">Schedule</h1>
-          <p className="mt-3 font-inter text-base text-[#555555]">
+          <h1 className="font-montserrat text-4xl font-bold text-text-primary">Schedule</h1>
+          <p className="mt-3 font-inter text-base text-text-secondary">
             Stay up to date with codeXperts meetings, events, and deadlines.
           </p>
         </div>
       </section>
 
       {/* Calendar Section */}
-      <section className="bg-white py-12">
+      <section className="bg-bg-base py-12">
         <div className="max-w-[1000px] mx-auto px-6">
           {/* Month Navigation */}
           <div className="flex items-center gap-4 mb-5">
             <button
               onClick={handlePrevMonth}
               aria-label="Previous month"
-              className="p-1.5 rounded hover:bg-[#F3F3F3] transition-colors text-[#555555] hover:text-[#1A1A1A]"
+              className="p-1.5 rounded hover:bg-bg-elevated transition-colors text-text-secondary hover:text-text-primary"
             >
               <ChevronLeft size={20} />
             </button>
-            <span className="font-montserrat text-base font-semibold text-[#1A1A1A] min-w-[140px] text-center">
+            <span className="font-montserrat text-base font-semibold text-text-primary min-w-[140px] text-center">
               {monthLabel}
             </span>
             <button
               onClick={handleNextMonth}
               aria-label="Next month"
-              className="p-1.5 rounded hover:bg-[#F3F3F3] transition-colors text-[#555555] hover:text-[#1A1A1A]"
+              className="p-1.5 rounded hover:bg-bg-elevated transition-colors text-text-secondary hover:text-text-primary"
             >
               <ChevronRight size={20} />
             </button>
           </div>
 
           {/* Google Calendar Embed */}
-          <div className="w-full rounded overflow-hidden border border-[#E5E5E5]">
+          <div className="w-full rounded overflow-hidden border border-border">
             <iframe
               key={calendarSrc}
               src={calendarSrc}
@@ -254,14 +243,14 @@ export default function SchedulePage() {
       </section>
 
       {/* Action Buttons */}
-      <section className="bg-white pb-8">
+      <section className="bg-bg-base pb-8">
         <div className="max-w-[1000px] mx-auto px-6">
           <div className="flex flex-wrap gap-3">
             <a
               href={SUBSCRIBE_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-[6px] border border-[#CCCCCC] text-[#555555] font-inter text-sm font-medium hover:border-[#1A1A1A] hover:text-[#1A1A1A] transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-[6px] border border-border-strong text-text-secondary font-inter text-sm font-medium hover:border-text-primary hover:text-text-primary transition-colors"
             >
               <CalendarPlus size={16} />
               Subscribe
@@ -269,7 +258,7 @@ export default function SchedulePage() {
             <a
               href={ICS_URL}
               download="codexperts-schedule.ics"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-[6px] border border-[#CCCCCC] text-[#555555] font-inter text-sm font-medium hover:border-[#1A1A1A] hover:text-[#1A1A1A] transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-[6px] border border-border-strong text-text-secondary font-inter text-sm font-medium hover:border-text-primary hover:text-text-primary transition-colors"
             >
               <Download size={16} />
               Download .ics
@@ -279,66 +268,58 @@ export default function SchedulePage() {
       </section>
 
       {/* Monthly Event List */}
-      <section className="bg-[#F9F9F9] py-12">
+      <section className="bg-bg-surface py-12">
         <div className="max-w-[1000px] mx-auto px-6">
-          {/* Layer 1 — wraps title + event list */}
+          {/* Layer 1 (#EAEAEA) — wraps title + event list */}
           <div
-            className="rounded-2xl p-6"
-            style={{
-              backgroundColor: '#EAEAEA',
-              boxShadow: '0 1px 3px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06)',
-            }}
+            className="rounded-2xl p-6 bg-bg-layer1"
+            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06)' }}
           >
-            <h3 className="font-montserrat text-xl font-semibold text-[#1A1A1A] mb-5">
+            <h3 className="font-montserrat text-xl font-semibold text-text-primary mb-5">
               {monthLabel} Events
             </h3>
 
             {isLoading && (
-              <p className="font-inter text-sm text-[#999999]">Loading events...</p>
+              <p className="font-inter text-sm text-text-hint">Loading events...</p>
             )}
 
             {!isLoading && hasError && (
-              <p className="font-inter text-sm text-[#999999]">
+              <p className="font-inter text-sm text-text-hint">
                 Unable to load events. Please try again later.
               </p>
             )}
 
             {!isLoading && !hasError && events.length === 0 && (
-              <p className="font-inter text-sm text-[#999999]">No events this month.</p>
+              <p className="font-inter text-sm text-text-hint">No events this month.</p>
             )}
 
             {!isLoading && !hasError && events.length > 0 && (
               <ul className="space-y-3">
                 {events.map((event) => (
                   <li key={`${event.date}-${event.title}`}>
-                    {/* Layer 2 — clickable pill: opens event detail modal */}
+                    {/* Layer 2 (#DBDBDB) — clickable pill: opens event detail modal */}
                     <button
                       onClick={() => setSelectedEvent(event)}
-                      className="w-full flex items-center gap-3 rounded-full px-4 py-2 transition-all text-left cursor-pointer"
-                      style={{
-                        backgroundColor: '#DBDBDB',
-                        boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)',
-                      }}
+                      className="w-full flex items-center gap-3 rounded-full px-4 py-2 transition-all text-left cursor-pointer bg-bg-layer2"
+                      style={{ boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)' }}
                       onMouseEnter={(e) => {
-                        e.currentTarget.style.backgroundColor = '#CFCFCF';
-                        e.currentTarget.style.boxShadow =
-                          '0 2px 4px rgba(0,0,0,0.22), 0 4px 8px rgba(0,0,0,0.10)';
+                        e.currentTarget.style.backgroundColor = '#CFCFCF'; /* bg-bg-layer2Hover */
+                        e.currentTarget.style.boxShadow = '0 2px 4px rgba(0,0,0,0.22), 0 4px 8px rgba(0,0,0,0.10)';
                       }}
                       onMouseLeave={(e) => {
-                        e.currentTarget.style.backgroundColor = '#DBDBDB';
-                        e.currentTarget.style.boxShadow =
-                          '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)';
+                        e.currentTarget.style.backgroundColor = ''; // restore bg-bg-layer2
+                        e.currentTarget.style.boxShadow = '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)';
                       }}
                     >
-                      <span className="font-inter text-xs font-semibold text-[#1A1A1A] shrink-0 w-12">
+                      <span className="font-inter text-xs font-semibold text-text-primary shrink-0 w-12">
                         {formatEventDate(event.date)}
                       </span>
-                      <span className="font-inter text-sm font-normal text-[#555555] flex-1 min-w-0 truncate">
+                      <span className="font-inter text-sm font-normal text-text-secondary flex-1 min-w-0 truncate">
                         {event.title}
                       </span>
-                      {event.startTime && (
-                        <span className="font-inter text-xs text-[#999999] shrink-0 ml-1">
-                          {event.startTime}{event.endTime ? ` – ${event.endTime}` : ''}
+                      {event.startTime && event.endTime && (
+                        <span className="font-inter text-xs text-text-hint shrink-0 ml-1">
+                          {event.startTime} – {event.endTime}
                         </span>
                       )}
                     </button>

--- a/src/app/schedule/page.js
+++ b/src/app/schedule/page.js
@@ -1,10 +1,332 @@
-export default function SchedulePage() {
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronLeft, ChevronRight, CalendarPlus, Download, MapPin, AlignLeft, X } from 'lucide-react';
+
+const CALENDAR_ID = 'codexperts2024@gmail.com';
+const CALENDAR_TIMEZONE = 'America%2FToronto';
+const ICS_URL = `https://calendar.google.com/calendar/ical/${encodeURIComponent(CALENDAR_ID)}/public/basic.ics`;
+const SUBSCRIBE_URL = `https://calendar.google.com/calendar/r?cid=${CALENDAR_ID}`;
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+// Format a date string for display: "Apr 8"
+const formatEventDate = (isoString) => {
+  const d = new Date(isoString);
+  const month = MONTH_NAMES[d.getMonth()].slice(0, 3);
+  const day = d.getDate();
+  return `${month} ${day}`;
+};
+
+// Build the Google Calendar embed src for a given month
+const buildCalendarSrc = (year, month) => {
+  // First day of the month in YYYYMMDD format
+  const pad = (n) => String(n).padStart(2, '0');
+  const dateStr = `${year}${pad(month)}01`;
   return (
-    <main className="min-h-screen flex items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-5xl font-bold text-gray-900">Schedule</h1>
-        <p className="mt-3 text-gray-400 text-lg">Google Calendar embed · Weekly meeting times</p>
+    `https://calendar.google.com/calendar/embed` +
+    `?src=${encodeURIComponent(CALENDAR_ID)}` +
+    `&ctz=${CALENDAR_TIMEZONE}` +
+    `&mode=MONTH` +
+    `&dates=${dateStr}%2F${dateStr}`
+  );
+};
+
+// Event detail modal
+const EventModal = ({ event, onClose }) => {
+  // Close on Escape key
+  useEffect(() => {
+    const handleKey = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const d = new Date(event.date);
+  const fullDate = d.toLocaleDateString('en-US', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+  });
+
+  return (
+    // Backdrop
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-4"
+      style={{ backgroundColor: 'rgba(0,0,0,0.30)' }}
+      onClick={onClose}
+    >
+      {/* Modal card — Layer 1 */}
+      <div
+        className="relative w-full max-w-md rounded-2xl p-6"
+        style={{
+          backgroundColor: '#EAEAEA',
+          boxShadow: '0 8px 24px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.10)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 p-1 rounded-full hover:bg-[#DBDBDB] transition-colors text-[#555555]"
+          aria-label="Close"
+        >
+          <X size={18} />
+        </button>
+
+        {/* Title */}
+        <h4 className="font-montserrat text-lg font-semibold text-[#1A1A1A] pr-8 mb-1">
+          {event.title}
+        </h4>
+        {/* Date */}
+        <p className="font-inter text-sm text-[#555555] mb-4">{fullDate}</p>
+
+        {/* Details — Layer 2 pills */}
+        <div className="space-y-3">
+          {event.location && (
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-start gap-3 rounded-2xl px-4 py-3 transition-all"
+              style={{
+                backgroundColor: '#DBDBDB',
+                boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = '#CFCFCF';
+                e.currentTarget.style.boxShadow = '0 2px 4px rgba(0,0,0,0.22), 0 4px 8px rgba(0,0,0,0.10)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = '#DBDBDB';
+                e.currentTarget.style.boxShadow = '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)';
+              }}
+            >
+              <MapPin size={15} className="shrink-0 mt-0.5 text-[#C0392B]" />
+              <span className="font-inter text-sm text-[#555555] underline underline-offset-2">
+                {event.location}
+              </span>
+            </a>
+          )}
+          {event.description && (
+            <div
+              className="flex items-start gap-3 rounded-2xl px-4 py-3"
+              style={{
+                backgroundColor: '#DBDBDB',
+                boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)',
+              }}
+            >
+              <AlignLeft size={15} className="shrink-0 mt-0.5 text-[#555555]" />
+              <span className="font-inter text-sm text-[#555555]">{event.description}</span>
+            </div>
+          )}
+          {!event.location && !event.description && (
+            <p className="font-inter text-sm text-[#999999]">No additional details.</p>
+          )}
+        </div>
       </div>
+    </div>
+  );
+};
+
+export default function SchedulePage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+  const [events, setEvents] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState(null);
+
+  const fetchEvents = async (y, m) => {
+    setIsLoading(true);
+    setHasError(false);
+    try {
+      const res = await fetch(`/api/calendar?year=${y}&month=${m}`);
+      if (!res.ok) throw new Error('Network error');
+      const data = await res.json();
+      setEvents(data.events ?? []);
+    } catch {
+      setHasError(true);
+      setEvents([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchEvents(year, month);
+  }, [year, month]);
+
+  const handleCloseModal = useCallback(() => setSelectedEvent(null), []);
+
+  const handlePrevMonth = () => {
+    if (month === 1) {
+      setYear((y) => y - 1);
+      setMonth(12);
+    } else {
+      setMonth((m) => m - 1);
+    }
+  };
+
+  const handleNextMonth = () => {
+    if (month === 12) {
+      setYear((y) => y + 1);
+      setMonth(1);
+    } else {
+      setMonth((m) => m + 1);
+    }
+  };
+
+  const calendarSrc = buildCalendarSrc(year, month);
+  const monthLabel = `${MONTH_NAMES[month - 1]} ${year}`;
+
+  return (
+    <main className="min-h-screen bg-white">
+      {selectedEvent && (
+        <EventModal event={selectedEvent} onClose={handleCloseModal} />
+      )}
+      {/* Page Header */}
+      <section className="bg-[#F9F9F9] py-12">
+        <div className="max-w-[1000px] mx-auto px-6">
+          <h1 className="font-montserrat text-4xl font-bold text-[#1A1A1A]">Schedule</h1>
+          <p className="mt-3 font-inter text-base text-[#555555]">
+            Stay up to date with codeXperts meetings, events, and deadlines.
+          </p>
+        </div>
+      </section>
+
+      {/* Calendar Section */}
+      <section className="bg-white py-12">
+        <div className="max-w-[1000px] mx-auto px-6">
+          {/* Month Navigation */}
+          <div className="flex items-center gap-4 mb-5">
+            <button
+              onClick={handlePrevMonth}
+              aria-label="Previous month"
+              className="p-1.5 rounded hover:bg-[#F3F3F3] transition-colors text-[#555555] hover:text-[#1A1A1A]"
+            >
+              <ChevronLeft size={20} />
+            </button>
+            <span className="font-montserrat text-base font-semibold text-[#1A1A1A] min-w-[140px] text-center">
+              {monthLabel}
+            </span>
+            <button
+              onClick={handleNextMonth}
+              aria-label="Next month"
+              className="p-1.5 rounded hover:bg-[#F3F3F3] transition-colors text-[#555555] hover:text-[#1A1A1A]"
+            >
+              <ChevronRight size={20} />
+            </button>
+          </div>
+
+          {/* Google Calendar Embed */}
+          <div className="w-full rounded overflow-hidden border border-[#E5E5E5]">
+            <iframe
+              key={calendarSrc}
+              src={calendarSrc}
+              style={{ border: 0 }}
+              width="100%"
+              height="600"
+              frameBorder="0"
+              scrolling="no"
+              title="codeXperts Schedule"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Action Buttons */}
+      <section className="bg-white pb-8">
+        <div className="max-w-[1000px] mx-auto px-6">
+          <div className="flex flex-wrap gap-3">
+            <a
+              href={SUBSCRIBE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-[6px] border border-[#CCCCCC] text-[#555555] font-inter text-sm font-medium hover:border-[#1A1A1A] hover:text-[#1A1A1A] transition-colors"
+            >
+              <CalendarPlus size={16} />
+              Subscribe
+            </a>
+            <a
+              href={ICS_URL}
+              download="codexperts-schedule.ics"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-[6px] border border-[#CCCCCC] text-[#555555] font-inter text-sm font-medium hover:border-[#1A1A1A] hover:text-[#1A1A1A] transition-colors"
+            >
+              <Download size={16} />
+              Download .ics
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Monthly Event List */}
+      <section className="bg-[#F9F9F9] py-12">
+        <div className="max-w-[1000px] mx-auto px-6">
+          {/* Layer 1 — wraps title + event list */}
+          <div
+            className="rounded-2xl p-6"
+            style={{
+              backgroundColor: '#EAEAEA',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06)',
+            }}
+          >
+            <h3 className="font-montserrat text-xl font-semibold text-[#1A1A1A] mb-5">
+              {monthLabel} Events
+            </h3>
+
+            {isLoading && (
+              <p className="font-inter text-sm text-[#999999]">Loading events...</p>
+            )}
+
+            {!isLoading && hasError && (
+              <p className="font-inter text-sm text-[#999999]">
+                Unable to load events. Please try again later.
+              </p>
+            )}
+
+            {!isLoading && !hasError && events.length === 0 && (
+              <p className="font-inter text-sm text-[#999999]">No events this month.</p>
+            )}
+
+            {!isLoading && !hasError && events.length > 0 && (
+              <ul className="space-y-3">
+                {events.map((event, i) => (
+                  <li key={i}>
+                    {/* Layer 2 — clickable pill: opens event detail modal */}
+                    <button
+                      onClick={() => setSelectedEvent(event)}
+                      className="w-full flex items-center gap-3 rounded-full px-4 py-2 transition-all text-left cursor-pointer"
+                      style={{
+                        backgroundColor: '#DBDBDB',
+                        boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)',
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.backgroundColor = '#CFCFCF';
+                        e.currentTarget.style.boxShadow =
+                          '0 2px 4px rgba(0,0,0,0.22), 0 4px 8px rgba(0,0,0,0.10)';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.backgroundColor = '#DBDBDB';
+                        e.currentTarget.style.boxShadow =
+                          '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)';
+                      }}
+                    >
+                      <span className="font-inter text-xs font-semibold text-[#1A1A1A] shrink-0 w-12">
+                        {formatEventDate(event.date)}
+                      </span>
+                      <span className="font-inter text-sm font-normal text-[#555555]">
+                        {event.title}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </section>
     </main>
-  )
+  );
 }

--- a/src/app/schedule/page.js
+++ b/src/app/schedule/page.js
@@ -142,7 +142,7 @@ export default function SchedulePage() {
     setIsLoading(true);
     setHasError(false);
     try {
-      const res = await fetch(`/api/calendar?year=${y}&month=${m}`);
+      const res = await fetch(`/api/calendar?year=${y}&month=${m}`, { cache: 'no-store' });
       if (!res.ok) throw new Error('Network error');
       const data = await res.json();
       setEvents(data.events ?? []);

--- a/src/app/schedule/page.js
+++ b/src/app/schedule/page.js
@@ -83,7 +83,14 @@ const EventModal = ({ event, onClose }) => {
           {event.title}
         </h4>
         {/* Date */}
-        <p className="font-inter text-sm text-[#555555] mb-4">{fullDate}</p>
+        <p className="font-inter text-sm text-[#555555] mb-1">{fullDate}</p>
+        {/* Time (only for timed events) */}
+        {event.startTime && (
+          <p className="font-inter text-sm text-[#555555] mb-4">
+            {event.startTime}{event.endTime ? ` – ${event.endTime}` : ''}
+          </p>
+        )}
+        {!event.startTime && <div className="mb-4" />}
 
         {/* Details — Layer 2 pills */}
         <div className="space-y-3">
@@ -326,9 +333,14 @@ export default function SchedulePage() {
                       <span className="font-inter text-xs font-semibold text-[#1A1A1A] shrink-0 w-12">
                         {formatEventDate(event.date)}
                       </span>
-                      <span className="font-inter text-sm font-normal text-[#555555]">
+                      <span className="font-inter text-sm font-normal text-[#555555] flex-1 min-w-0 truncate">
                         {event.title}
                       </span>
+                      {event.startTime && (
+                        <span className="font-inter text-xs text-[#999999] shrink-0 ml-1">
+                          {event.startTime}{event.endTime ? ` – ${event.endTime}` : ''}
+                        </span>
+                      )}
                     </button>
                   </li>
                 ))}

--- a/src/app/schedule/page.js
+++ b/src/app/schedule/page.js
@@ -37,11 +37,15 @@ const buildCalendarSrc = (year, month) => {
 
 // Event detail modal
 const EventModal = ({ event, onClose }) => {
-  // Close on Escape key
+  // Lock body scroll and close on Escape key while modal is open
   useEffect(() => {
+    document.body.style.overflow = 'hidden';
     const handleKey = (e) => { if (e.key === 'Escape') onClose(); };
     window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
+    return () => {
+      document.body.style.overflow = '';
+      window.removeEventListener('keydown', handleKey);
+    };
   }, [onClose]);
 
   const d = new Date(event.date);
@@ -138,25 +142,31 @@ export default function SchedulePage() {
   const [hasError, setHasError] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState(null);
 
-  const fetchEvents = async (y, m) => {
+  const fetchEvents = useCallback(async (y, m, signal) => {
     setIsLoading(true);
     setHasError(false);
     try {
-      const res = await fetch(`/api/calendar?year=${y}&month=${m}`, { cache: 'no-store' });
+      const res = await fetch(`/api/calendar?year=${y}&month=${m}`, {
+        cache: 'no-store',
+        signal,
+      });
       if (!res.ok) throw new Error('Network error');
       const data = await res.json();
       setEvents(data.events ?? []);
-    } catch {
+      setIsLoading(false);
+    } catch (err) {
+      if (err.name === 'AbortError') return; // newer request is in flight — ignore
       setHasError(true);
       setEvents([]);
-    } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
-    fetchEvents(year, month);
-  }, [year, month]);
+    const controller = new AbortController();
+    fetchEvents(year, month, controller.signal);
+    return () => controller.abort();
+  }, [year, month, fetchEvents]);
 
   const handleCloseModal = useCallback(() => setSelectedEvent(null), []);
 
@@ -292,8 +302,8 @@ export default function SchedulePage() {
 
             {!isLoading && !hasError && events.length > 0 && (
               <ul className="space-y-3">
-                {events.map((event, i) => (
-                  <li key={i}>
+                {events.map((event) => (
+                  <li key={`${event.date}-${event.title}`}>
                     {/* Layer 2 — clickable pill: opens event detail modal */}
                     <button
                       onClick={() => setSelectedEvent(event)}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,10 @@ module.exports = {
           surface: '#F9F9F9',
           elevated: '#F3F3F3',
           input: '#F5F5F5',
+          // 3-Layer Depth System — each step is -15 RGB from the previous layer
+          layer1: '#EAEAEA',      // #EAEAEA (234) — container card
+          layer2: '#DBDBDB',      // #DBDBDB (219) — row / pill default
+          layer2Hover: '#CFCFCF', // #CFCFCF (207) — row / pill hover
         },
         text: {
           primary: '#1A1A1A',


### PR DESCRIPTION
## Summary

Closes #18. Implements the public Schedule page end-to-end — Google Calendar embed, live event list auto-synced from the public iCal feed, event detail modal, and the 3-Layer Depth UI system.

- **`/api/calendar` route** — server-side iCal parser with full RRULE expansion (DAILY / WEEKLY / MONTHLY / YEARLY, BYDAY, INTERVAL, UNTIL, COUNT, EXDATE). No Google API key required; uses the public `.ics` feed.
- **Schedule page** — custom `[ ← ] Month [ → ]` navigation controls both the Google Calendar iframe src and the event list fetch simultaneously. Clicking any event row opens an in-page detail modal (title, full date, location → Google Maps link, description).
- **3-Layer Depth System** — `#F9F9F9` (section) → `#EAEAEA` (container card) → `#DBDBDB` (row pill) with a two-layer `box-shadow` (tight dark + soft ambient) at each level.
- **Docs updated** — `docs/design/page-specs/schedule.md` fully rewritten to match implementation; `docs/design/design-system.md` gains a new Section 4 (3-Layer Depth System); `docs/sprints/w3.md` marked Schedule deliverables as complete.

## Files Changed

| File | Change |
|------|--------|
| `src/app/api/calendar/route.js` | New — iCal fetch + parse API route |
| `src/app/schedule/page.js` | Full rewrite — embed, nav, event list, modal |
| `docs/design/page-specs/schedule.md` | Full rewrite — matches actual implementation |
| `docs/design/design-system.md` | Added Section 4: 3-Layer Depth System |
| `docs/sprints/w3.md` | Added Schedule deliverables, checked done items |
| `package.json` / `package-lock.json` | Added `lucide-react` |
| `.gitignore` | Added `.mcp.json` (Figma MCP token — never committed) |

## Test Plan

- [x] Navigate to `/schedule` — page header, embed, and event list all render correctly
- [x] Click `[ ← ]` / `[ → ]` — iframe and event list both update to the new month
- [x] Verify current month shows real events pulled from the Google Calendar iCal feed
- [x] Verify recurring events (e.g., weekly meetings) appear on every correct date in the list
- [x] Click an event row — detail modal opens with title, date, location pill, description pill
- [x] Click the location pill — opens Google Maps in a new tab for the correct location
- [x] Click backdrop or press Escape — modal closes
- [x] Click Subscribe — opens Google Calendar "Add to my calendar" in new tab
- [x] Click Download .ics — browser downloads `codexperts-schedule.ics`
- [x] Navigate to a month with no events — "No events this month." displayed
- [x] Verify no `console.log` statements in any changed files