### PR TITLE
feat: implement issue #88 join modal profile fields

### DIFF
--- a/docs/design/page-specs/members.md
+++ b/docs/design/page-specs/members.md
@@ -50,8 +50,10 @@
 │  [All Cohorts ▾]  [All Schools ▾]  [All Status ▾]  [All Roles ▾]
 │                                                     │
 │  Cohort dropdown:                                   │
-│    All Cohorts / Winter 2024 / Summer 2024 /        │
-│    Fall 2024 / Winter 2025 / ...                    │
+│    All Cohorts / 5th Cohort / 4th Cohort /          │
+│    3rd Cohort / 2nd Cohort / 1st Cohort             │
+│    (auto-generated from Fall 2024; Summer 2025      │
+│     skipped; new cohort added each term)            │
 │                                                     │
 │  School dropdown:                                   │
 │    All Schools / Seneca College / York University   │

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -7,24 +7,53 @@ import { useAuth } from '@/hooks/useAuth'
 import { createProfile } from '@/services/authService'
 import Button from '@/components/ui/Button'
 
-const CAMPUSES = ['Seneca College', 'York University']
+const SCHOOLS = ['Seneca College', 'York University']
+
+const FIRST_COHORT = { season: 'Fall', year: 2024 }
+const SKIPPED_TERMS = new Set(['Summer 2025'])
+const SEASON_ORDER = ['Winter', 'Summer', 'Fall']
+
+function ordinal(n) {
+  if (n % 100 >= 11 && n % 100 <= 13) return `${n}th`
+  switch (n % 10) {
+    case 1: return `${n}st`
+    case 2: return `${n}nd`
+    case 3: return `${n}rd`
+    default: return `${n}th`
+  }
+}
+
+function getCurrentTerm() {
+  const month = new Date().getMonth() + 1
+  const year = new Date().getFullYear()
+  if (month <= 4) return { season: 'Winter', year }
+  if (month <= 8) return { season: 'Summer', year }
+  return { season: 'Fall', year }
+}
 
 function generateCohorts() {
-  const terms = ['Winter', 'Summer', 'Fall']
-  const termMonths = { Winter: [1, 4], Summer: [5, 8], Fall: [9, 12] }
-  const now = new Date()
-  const currentYear = now.getFullYear()
-  const currentMonth = now.getMonth() + 1
+  const current = getCurrentTerm()
   const cohorts = []
+  let { season, year } = FIRST_COHORT
 
-  for (let year = 2024; year <= currentYear + 1; year++) {
-    for (const term of terms) {
-      const [start] = termMonths[term]
-      if (year > currentYear) break
-      if (year === currentYear && start > currentMonth + 4) break
-      cohorts.push(`${term} ${year}`)
+  while (true) {
+    const term = `${season} ${year}`
+    const isCurrent = season === current.season && year === current.year
+
+    if (!SKIPPED_TERMS.has(term)) {
+      cohorts.push({
+        value: term,
+        label: `${ordinal(cohorts.length + 1)} Cohort (Joined ${term}${isCurrent ? ' ← now' : ''})`,
+      })
     }
+
+    if (isCurrent) break
+
+    const idx = SEASON_ORDER.indexOf(season)
+    if (idx === 2) { season = 'Winter'; year += 1 }
+    else season = SEASON_ORDER[idx + 1]
   }
+
   return cohorts.reverse()
 }
 
@@ -39,9 +68,14 @@ export default function JoinModal() {
   const { isOpen, openModal, closeModal } = useJoinModal()
   const { user, profile, loading, refreshProfile } = useAuth()
   const router = useRouter()
-  const [campus, setCampus] = useState('')
+  const [name, setName] = useState('')
+  const [school, setSchool] = useState('')
   const [cohort, setCohort] = useState('')
   const [phone, setPhone] = useState('')
+  const [status, setStatus] = useState('')
+  const [occupation, setOccupation] = useState('')
+  const [linkedin, setLinkedin] = useState('')
+  const [github, setGithub] = useState('')
   const [errors, setErrors] = useState({})
   const [submitting, setSubmitting] = useState(false)
   const cohorts = generateCohorts()
@@ -65,10 +99,22 @@ export default function JoinModal() {
   }, [isOpen])
 
   useEffect(() => {
+    if (isOpen && user) {
+      const meta = user.user_metadata
+      setName(meta?.full_name ?? meta?.name ?? '')
+    }
+  }, [isOpen, user])
+
+  useEffect(() => {
     if (!isOpen) {
-      setCampus('')
+      setName('')
+      setSchool('')
       setCohort('')
       setPhone('')
+      setStatus('')
+      setOccupation('')
+      setLinkedin('')
+      setGithub('')
       setErrors({})
       setSubmitting(false)
     }
@@ -81,9 +127,11 @@ export default function JoinModal() {
 
   function validate() {
     const next = {}
-    if (!campus) next.campus = 'Please select a campus'
+    if (!name.trim()) next.name = 'Please enter your name'
+    if (!school) next.school = 'Please select a school'
     if (!cohort) next.cohort = 'Please select a cohort'
     if (!/^\(\d{3}\) \d{3}-\d{4}$/.test(phone)) next.phone = 'Enter a valid phone number: (XXX) XXX-XXXX'
+    if (!status) next.status = 'Please select your status'
     setErrors(next)
     return Object.keys(next).length === 0
   }
@@ -93,15 +141,18 @@ export default function JoinModal() {
     setSubmitting(true)
 
     try {
-      const meta = user.user_metadata
       await createProfile({
         id: user.id,
-        name: meta?.full_name ?? meta?.name ?? '',
+        name: name.trim(),
         email: user.email,
-        avatarUrl: meta?.avatar_url ?? '',
-        campus,
+        avatarUrl: user.user_metadata?.avatar_url ?? '',
+        school,
         cohort,
         phone,
+        status,
+        occupation,
+        linkedin,
+        github,
       })
 
       sessionStorage.removeItem('join_modal_dismissed')
@@ -163,37 +214,50 @@ export default function JoinModal() {
           </div>
         )}
 
-        {/* Campus */}
+        {/* Name */}
         <div className="mb-4">
-          <label className="block text-sm font-medium text-text-primary mb-1.5">Campus</label>
+          <label className="block text-sm font-medium text-text-primary mb-1.5">Name <span className="text-red-500">*</span></label>
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Your full name"
+            className={`${inputBase} ${inputFocus} ${errors.name ? 'border-red-400' : inputNormal}`}
+          />
+          {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
+        </div>
+
+        {/* School */}
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-text-primary mb-1.5">School <span className="text-red-500">*</span></label>
           <select
-            value={campus}
-            onChange={e => setCampus(e.target.value)}
-            className={`${inputBase} ${inputFocus} ${errors.campus ? 'border-red-400' : inputNormal}`}
+            value={school}
+            onChange={e => setSchool(e.target.value)}
+            className={`${inputBase} ${inputFocus} ${errors.school ? 'border-red-400' : inputNormal}`}
           >
-            <option value="">Select your campus</option>
-            {CAMPUSES.map(c => <option key={c} value={c}>{c}</option>)}
+            <option value="">Select your school</option>
+            {SCHOOLS.map(s => <option key={s} value={s}>{s}</option>)}
           </select>
-          {errors.campus && <p className="mt-1 text-xs text-red-500">{errors.campus}</p>}
+          {errors.school && <p className="mt-1 text-xs text-red-500">{errors.school}</p>}
         </div>
 
         {/* Cohort */}
         <div className="mb-4">
-          <label className="block text-sm font-medium text-text-primary mb-1.5">Cohort <span className="text-text-hint font-normal">(when did you join?)</span></label>
+          <label className="block text-sm font-medium text-text-primary mb-1.5">Cohort <span className="text-text-hint font-normal">(when did you join?)</span> <span className="text-red-500">*</span></label>
           <select
             value={cohort}
             onChange={e => setCohort(e.target.value)}
             className={`${inputBase} ${inputFocus} ${errors.cohort ? 'border-red-400' : inputNormal}`}
           >
             <option value="">Select cohort</option>
-            {cohorts.map(c => <option key={c} value={c}>{c}</option>)}
+            {cohorts.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
           </select>
           {errors.cohort && <p className="mt-1 text-xs text-red-500">{errors.cohort}</p>}
         </div>
 
         {/* Phone */}
-        <div className="mb-6">
-          <label className="block text-sm font-medium text-text-primary mb-1.5">Phone Number</label>
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-text-primary mb-1.5">Phone Number <span className="text-red-500">*</span></label>
           <input
             type="tel"
             value={phone}
@@ -202,6 +266,57 @@ export default function JoinModal() {
             className={`${inputBase} ${inputFocus} ${errors.phone ? 'border-red-400' : inputNormal}`}
           />
           {errors.phone && <p className="mt-1 text-xs text-red-500">{errors.phone}</p>}
+        </div>
+
+        {/* Status */}
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-text-primary mb-1.5">Status <span className="text-red-500">*</span></label>
+          <select
+            value={status}
+            onChange={e => setStatus(e.target.value)}
+            className={`${inputBase} ${inputFocus} ${errors.status ? 'border-red-400' : inputNormal}`}
+          >
+            <option value="">Select your status</option>
+            <option value="student">Student</option>
+            <option value="graduated">Graduated</option>
+          </select>
+          {errors.status && <p className="mt-1 text-xs text-red-500">{errors.status}</p>}
+        </div>
+
+        {/* Occupation */}
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-text-primary mb-1.5">Occupation <span className="text-text-hint font-normal">(optional)</span></label>
+          <input
+            type="text"
+            value={occupation}
+            onChange={e => setOccupation(e.target.value)}
+            placeholder="e.g. Software Developer, Student"
+            className={`${inputBase} ${inputFocus} ${inputNormal}`}
+          />
+        </div>
+
+        {/* LinkedIn */}
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-text-primary mb-1.5">LinkedIn <span className="text-text-hint font-normal">(optional)</span></label>
+          <input
+            type="url"
+            value={linkedin}
+            onChange={e => setLinkedin(e.target.value)}
+            placeholder="https://linkedin.com/in/..."
+            className={`${inputBase} ${inputFocus} ${inputNormal}`}
+          />
+        </div>
+
+        {/* GitHub */}
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-text-primary mb-1.5">GitHub <span className="text-text-hint font-normal">(optional)</span></label>
+          <input
+            type="url"
+            value={github}
+            onChange={e => setGithub(e.target.value)}
+            placeholder="https://github.com/..."
+            className={`${inputBase} ${inputFocus} ${inputNormal}`}
+          />
         </div>
 
         {/* Submit */}

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -192,16 +192,10 @@ export default function Navbar() {
               Log out
             </button>
           ) : (
-            <>
-              <button onClick={handleLogIn}
-                className="px-3 py-1.5 text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">
-                Log In
-              </button>
-              <button onClick={handleLogIn}
-                className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
-                Join Us
-              </button>
-            </>
+            <button onClick={handleLogIn}
+              className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
+              Log In
+            </button>
           ))}
 
           {isAdmin && (
@@ -293,16 +287,10 @@ export default function Navbar() {
               Log out
             </button>
           ) : (
-            <div className="flex flex-col gap-2">
-              <button onClick={() => { setMobileOpen(false); handleLogIn() }}
-                className="w-full px-4 py-2.5 rounded-md text-sm font-medium border border-border text-text-primary hover:bg-bg-surface transition-colors text-center">
-                Log In
-              </button>
-              <button onClick={() => { setMobileOpen(false); handleLogIn() }}
-                className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
-                Join Us
-              </button>
-            </div>
+            <button onClick={() => { setMobileOpen(false); handleLogIn() }}
+              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
+              Log In
+            </button>
           ))}
         </div>
       )}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -28,19 +28,22 @@ export async function fetchProfile(userId) {
   return data ?? null
 }
 
-export async function createProfile({ id, name, email, avatarUrl, campus, cohort, phone }) {
+export async function createProfile({ id, name, email, avatarUrl, school, cohort, phone, status, occupation, linkedin, github }) {
   const { data, error } = await supabase
     .from('profiles')
-    .upsert({
-      id,
+    .update({
       name,
       email,
       avatar_url: avatarUrl,
-      campus,
+      school,
       cohort,
       phone,
-      role: 'pending',
+      status,
+      occupation,
+      linkedin,
+      github,
     })
+    .eq('id', id)
     .select()
     .single()
 


### PR DESCRIPTION
## Summary

- Remove `Join Us` button from Navbar (desktop + mobile) — login flow now starts from `Log In` only
- Rename `campus` → `school` throughout JoinModal and authService to match DB schema
- Add new profile fields to JoinModal: `name`, `status`, `occupation`, `linkedin`, `github`
- Auto-generate ordinal cohort list starting from Fall 2024 (Summer 2025 skipped), updates automatically each term
- Mark required fields (`name`, `school`, `cohort`, `phone`, `status`) with `*`
- Fix `createProfile`: changed `upsert` → `update` to comply with RLS policy (`profiles_update_own`)

## Test plan

- [x] Log in with Google → modal opens on `/pending`
- [x] Required field validation shows errors on empty submit
- [x] Phone number formats correctly as `(XXX) XXX-XXXX`
- [x] Cohort dropdown shows ordinal labels (1st, 2nd, 3rd... Cohort) with current term marked
- [x] Submit saves all fields to Supabase `profiles` table
- [x] After submit, redirects correctly and modal does not reopen on next login

Closes #88