### PR TITLE
fix: reliable logout + prevent navbar flash on init

### DIFF
--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -75,6 +75,37 @@ function IconChevron() {
   )
 }
 
+const ROLE_STYLES = {
+  admin:     'bg-green-100 text-green-700',
+  executive: 'bg-purple-100 text-purple-700',
+  member:    'bg-accent/10 text-accent',
+  pending:   'bg-yellow-100 text-yellow-700',
+}
+
+function UserChip({ user, profile }) {
+  const role = profile?.role
+  const avatarUrl = user?.user_metadata?.avatar_url ?? profile?.avatar_url
+  const initial = (user?.email?.[0] ?? '?').toUpperCase()
+  const roleStyle = ROLE_STYLES[role] ?? 'bg-gray-100 text-gray-500'
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {avatarUrl ? (
+        <img src={avatarUrl} alt="" referrerPolicy="no-referrer" className="w-6 h-6 rounded-full shrink-0" />
+      ) : (
+        <div className="w-6 h-6 rounded-full bg-bg-elevated flex items-center justify-center text-[10px] font-medium text-text-secondary shrink-0">
+          {initial}
+        </div>
+      )}
+      {role && (
+        <span className={`px-1.5 py-0.5 rounded text-[11px] font-medium capitalize ${roleStyle}`}>
+          {role}
+        </span>
+      )}
+    </div>
+  )
+}
+
 function NavLink({ href, label, pathname }) {
   const active = pathname === href
   return (
@@ -187,10 +218,13 @@ export default function Navbar() {
           <div className="w-px h-5 bg-border mx-1" />
 
           {!loading && (user ? (
-            <button onClick={signOut}
-              className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
-              Log out
-            </button>
+            <>
+              <UserChip user={user} profile={profile} />
+              <button onClick={signOut}
+                className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
+                Log out
+              </button>
+            </>
           ) : (
             <>
               <button onClick={handleLogIn}
@@ -288,10 +322,15 @@ export default function Navbar() {
 
           {/* Auth */}
           {!loading && (user ? (
-            <button onClick={() => { signOut(); setMobileOpen(false) }}
-              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
-              Log out
-            </button>
+            <div className="flex flex-col gap-2">
+              <div className="px-2 py-1">
+                <UserChip user={user} profile={profile} />
+              </div>
+              <button onClick={() => { signOut(); setMobileOpen(false) }}
+                className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
+                Log out
+              </button>
+            </div>
           ) : (
             <div className="flex flex-col gap-2">
               <button onClick={() => { setMobileOpen(false); handleLogIn() }}

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -17,6 +17,8 @@ export function AuthProvider({ children }) {
   // intentionally mount-only.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
+    let initialized = false
+
     async function init() {
       try {
         const session = await getSession()
@@ -27,6 +29,7 @@ export function AuthProvider({ children }) {
         }
       } finally {
         setLoading(false)
+        initialized = true
       }
     }
 
@@ -34,17 +37,20 @@ export function AuthProvider({ children }) {
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (_event, session) => {
+        // Skip INITIAL_SESSION — init() already handles it and setting state
+        // here before init() completes causes a profile-null flash (navbar
+        // buttons disappear briefly).
+        if (!initialized) return
         setUser(session?.user ?? null)
         if (session?.user) {
           try {
             const p = await fetchProfile(session.user.id)
             setProfile(p)
-          } finally {
-            setLoading(false)
+          } catch {
+            setProfile(null)
           }
         } else {
           setProfile(null)
-          setLoading(false)
         }
       }
     )
@@ -62,7 +68,12 @@ export function AuthProvider({ children }) {
   }
 
   async function signOut() {
-    await authSignOut()
+    try {
+      await authSignOut()
+    } catch {
+      // Supabase sign-out may throw if the session is already expired;
+      // always clean up client state and redirect regardless.
+    }
     setUser(null)
     setProfile(null)
     sessionStorage.removeItem('join_modal_dismissed')


### PR DESCRIPTION
## Summary
- **Logout bug (#96)**: `signOut()` had no error handling — if Supabase threw (expired session, network error), `setUser(null)` and `router.push('/')` never ran so the button appeared unresponsive. Now wrapped in try/catch; state cleanup and redirect always run regardless.
- **Navbar buttons disappearing (#97)**: `onAuthStateChange` was firing Supabase's `INITIAL_SESSION` event before `init()` finished, briefly resetting `user` without a `profile`, which caused the navbar's `!loading` gate to flash and links to vanish. Added an `initialized` guard so the listener skips the initial event and only handles real auth changes (login/logout/token refresh) after init completes.
- **Role not visible (#98)**: Added `UserChip` component to the navbar — shows the Google avatar (email-initial fallback) and a colour-coded role badge (admin/executive/member/pending) next to the logout button on desktop and mobile.

## Test plan
- [ ] Log in → verify avatar and role badge appear in the navbar
- [ ] Click "Log out" → verify redirect to home and session cleared
- [ ] Log in with an expired/invalid session (or simulate signOut failure) → verify still redirected to home
- [ ] Hard-refresh while logged in → verify navbar links and logout button appear immediately without flashing
- [ ] Log out and log back in → verify member-only links appear after login without a disappear flash
- [ ] Check mobile menu → verify avatar + role badge appear above the logout button

Closes #96
Closes #97
Closes #98