### PR TITLE
feat: coding problems list page — Post View & List View (#24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "next": "^16.2.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import {
   ChevronLeft, ChevronRight, List, Trash2, Plus, Download, PenLine, Check, Minus,
 } from 'lucide-react'
@@ -43,7 +43,7 @@ function downloadMd(problem) {
   URL.revokeObjectURL(url)
 }
 
-function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDelete, schoolFilter, setSchoolFilter }) {
+function PostView({ problems, currentIdx, navigateTo, setView, profile, onDelete, schoolFilter, setSchoolFilter }) {
   const router = useRouter()
   const problem = problems[currentIdx]
   const isAdmin = profile?.role === ROLES.ADMIN || profile?.role === ROLES.EXECUTIVE
@@ -143,7 +143,7 @@ function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDel
       <div className="border-t border-border py-8 bg-bg-base">
         <div className="max-w-[800px] mx-auto px-6 flex items-center justify-between">
           <button
-            onClick={() => setCurrentIdx(i => i + 1)}
+            onClick={() => navigateTo(currentIdx + 1)}
             disabled={isOldest}
             className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
           >
@@ -171,7 +171,7 @@ function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDel
 
           <div className="flex items-center gap-3">
             <button
-              onClick={() => setCurrentIdx(i => i - 1)}
+              onClick={() => navigateTo(currentIdx - 1)}
               disabled={isNewest}
               className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
             >
@@ -194,7 +194,7 @@ function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDel
   )
 }
 
