### PR TITLE
fix: address Copilot review on PR #74 (Issue #76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-![Next.js](https://img.shields.io/badge/Next.js-15-000000?style=for-the-badge&logo=nextdotjs&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-16-000000?style=for-the-badge&logo=nextdotjs&logoColor=white)
 ![React](https://img.shields.io/badge/React-18-61DAFB?style=for-the-badge&logo=react&logoColor=black)
 ![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL%20%7C%20Auth-3ECF8E?style=for-the-badge&logo=supabase&logoColor=white)
 ![FastAPI](https://img.shields.io/badge/FastAPI-Python-009688?style=for-the-badge&logo=fastapi&logoColor=white)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,11 @@
 # Backend environment variables
 # Copy this file to .env and fill in values
 
+# CORS — comma-separated list of explicit allowed origins.
+# Vercel preview URLs are matched by CORS_ORIGIN_REGEX (default covers them).
+CORS_ORIGINS=http://localhost:3000,https://codexperts.ca,https://www.codexperts.ca
+# Optional override for the preview URL regex.
+# CORS_ORIGIN_REGEX=https://codexperts-web.*\.vercel\.app
+
 # Add backend-specific env vars here as needed
 # PISTON_API_URL=https://emkc.org/api/v2/piston

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ origins = [
 # preview URL explicitly.
 origin_regex = os.getenv(
     "CORS_ORIGIN_REGEX",
-    r"https://codexperts-web.*\.vercel\.app",
+    r"https://codexperts-web[\w-]*\.vercel\.app$",
 )
 
 app.add_middleware(

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,16 +1,29 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(title="codeXperts API")
 
+# Comma-separated list of explicit origins. Production domain and any extra
+# Vercel preview aliases should be set here in the Railway environment.
 origins = [
-    "http://localhost:3000",
-    "https://codexperts-web-psi.vercel.app",
+    o.strip()
+    for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
+    if o.strip()
 ]
+
+# Allow every Vercel preview deployment for this project without listing each
+# preview URL explicitly.
+origin_regex = os.getenv(
+    "CORS_ORIGIN_REGEX",
+    r"https://codexperts-web.*\.vercel\.app",
+)
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
+    allow_origin_regex=origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,9 +15,9 @@ origins = [
 
 # Allow every Vercel preview deployment for this project without listing each
 # preview URL explicitly.
-origin_regex = os.getenv(
-    "CORS_ORIGIN_REGEX",
-    r"https://codexperts-web[\w-]*\.vercel\.app$",
+origin_regex = (
+    os.getenv("CORS_ORIGIN_REGEX", r"https://codexperts-web[\w-]*\.vercel\.app$").strip()
+    or None
 )
 
 app.add_middleware(

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -478,8 +478,10 @@ text-align: center
 ### Page 7: Join Us (modal, public)
 
 Signup is a modal triggered from the [Join Us] button — there is no `/join`
-route. The modal runs Google OAuth first and then collects name/school as a
-profile-completion step. See `page-specs/join.md` for the full modal spec.
+route. The modal runs Google OAuth first; name and email are pulled from
+Google metadata automatically. The profile-completion step then collects
+campus, cohort, and phone number. See `page-specs/join.md` for the full
+modal spec.
 
 ---
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -251,7 +251,7 @@ Practice dropdown (member only):
 | About | dropdown | public | About Us + Our Team |
 | Updates | dropdown | public | Announcements + Schedule |
 | Events | `/events` | public | |
-| Join Us | `/join` | public | Hidden after login & approval |
+| Join Us | modal | public | Opens signup modal; hidden after login & approval |
 | Practice | dropdown | member | Problems + Solutions |
 | Members | `/members` | member | |
 | LinkedIn | external | public | Icon button |
@@ -475,9 +475,11 @@ text-align: center
 
 ---
 
-### Page 7: `/join` Join Us (public)
+### Page 7: Join Us (modal, public)
 
-> TBD — confirm layout in next session
+Signup is a modal triggered from the [Join Us] button — there is no `/join`
+route. The modal runs Google OAuth first and then collects name/school as a
+profile-completion step. See `page-specs/join.md` for the full modal spec.
 
 ---
 

--- a/docs/schema/tables/profiles.sql
+++ b/docs/schema/tables/profiles.sql
@@ -10,10 +10,10 @@ $$ LANGUAGE plpgsql;
 
 CREATE TABLE profiles (
   id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
-  name TEXT NOT NULL,
+  name TEXT,
   email TEXT UNIQUE NOT NULL,
   role member_role NOT NULL DEFAULT 'pending',
-  school TEXT NOT NULL,
+  school TEXT,
   linkedin TEXT,
   github TEXT,
   avatar_url TEXT,

--- a/docs/schema/tables/rls_policies.sql
+++ b/docs/schema/tables/rls_policies.sql
@@ -6,6 +6,19 @@ ALTER TABLE public.attendances ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.announcements ENABLE ROW LEVEL SECURITY;
 
 
+-- Helper used by profiles_select_directory_member_plus to avoid the RLS
+-- infinite-recursion error that occurs when a policy on profiles subqueries
+-- profiles. SECURITY DEFINER runs with row security disabled.
+CREATE OR REPLACE FUNCTION public.get_my_role()
+RETURNS public.member_role
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT role FROM public.profiles WHERE id = auth.uid()
+$$;
+
 CREATE POLICY profiles_select_self
 ON public.profiles
 FOR SELECT
@@ -17,12 +30,7 @@ ON public.profiles
 FOR SELECT
 TO authenticated
 USING (
-  EXISTS (
-    SELECT 1
-    FROM public.profiles AS p
-    WHERE p.id = auth.uid()
-      AND p.role IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
-  )
+  public.get_my_role() IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
 );
 
 CREATE OR REPLACE FUNCTION public.handle_new_user()

--- a/docs/schema/tables/rls_policies.sql
+++ b/docs/schema/tables/rls_policies.sql
@@ -6,20 +6,37 @@ ALTER TABLE public.attendances ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.announcements ENABLE ROW LEVEL SECURITY;
 
 
-CREATE POLICY profiles_select_all
+CREATE POLICY profiles_select_self
 ON public.profiles
 FOR SELECT
 TO authenticated
-USING (TRUE);
+USING (auth.uid() = id);
+
+CREATE POLICY profiles_select_directory_member_plus
+ON public.profiles
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
+  )
+);
 
 CREATE OR REPLACE FUNCTION public.handle_new_user()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
 BEGIN
   INSERT INTO public.profiles (id, email, role)
   VALUES (NEW.id, NEW.email, 'pending'::public.member_role);
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;
 
 CREATE TRIGGER on_auth_user_created
 AFTER INSERT ON auth.users
@@ -37,11 +54,18 @@ WITH CHECK (
   auth.uid() = id
 );
 
-CREATE POLICY problems_select_public
+CREATE POLICY problems_select_member_plus
 ON public.problems
 FOR SELECT
-TO anon, authenticated
-USING (TRUE);
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
+  )
+);
 
 CREATE POLICY problems_insert_exec_admin
 ON public.problems
@@ -154,11 +178,18 @@ USING (
   )
 );
 
-CREATE POLICY sessions_select_public_active
+CREATE POLICY sessions_select_exec_admin
 ON public.sessions
 FOR SELECT
-TO anon, authenticated
-USING (is_active = TRUE);
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('executive'::public.member_role, 'admin'::public.member_role)
+  )
+);
 
 CREATE POLICY sessions_insert_exec_admin
 ON public.sessions

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -47,7 +47,7 @@ export default function JoinModal() {
   const cohorts = generateCohorts()
   const overlayRef = useRef(null)
 
-  const needsCompletion = !loading && user && !profile
+  const needsCompletion = !loading && !!user && !!profile && !profile.name
 
   useEffect(() => {
     if (needsCompletion && !sessionStorage.getItem('join_modal_dismissed')) {

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -13,7 +13,8 @@ export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true)
   const router = useRouter()
 
-  // fetchProfile / authSignOut are stable module imports; intentionally mount-only.
+  // getSession, fetchProfile, supabase are stable module-level references;
+  // intentionally mount-only.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     async function init() {

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -13,6 +13,8 @@ export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true)
   const router = useRouter()
 
+  // fetchProfile / authSignOut are stable module imports; intentionally mount-only.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     async function init() {
       try {
@@ -47,9 +49,6 @@ export function AuthProvider({ children }) {
     )
 
     return () => subscription.unsubscribe()
-    // fetchProfile / authSignOut are stable module imports; this effect is
-    // intentionally mount-only.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   async function refreshProfile() {

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -47,6 +47,9 @@ export function AuthProvider({ children }) {
     )
 
     return () => subscription.unsubscribe()
+    // fetchProfile / authSignOut are stable module imports; this effect is
+    // intentionally mount-only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   async function refreshProfile() {

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -31,7 +31,7 @@ export async function fetchProfile(userId) {
 export async function createProfile({ id, name, email, avatarUrl, campus, cohort, phone }) {
   const { data, error } = await supabase
     .from('profiles')
-    .insert({
+    .upsert({
       id,
       name,
       email,

--- a/supabase/migrations/20260514120000_rls_security_fixes.sql
+++ b/supabase/migrations/20260514120000_rls_security_fixes.sql
@@ -59,6 +59,21 @@ USING (
 -- 5. profiles: split the blanket SELECT so pending users can read their own
 --    row (needed for AuthContext + JoinModal) but cannot browse the member
 --    directory.
+--
+--    A policy ON profiles cannot subquery profiles itself without triggering
+--    "infinite recursion detected in policy for relation 'profiles'".
+--    The fix is a SECURITY DEFINER helper that reads the caller's role with
+--    row security disabled, breaking the cycle.
+CREATE OR REPLACE FUNCTION public.get_my_role()
+RETURNS public.member_role
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT role FROM public.profiles WHERE id = auth.uid()
+$$;
+
 DROP POLICY IF EXISTS profiles_select_all ON public.profiles;
 
 CREATE POLICY profiles_select_self
@@ -72,10 +87,5 @@ ON public.profiles
 FOR SELECT
 TO authenticated
 USING (
-  EXISTS (
-    SELECT 1
-    FROM public.profiles AS p
-    WHERE p.id = auth.uid()
-      AND p.role IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
-  )
+  public.get_my_role() IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
 );

--- a/supabase/migrations/20260514120000_rls_security_fixes.sql
+++ b/supabase/migrations/20260514120000_rls_security_fixes.sql
@@ -1,0 +1,81 @@
+-- RLS and trigger fixes addressing Copilot review on PR #74 (Issue #76).
+-- Covers P0 fixes (signup trigger, problems anon read, sessions token exposure,
+-- search_path hardening) and the P1 profiles directory tightening.
+
+-- 1. Allow signup to succeed: handle_new_user() trigger only inserts
+--    (id, email, role), but profiles.name/school were NOT NULL.
+ALTER TABLE public.profiles ALTER COLUMN name DROP NOT NULL;
+ALTER TABLE public.profiles ALTER COLUMN school DROP NOT NULL;
+
+-- 2. Harden handle_new_user(): pin search_path for the SECURITY DEFINER
+--    function so object resolution can't be hijacked by a caller's search_path.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, role)
+  VALUES (NEW.id, NEW.email, 'pending'::public.member_role);
+  RETURN NEW;
+END;
+$$;
+
+-- 3. problems: remove anon SELECT, restrict to member+.
+DROP POLICY IF EXISTS problems_select_public ON public.problems;
+
+CREATE POLICY problems_select_member_plus
+ON public.problems
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
+  )
+);
+
+-- 4. sessions: remove anon SELECT of active session tokens. Token validation
+--    must happen server-side via the service role; the broad SELECT is only
+--    needed by executive/admin dashboards.
+DROP POLICY IF EXISTS sessions_select_public_active ON public.sessions;
+
+CREATE POLICY sessions_select_exec_admin
+ON public.sessions
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('executive'::public.member_role, 'admin'::public.member_role)
+  )
+);
+
+-- 5. profiles: split the blanket SELECT so pending users can read their own
+--    row (needed for AuthContext + JoinModal) but cannot browse the member
+--    directory.
+DROP POLICY IF EXISTS profiles_select_all ON public.profiles;
+
+CREATE POLICY profiles_select_self
+ON public.profiles
+FOR SELECT
+TO authenticated
+USING (auth.uid() = id);
+
+CREATE POLICY profiles_select_directory_member_plus
+ON public.profiles
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
+  )
+);


### PR DESCRIPTION
## Summary

Addresses all 11 Copilot review comments on [PR #74](https://github.com/codexperts2024/codexperts-web/pull/74). Unblocks the develop → main release.

Closes #76.

## Changes by priority

### P0 — security / signup regression
| # | Fix |
|---|-----|
| 1 | `profiles.name` / `profiles.school` NOT NULL dropped + `handle_new_user` trigger keeps inserting `(id, email, role)`. Google OAuth signup no longer fails; name/school are collected by JoinModal post-OAuth. |
| 2 | `sessions_select_public_active` removed (was exposing active attendance tokens to anon). Replaced with executive/admin-only SELECT. Token validation continues to run server-side via service role. |
| 3 | `problems_select_public` removed (anon could bypass RoleGuard via REST). Replaced with member+ SELECT. |
| 5 | `handle_new_user` re-defined with `SET search_path = public` to harden the SECURITY DEFINER function. |

### P1 — directory access / deploy config
| # | Fix |
|---|-----|
| 4 | `profiles_select_all` split into `profiles_select_self` (any auth user can read own row) + `profiles_select_directory_member_plus` (member+ only). Pending users can no longer browse the directory. |
| 6 | README badge bumped to Next.js 16 to match `package.json`. |
| 7 | Backend CORS sourced from `CORS_ORIGINS` env + `CORS_ORIGIN_REGEX` for Vercel preview URLs. `.env.example` updated. **Action item:** Dave to set `CORS_ORIGINS` in Railway (`https://codexperts.ca,https://www.codexperts.ca,...`). |

### P2 — lint / docs / no-op
| # | Fix |
|---|-----|
| 8 | No code change. `/admin` stays admin-only by design. Exec content management (problems/events/schedule/announcements upload UIs) is a follow-up — separate issue to be filed. |
| 9 | No code change. `src/utils/constants.js` already follows project convention (2-space, no semicolons); Copilot's formatting comment was a false positive. |
| 10 | `AuthContext.js` mount-only effect annotated with `eslint-disable-next-line react-hooks/exhaustive-deps` + rationale. |
| 11 | `docs/design/design-system.md` navbar table + Page 7 section updated to reflect modal-only signup (no `/join` route). |

## Files
- `supabase/migrations/20260514120000_rls_security_fixes.sql` (new)
- `docs/schema/tables/profiles.sql`, `docs/schema/tables/rls_policies.sql` (sync)
- `backend/main.py`, `backend/.env.example`
- `src/contexts/AuthContext.js`
- `docs/design/design-system.md`
- `README.md`

## Test plan
- [ ] Vercel preview build passes
- [ ] Fresh Google OAuth signup creates a `profiles` row with `role=pending`, NULL name/school
- [ ] JoinModal saves name/school → profile becomes complete
- [ ] As `pending`, `/members` and `/problems` are blocked (RoleGuard + RLS both deny)
- [ ] Anon REST `GET /rest/v1/problems`, `/sessions`, `/profiles` return empty / 401
- [ ] After admin promotes to `member`, `/members` and `/problems` work
- [ ] `/admin` still admin-only

## Follow-ups (not in this PR)
- Executive content-management UIs (problems upload, events / schedule / announcements creation)
- Railway env: set `CORS_ORIGINS` for prod and any extra preview aliases