### PR TITLE
chore: add content width tokens to tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,6 +55,10 @@ module.exports = {
         montserrat: ['var(--font-montserrat)', 'sans-serif'],
         mono: ['var(--font-jetbrains-mono)', 'monospace'],
       },
+      maxWidth: {
+        'content': '800px',
+        'content-wide': '1000px',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- Add `max-w-content` (800px) and `max-w-content-wide` (1000px) to `tailwind.config.js`
- Standardizes layout widths across pages (problems, schedule, future pages)

## Related Issue
Related to #84 (PR review feedback)

## Checklist
- [x] Tested locally
- [x] No console.log left
- [x] Follows code conventions