-function ListView({ problems, setCurrentIdx, setView, profile, schoolFilter, setSchoolFilter, userSubmissions }) {
+function ListView({ problems, navigateTo, setView, profile, schoolFilter, setSchoolFilter, userSubmissions }) {
   const isAdmin = profile?.role === ROLES.ADMIN || profile?.role === ROLES.EXECUTIVE
 
   return (
@@ -243,7 +243,7 @@ function ListView({ problems, setCurrentIdx, setView, profile, schoolFilter, set
                   return (
                     <tr
                       key={p.id}
-                      onClick={() => { setCurrentIdx(idx); setView('post') }}
+                      onClick={() => { navigateTo(idx); setView('post') }}
                       className="border-b border-border cursor-pointer transition-colors hover:bg-bg-surface"
                     >
                       <td className="font-inter text-sm text-text-primary py-3.5 pr-4">
@@ -295,18 +295,36 @@ function SchoolFilter({ value, onChange }) {
 
 function ProblemsContent() {
   const { profile } = useAuth()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
   const [view, setView] = useState('post')
   const [problems, setProblems] = useState([])
   const [currentIdx, setCurrentIdx] = useState(0)
   const [schoolFilter, setSchoolFilter] = useState('All Schools')
   const [userSubmissions, setUserSubmissions] = useState(new Set())
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  // Restore index from URL on first load only
+  const restoredFromUrl = useRef(false)
+  useEffect(() => {
+    if (problems.length === 0 || restoredFromUrl.current) return
+    restoredFromUrl.current = true
+    const id = searchParams.get('id')
+    if (!id) return
+    const idx = problems.findIndex(p => String(p.id) === id)
+    if (idx !== -1) setCurrentIdx(idx)
+  }, [problems, searchParams])
 
   const loadProblems = useCallback(async () => {
     setLoading(true)
+    setError(null)
     try {
       const data = await fetchProblems(schoolFilter)
       setProblems(data)
+    } catch {
+      setError('Failed to load problems. Please try again.')
     } finally {
       setLoading(false)
     }
@@ -314,13 +332,23 @@ function ProblemsContent() {
 
   const loadSubmissions = useCallback(async () => {
     if (!profile?.id) return
-    const solved = await fetchUserSubmissions(profile.id)
-    setUserSubmissions(solved)
+    try {
+      const solved = await fetchUserSubmissions(profile.id)
+      setUserSubmissions(solved)
+    } catch {
+      // Submissions are non-critical; fail silently
+    }
   }, [profile?.id])
 
   useEffect(() => { loadProblems() }, [loadProblems])
   useEffect(() => { loadSubmissions() }, [loadSubmissions])
   useEffect(() => { setCurrentIdx(0) }, [schoolFilter])
+
+  function navigateTo(idx) {
+    setCurrentIdx(idx)
+    const p = problems[idx]
+    if (p) router.push(`/problems?id=${p.id}`, { scroll: false })
+  }
 
   async function handleDelete(id) {
     if (!confirm('Delete this problem? This cannot be undone.')) return
@@ -341,20 +369,28 @@ function ProblemsContent() {
     )
   }
 
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center py-24">
+        <p className="text-text-secondary font-inter">{error}</p>
+      </div>
+    )
+  }
+
   const sharedProps = { problems, profile, schoolFilter, setSchoolFilter, userSubmissions }
 
   return view === 'post' ? (
     <PostView
       {...sharedProps}
       currentIdx={currentIdx}
-      setCurrentIdx={setCurrentIdx}
+      navigateTo={navigateTo}
       setView={setView}
       onDelete={handleDelete}
     />
   ) : (
     <ListView
       {...sharedProps}
-      setCurrentIdx={setCurrentIdx}
+      navigateTo={navigateTo}
       setView={setView}
     />
   )
@@ -364,7 +400,9 @@ export default function ProblemsPage() {
   return (
     <RoleGuard>
       <div className="min-h-screen flex flex-col bg-bg-base">
-        <ProblemsContent />
+        <Suspense>
+          <ProblemsContent />
+        </Suspense>
       </div>
     </RoleGuard>
   )

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -1,15 +1,376 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  ChevronLeft, ChevronRight, List, Trash2, Plus, Download, PenLine, Check, Minus,
+} from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
 import RoleGuard from '@/components/auth/RoleGuard'
+import { useAuth } from '@/hooks/useAuth'
+import { supabase } from '@/lib/supabase'
+import { ROLES } from '@/utils/constants'
+
+const SCHOOLS = ['All Schools', 'Seneca College', 'York University']
+
+function LanguageTag({ lang }) {
+  return (
+    <span
+      className="font-inter inline-block"
+      style={{ background: '#FDECEA', color: '#C0392B', fontSize: 11, padding: '2px 8px', borderRadius: 4 }}
+    >
+      {lang}
+    </span>
+  )
+}
+
+function formatDue(dateStr) {
+  if (!dateStr) return null
+  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function downloadMd(problem) {
+  const slug = (problem.title || 'problem').toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
+  const week = problem.week ?? 'x'
+  const filename = `week-${week}-${slug}.md`
+  const blob = new Blob([problem.description || ''], { type: 'text/markdown' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDelete, schoolFilter, setSchoolFilter }) {
+  const router = useRouter()
+  const problem = problems[currentIdx]
+  const isAdmin = profile?.role === ROLES.ADMIN || profile?.role === ROLES.EXECUTIVE
+  const isFirst = currentIdx === problems.length - 1
+  const isLast = currentIdx === 0
+
+  if (!problem) {
+    return (
+      <div className="flex-1 flex items-center justify-center py-24">
+        <p className="text-text-secondary font-inter">No problems found.</p>
+      </div>
+    )
+  }
+
+  const langs = Array.isArray(problem.languages) ? problem.languages : []
+
+  return (
+    <>
+      {/* Page header */}
+      <div className="bg-bg-surface py-8 border-b border-border">
+        <div className="max-w-[800px] mx-auto px-6 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <h1 className="font-montserrat font-bold text-4xl text-text-primary">Problems</h1>
+            <SchoolFilter value={schoolFilter} onChange={setSchoolFilter} />
+          </div>
+          {isAdmin && (
+            <button
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter text-white transition-colors"
+              style={{ background: '#C0392B' }}
+              onMouseEnter={e => e.currentTarget.style.background = '#A93226'}
+              onMouseLeave={e => e.currentTarget.style.background = '#C0392B'}
+            >
+              <Plus size={14} />
+              New
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Problem content */}
+      <div className="flex-1 bg-bg-base py-12">
+        <div className="max-w-[800px] mx-auto px-6">
+          <h2 className="font-montserrat font-semibold text-2xl text-text-primary mb-3">
+            {problem.title}
+          </h2>
+
+          {/* Meta row */}
+          <div className="flex flex-wrap items-center gap-2 text-text-secondary font-inter text-sm mb-4">
+            {langs.length > 0 && (
+              <span className="flex items-center gap-1.5">
+                {langs.map((l, i) => <LanguageTag key={i} lang={l} />)}
+              </span>
+            )}
+            {problem.week != null && (
+              <span className={langs.length > 0 ? 'before:content-["·"] before:mr-2' : ''}>
+                Week {problem.week}
+              </span>
+            )}
+            {problem.due_date && (
+              <span className="before:content-['📅'] before:mr-1">
+                Due: {formatDue(problem.due_date)}
+              </span>
+            )}
+            {problem.school && (
+              <span className="text-text-hint">· {problem.school}</span>
+            )}
+            {problem.posted_by && (
+              <span className="text-text-hint">· Posted by: {problem.posted_by}</span>
+            )}
+          </div>
+
+          <hr className="border-border mb-6" />
+
+          {/* Markdown body */}
+          <div className="font-inter text-base text-text-primary leading-[1.7] prose max-w-none mb-8
+            prose-headings:font-montserrat prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
+            prose-code:font-mono prose-code:text-sm prose-code:bg-bg-elevated prose-code:px-1 prose-code:py-0.5 prose-code:rounded
+            prose-pre:bg-bg-elevated prose-pre:p-4 prose-pre:rounded-lg prose-pre:font-mono prose-pre:text-sm">
+            <ReactMarkdown>{problem.description || '_No content._'}</ReactMarkdown>
+          </div>
+
+          {/* Solution button */}
+          <button
+            onClick={() => router.push(`/solutions?problem=${problem.id}`)}
+            className="w-full py-3 rounded-md text-white font-inter font-medium text-sm flex items-center justify-center gap-2 transition-colors"
+            style={{ background: '#C0392B' }}
+            onMouseEnter={e => e.currentTarget.style.background = '#A93226'}
+            onMouseLeave={e => e.currentTarget.style.background = '#C0392B'}
+          >
+            <PenLine size={14} />
+            Go to My Solution →
+          </button>
+        </div>
+      </div>
+
+      {/* Navigation row */}
+      <div className="border-t border-border py-8 bg-bg-base">
+        <div className="max-w-[800px] mx-auto px-6 flex items-center justify-between">
+          <button
+            onClick={() => setCurrentIdx(i => i + 1)}
+            disabled={isFirst}
+            className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
+          >
+            <ChevronLeft size={14} />
+            Previous
+          </button>
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setView('list')}
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary transition-colors"
+            >
+              <List size={14} />
+              List
+            </button>
+            <button
+              onClick={() => downloadMd(problem)}
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary transition-colors"
+              title="Download .md"
+            >
+              <Download size={14} />
+              .md
+            </button>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setCurrentIdx(i => i - 1)}
+              disabled={isLast}
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
+            >
+              Next
+              <ChevronRight size={14} />
+            </button>
+            {isAdmin && (
+              <button
+                onClick={() => onDelete(problem.id)}
+                className="flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium font-inter transition-colors text-accent hover:text-accent-hover"
+              >
+                <Trash2 size={14} />
+                Delete
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function ListView({ problems, setCurrentIdx, setView, profile, schoolFilter, setSchoolFilter, userSubmissions }) {
+  const isAdmin = profile?.role === ROLES.ADMIN || profile?.role === ROLES.EXECUTIVE
+
+  return (
+    <>
+      {/* Page header */}
+      <div className="bg-bg-surface py-8 border-b border-border">
+        <div className="max-w-[900px] mx-auto px-6 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <h1 className="font-montserrat font-bold text-4xl text-text-primary">Problems</h1>
+            <SchoolFilter value={schoolFilter} onChange={setSchoolFilter} />
+          </div>
+          {isAdmin && (
+            <button
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter text-white transition-colors"
+              style={{ background: '#C0392B' }}
+              onMouseEnter={e => e.currentTarget.style.background = '#A93226'}
+              onMouseLeave={e => e.currentTarget.style.background = '#C0392B'}
+            >
+              <Plus size={14} />
+              New
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 bg-bg-base py-12">
+        <div className="max-w-[900px] mx-auto px-6">
+          {problems.length === 0 ? (
+            <p className="text-text-secondary font-inter text-center py-16">No problems found.</p>
+          ) : (
+            <table className="w-full border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left font-inter text-sm font-medium text-text-secondary py-3 pr-4 w-16">Week</th>
+                  <th className="text-left font-inter text-sm font-medium text-text-secondary py-3 pr-4">Title</th>
+                  <th className="text-left font-inter text-sm font-medium text-text-secondary py-3 pr-4">Lang</th>
+                  <th className="text-left font-inter text-sm font-medium text-text-secondary py-3 pr-4">Due</th>
+                  <th className="text-center font-inter text-sm font-medium text-text-secondary py-3 w-10">✓</th>
+                </tr>
+              </thead>
+              <tbody>
+                {problems.map((p, idx) => {
+                  const solved = userSubmissions.has(p.id)
+                  const langs = Array.isArray(p.languages) ? p.languages : []
+                  return (
+                    <tr
+                      key={p.id}
+                      onClick={() => { setCurrentIdx(idx); setView('post') }}
+                      className="border-b border-border cursor-pointer transition-colors hover:bg-bg-surface"
+                    >
+                      <td className="font-inter text-sm text-text-primary py-3.5 pr-4">
+                        {p.week != null ? p.week : '—'}
+                      </td>
+                      <td className="font-inter text-sm text-text-primary py-3.5 pr-4 font-medium">
+                        {p.title}
+                      </td>
+                      <td className="py-3.5 pr-4">
+                        <div className="flex flex-wrap gap-1">
+                          {langs.length > 0
+                            ? langs.map((l, i) => <LanguageTag key={i} lang={l} />)
+                            : <span className="text-text-hint text-sm">—</span>
+                          }
+                        </div>
+                      </td>
+                      <td className="font-inter text-sm text-text-secondary py-3.5 pr-4">
+                        {formatDue(p.due_date) ?? '—'}
+                      </td>
+                      <td className="text-center py-3.5">
+                        {solved
+                          ? <Check size={15} style={{ color: '#2E7D5E', margin: '0 auto' }} />
+                          : <Minus size={15} className="text-text-hint mx-auto" />
+                        }
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function SchoolFilter({ value, onChange }) {
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      className="font-inter text-sm text-text-secondary bg-bg-input border border-border-strong rounded-md px-3 py-1.5 focus:outline-none focus:border-accent"
+    >
+      {SCHOOLS.map(s => <option key={s}>{s}</option>)}
+    </select>
+  )
+}
+
+function ProblemsContent() {
+  const { profile } = useAuth()
+  const [view, setView] = useState('post')
+  const [problems, setProblems] = useState([])
+  const [currentIdx, setCurrentIdx] = useState(0)
+  const [schoolFilter, setSchoolFilter] = useState('All Schools')
+  const [userSubmissions, setUserSubmissions] = useState(new Set())
+  const [loading, setLoading] = useState(true)
+
+  const fetchProblems = useCallback(async () => {
+    setLoading(true)
+    let query = supabase
+      .from('problems')
+      .select('*')
+      .order('week', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false })
+
+    if (schoolFilter !== 'All Schools') {
+      query = query.eq('school', schoolFilter)
+    }
+
+    const { data, error } = await query
+    if (!error && data) setProblems(data)
+    setLoading(false)
+  }, [schoolFilter])
+
+  const fetchSubmissions = useCallback(async () => {
+    if (!profile?.id) return
+    const { data } = await supabase
+      .from('submissions')
+      .select('problem_id')
+      .eq('profile_id', profile.id)
+    if (data) setUserSubmissions(new Set(data.map(s => s.problem_id)))
+  }, [profile?.id])
+
+  useEffect(() => { fetchProblems() }, [fetchProblems])
+  useEffect(() => { fetchSubmissions() }, [fetchSubmissions])
+  useEffect(() => { setCurrentIdx(0) }, [schoolFilter])
+
+  async function handleDelete(id) {
+    if (!confirm('Delete this problem? This cannot be undone.')) return
+    await supabase.from('problems').delete().eq('id', id)
+    await fetchProblems()
+    setCurrentIdx(0)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center py-24">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent" />
+      </div>
+    )
+  }
+
+  const sharedProps = { problems, profile, schoolFilter, setSchoolFilter, userSubmissions }
+
+  return view === 'post' ? (
+    <PostView
+      {...sharedProps}
+      currentIdx={currentIdx}
+      setCurrentIdx={setCurrentIdx}
+      setView={setView}
+      onDelete={handleDelete}
+    />
+  ) : (
+    <ListView
+      {...sharedProps}
+      setCurrentIdx={setCurrentIdx}
+      setView={setView}
+    />
+  )
+}
 
 export default function ProblemsPage() {
   return (
     <RoleGuard>
-      <main className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-5xl font-bold text-gray-900">Problems</h1>
-          <p className="mt-3 text-gray-400 text-lg">Weekly coding problems</p>
-          <p className="mt-1 text-gray-300 text-sm">Members only</p>
-        </div>
-      </main>
+      <div className="min-h-screen flex flex-col bg-bg-base">
+        <ProblemsContent />
+      </div>
     </RoleGuard>
   )
 }

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -8,7 +8,8 @@ import {
 import ReactMarkdown from 'react-markdown'
 import RoleGuard from '@/components/auth/RoleGuard'
 import { useAuth } from '@/hooks/useAuth'
-import { supabase } from '@/lib/supabase'
+import { fetchProblems, deleteProblem } from '@/services/problemsService'
+import { fetchUserSubmissions } from '@/services/submissionsService'
 import { ROLES } from '@/utils/constants'
 
 const SCHOOLS = ['All Schools', 'Seneca College', 'York University']
@@ -46,8 +47,8 @@ function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDel
   const router = useRouter()
   const problem = problems[currentIdx]
   const isAdmin = profile?.role === ROLES.ADMIN || profile?.role === ROLES.EXECUTIVE
-  const isFirst = currentIdx === problems.length - 1
-  const isLast = currentIdx === 0
+  const isOldest = currentIdx === problems.length - 1
+  const isNewest = currentIdx === 0
 
   if (!problem) {
     return (
@@ -70,10 +71,10 @@ function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDel
           </div>
           {isAdmin && (
             <button
-              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter text-white transition-colors"
+              disabled
+              title="Coming soon"
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter text-white transition-colors opacity-40 cursor-not-allowed"
               style={{ background: '#C0392B' }}
-              onMouseEnter={e => e.currentTarget.style.background = '#A93226'}
-              onMouseLeave={e => e.currentTarget.style.background = '#C0392B'}
             >
               <Plus size={14} />
               New
@@ -143,7 +144,7 @@ function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDel
         <div className="max-w-[800px] mx-auto px-6 flex items-center justify-between">
           <button
             onClick={() => setCurrentIdx(i => i + 1)}
-            disabled={isFirst}
+            disabled={isOldest}
             className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
           >
             <ChevronLeft size={14} />
@@ -171,7 +172,7 @@ function PostView({ problems, currentIdx, setCurrentIdx, setView, profile, onDel
           <div className="flex items-center gap-3">
             <button
               onClick={() => setCurrentIdx(i => i - 1)}
-              disabled={isLast}
+              disabled={isNewest}
               className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
             >
               Next
@@ -207,10 +208,10 @@ function ListView({ problems, setCurrentIdx, setView, profile, schoolFilter, set
           </div>
           {isAdmin && (
             <button
-              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter text-white transition-colors"
+              disabled
+              title="Coming soon"
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter text-white transition-colors opacity-40 cursor-not-allowed"
               style={{ background: '#C0392B' }}
-              onMouseEnter={e => e.currentTarget.style.background = '#A93226'}
-              onMouseLeave={e => e.currentTarget.style.background = '#C0392B'}
             >
               <Plus size={14} />
               New
@@ -301,41 +302,35 @@ function ProblemsContent() {
   const [userSubmissions, setUserSubmissions] = useState(new Set())
   const [loading, setLoading] = useState(true)
 
-  const fetchProblems = useCallback(async () => {
+  const loadProblems = useCallback(async () => {
     setLoading(true)
-    let query = supabase
-      .from('problems')
-      .select('*')
-      .order('week', { ascending: false, nullsFirst: false })
-      .order('created_at', { ascending: false })
-
-    if (schoolFilter !== 'All Schools') {
-      query = query.eq('school', schoolFilter)
+    try {
+      const data = await fetchProblems(schoolFilter)
+      setProblems(data)
+    } finally {
+      setLoading(false)
     }
-
-    const { data, error } = await query
-    if (!error && data) setProblems(data)
-    setLoading(false)
   }, [schoolFilter])
 
-  const fetchSubmissions = useCallback(async () => {
+  const loadSubmissions = useCallback(async () => {
     if (!profile?.id) return
-    const { data } = await supabase
-      .from('submissions')
-      .select('problem_id')
-      .eq('profile_id', profile.id)
-    if (data) setUserSubmissions(new Set(data.map(s => s.problem_id)))
+    const solved = await fetchUserSubmissions(profile.id)
+    setUserSubmissions(solved)
   }, [profile?.id])
 
-  useEffect(() => { fetchProblems() }, [fetchProblems])
-  useEffect(() => { fetchSubmissions() }, [fetchSubmissions])
+  useEffect(() => { loadProblems() }, [loadProblems])
+  useEffect(() => { loadSubmissions() }, [loadSubmissions])
   useEffect(() => { setCurrentIdx(0) }, [schoolFilter])
 
   async function handleDelete(id) {
     if (!confirm('Delete this problem? This cannot be undone.')) return
-    await supabase.from('problems').delete().eq('id', id)
-    await fetchProblems()
-    setCurrentIdx(0)
+    try {
+      await deleteProblem(id)
+      await loadProblems()
+      setCurrentIdx(0)
+    } catch {
+      alert('Failed to delete. Please try again.')
+    }
   }
 
   if (loading) {

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -1,0 +1,22 @@
+import { supabase } from '@/lib/supabase'
+
+export async function fetchProblems(schoolFilter) {
+  let query = supabase
+    .from('problems')
+    .select('*')
+    .order('week', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false })
+
+  if (schoolFilter && schoolFilter !== 'All Schools') {
+    query = query.eq('school', schoolFilter)
+  }
+
+  const { data, error } = await query
+  if (error) throw error
+  return data ?? []
+}
+
+export async function deleteProblem(id) {
+  const { error } = await supabase.from('problems').delete().eq('id', id)
+  if (error) throw error
+}

--- a/src/services/submissionsService.js
+++ b/src/services/submissionsService.js
@@ -1,0 +1,10 @@
+import { supabase } from '@/lib/supabase'
+
+export async function fetchUserSubmissions(profileId) {
+  const { data, error } = await supabase
+    .from('submissions')
+    .select('problem_id')
+    .eq('profile_id', profileId)
+  if (error) throw error
+  return new Set((data ?? []).map(s => s.problem_id))
+}


### PR DESCRIPTION
## Summary

Closes #24

Implements the `/problems` page per the design spec (`docs/design/page-specs/problems.md`), member-only via `RoleGuard`.

---

## What's included

### Post View (default)
- Page header (`#F9F9F9`) with H1 "Problems", school filter dropdown, and `[+ New]` button (admin/executive only)
- Problem card: H2 title, language tags, week number, due date, author meta row
- Markdown body rendered via `react-markdown` (headings, code blocks, lists, bold)
- Full-width `[✏️ Go to My Solution →]` red CTA button → navigates to `/solutions?problem=:id`
- Navigation row: `[← Previous]` / `[List]` / `[⬇ .md]` / `[Next →]` / `[🗑 Delete]` (admin/executive only)
- Previous/Next disabled and grayed when at oldest/newest problem

### List View
- Table: Week / Title / Lang / Due / ✓ columns (max-width 900px, centered)
- ✓ = green checkmark if member has a submission, – = gray dash if not
- Row hover highlight, click navigates to Post View for that problem
- School filter applies here too

### School Filter
- Dropdown: All Schools / Seneca College / York University
- Filters Supabase query on both views
- Resets to first problem when changed

### Download
- `[⬇ .md]` button on Post View downloads problem body as `week-{N}-{title-slug}.md`

### Data
- Fetches from `problems` table ordered by `week DESC`, then `created_at DESC`
- Fetches member's `submissions` to compute solved status per problem
- Graceful empty state when no problems exist

---

## Design tokens used
- Accent: `#C0392B` / hover `#A93226`
- Language tag: bg `#FDECEA`, color `#C0392B`, 11px, padding `2px 8px`, radius `4px`
- Solved checkmark: `#2E7D5E`
- Fonts: Montserrat (headings) / Inter (body) — matches design system

---

## Dependencies
- Added `react-markdown@^10.1.0` to `package.json`

## Related
- Depends on RLS fix: #76
- Blocks: #24

---

## Test plan
- [x] `/problems` loads for members, redirects unauthenticated users to `/join`
- [x] Post View shows most recent problem by default
- [x] Language tags, week, due date, and author render correctly from DB
- [x] Markdown body renders headings, bold, code blocks, and lists
- [x] `[← Previous]` / `[Next →]` navigate between problems and disable at boundaries
- [x] `[List]` switches to List View; clicking a row returns to Post View
- [x] `[⬇ .md]` downloads the correct file with correct filename
- [x] School filter fetches only matching problems on both views
- [x] `[+ New]` and `[🗑 Delete]` visible to admin/executive only, hidden for members
- [x] Solved ✓ / – status reflects member's submissions correctly
- [x] Empty state shown when no problems match the filter

Signed-off-by: SystemProgrammerWizzard <tatandat110105@gmail.com>