### PR TITLE
feat: show user avatar and role badge in navbar

### DIFF
--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation'
 import { socialLinks } from '@/config/socialLinks'
 import { useAuth } from '@/hooks/useAuth'
 import { signInWithGoogle } from '@/services/authService'
+import UserAvatar from '@/components/common/UserAvatar'
 
 const publicLinks = [
   { label: 'Home', href: '/' },
@@ -188,10 +189,17 @@ export default function Navbar() {
           <div className="w-px h-5 bg-border mx-1" />
 
           {!loading && (user ? (
-            <button onClick={signOut}
-              className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
-              Log out
-            </button>
+            <div className="flex items-center gap-2">
+              <UserAvatar
+                avatarUrl={profile?.avatar_url}
+                name={profile?.name || user.email}
+                role={role}
+              />
+              <button onClick={signOut}
+                className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
+                Log out
+              </button>
+            </div>
           ) : (
             <button onClick={handleLogIn}
               className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
@@ -284,10 +292,20 @@ export default function Navbar() {
 
           {/* Auth */}
           {!loading && (user ? (
-            <button onClick={() => { signOut(); setMobileOpen(false) }}
-              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
-              Log out
-            </button>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2 px-2 py-1">
+                <UserAvatar
+                  avatarUrl={profile?.avatar_url}
+                  name={profile?.name || user.email}
+                  role={role}
+                />
+                <span className="text-sm text-text-secondary truncate">{profile?.name || user.email}</span>
+              </div>
+              <button onClick={() => { signOut(); setMobileOpen(false) }}
+                className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
+                Log out
+              </button>
+            </div>
           ) : (
             <button onClick={() => { setMobileOpen(false); handleLogIn() }}
               className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">

--- a/src/components/common/UserAvatar.js
+++ b/src/components/common/UserAvatar.js
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+
+const ROLE_BADGE = {
+  pending:   { label: 'P', className: 'bg-gray-100 text-gray-500' },
+  member:    { label: 'M', className: 'bg-blue-100 text-blue-600' },
+  executive: { label: 'E', className: 'bg-purple-100 text-purple-600' },
+  admin:     { label: 'A', className: 'bg-red-100 text-red-600' },
+}
+
+export default function UserAvatar({ avatarUrl, name, role }) {
+  const [imgError, setImgError] = useState(false)
+  const badge = ROLE_BADGE[role] ?? null
+  const initial = (name || '?')[0].toUpperCase()
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="h-8 w-8 rounded-full overflow-hidden bg-bg-surface flex items-center justify-center shrink-0 ring-1 ring-border">
+        {avatarUrl && !imgError ? (
+          <img
+            src={avatarUrl}
+            alt={name || 'avatar'}
+            className="h-full w-full object-cover"
+            onError={() => setImgError(true)}
+          />
+        ) : (
+          <span className="text-sm font-medium text-text-secondary select-none">{initial}</span>
+        )}
+      </div>
+      {badge && (
+        <span className={`text-xs font-semibold px-1.5 py-0.5 rounded ${badge.className}`}>
+          {badge.label}
+        </span>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `UserAvatar` component — circular profile photo with initial fallback and a role badge (P/M/E/A) to the right
- Desktop: avatar + badge displayed left of the logout button
- Mobile: avatar + badge + name row above the logout button

## Role badge
| Role | Badge | Color |
|------|-------|-------|
| pending | P | gray |
| member | M | blue |
| executive | E | purple |
| admin | A | red |

## Test plan
- [ ] Logged-in user sees avatar + badge on desktop nav
- [ ] Mobile menu shows avatar + name + badge above logout button
- [ ] Account without a Google profile photo falls back to initials
- [ ] Broken image URL falls back to initials via onError
- [ ] Logged-out state still shows Log In / Join Us buttons correctly

Closes #95