### PR TITLE
fix: auth reliability — logout, navbar flash, and OAuth back-navigation

### DIFF
--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -75,37 +75,6 @@ function IconChevron() {
   )
 }
 
-const ROLE_STYLES = {
-  admin:     'bg-green-100 text-green-700',
-  executive: 'bg-purple-100 text-purple-700',
-  member:    'bg-accent/10 text-accent',
-  pending:   'bg-yellow-100 text-yellow-700',
-}
-
-function UserChip({ user, profile }) {
-  const role = profile?.role
-  const avatarUrl = user?.user_metadata?.avatar_url ?? profile?.avatar_url
-  const initial = (user?.email?.[0] ?? '?').toUpperCase()
-  const roleStyle = ROLE_STYLES[role] ?? 'bg-gray-100 text-gray-500'
-
-  return (
-    <div className="flex items-center gap-1.5">
-      {avatarUrl ? (
-        <img src={avatarUrl} alt="" referrerPolicy="no-referrer" className="w-6 h-6 rounded-full shrink-0" />
-      ) : (
-        <div className="w-6 h-6 rounded-full bg-bg-elevated flex items-center justify-center text-[10px] font-medium text-text-secondary shrink-0">
-          {initial}
-        </div>
-      )}
-      {role && (
-        <span className={`px-1.5 py-0.5 rounded text-[11px] font-medium capitalize ${roleStyle}`}>
-          {role}
-        </span>
-      )}
-    </div>
-  )
-}
-
 function NavLink({ href, label, pathname }) {
   const active = pathname === href
   return (
@@ -219,13 +188,10 @@ export default function Navbar() {
           <div className="w-px h-5 bg-border mx-1" />
 
           {!loading && (user ? (
-            <>
-              <UserChip user={user} profile={profile} />
-              <button onClick={signOut}
-                className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
-                Log out
-              </button>
-            </>
+            <button onClick={signOut}
+              className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
+              Log out
+            </button>
           ) : (
             <button onClick={handleLogIn}
               className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
@@ -318,15 +284,10 @@ export default function Navbar() {
 
           {/* Auth */}
           {!loading && (user ? (
-            <div className="flex flex-col gap-2">
-              <div className="px-2 py-1">
-                <UserChip user={user} profile={profile} />
-              </div>
-              <button onClick={() => { signOut(); setMobileOpen(false) }}
-                className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
-                Log out
-              </button>
-            </div>
+            <button onClick={() => { signOut(); setMobileOpen(false) }}
+              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
+              Log out
+            </button>
           ) : (
             <button onClick={() => { setMobileOpen(false); handleLogIn() }}
               className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { socialLinks } from '@/config/socialLinks'
@@ -137,6 +137,16 @@ export default function Navbar() {
   const { user, profile, loading, signOut } = useAuth()
   const [mobileOpen, setMobileOpen] = useState(false)
   const [loggingIn, setLoggingIn] = useState(false)
+
+  // bfcache restores frozen React state — loggingIn would be stuck at true.
+  // Reset it so the Log In button works again after pressing back from Google.
+  useEffect(() => {
+    function handlePageShow(e) {
+      if (e.persisted) setLoggingIn(false)
+    }
+    window.addEventListener('pageshow', handlePageShow)
+    return () => window.removeEventListener('pageshow', handlePageShow)
+  }, [])
 
   const role = profile?.role ?? null
   const isMember = role === 'member' || role === 'executive' || role === 'admin'

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -187,7 +187,7 @@ export default function Navbar() {
 
           <div className="w-px h-5 bg-border mx-1" />
 
-          {!loading && (user ? (
+          {user ? (
             <button onClick={signOut}
               className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
               Log out
@@ -197,7 +197,7 @@ export default function Navbar() {
               className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
               Log In
             </button>
-          ))}
+          )}
 
           {isAdmin && (
             <Link href="/admin" title="Admin"
@@ -283,7 +283,7 @@ export default function Navbar() {
           <div className="my-2 h-px bg-border" />
 
           {/* Auth */}
-          {!loading && (user ? (
+          {user ? (
             <button onClick={() => { signOut(); setMobileOpen(false) }}
               className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
               Log out
@@ -293,7 +293,7 @@ export default function Navbar() {
               className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
               Log In
             </button>
-          ))}
+          )}
         </div>
       )}
     </nav>

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -136,6 +136,7 @@ export default function Navbar() {
   const pathname = usePathname()
   const { user, profile, loading, signOut } = useAuth()
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [loggingIn, setLoggingIn] = useState(false)
 
   const role = profile?.role ?? null
   const isMember = role === 'member' || role === 'executive' || role === 'admin'
@@ -149,10 +150,12 @@ export default function Navbar() {
   }
 
   async function handleLogIn() {
+    if (loggingIn) return
+    setLoggingIn(true)
     try {
       await signInWithGoogle(`${window.location.origin}/auth/callback`)
     } catch {
-      // OAuth redirect failed
+      setLoggingIn(false)
     }
   }
 
@@ -193,9 +196,9 @@ export default function Navbar() {
               Log out
             </button>
           ) : (
-            <button onClick={handleLogIn}
-              className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
-              Log In
+            <button onClick={handleLogIn} disabled={loggingIn}
+              className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed">
+              {loggingIn ? 'Redirecting…' : 'Log In'}
             </button>
           )}
 
@@ -289,9 +292,9 @@ export default function Navbar() {
               Log out
             </button>
           ) : (
-            <button onClick={() => { setMobileOpen(false); handleLogIn() }}
-              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
-              Log In
+            <button onClick={() => { setMobileOpen(false); handleLogIn() }} disabled={loggingIn}
+              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center disabled:opacity-60 disabled:cursor-not-allowed">
+              {loggingIn ? 'Redirecting…' : 'Log In'}
             </button>
           )}
         </div>

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -168,7 +168,7 @@ export default function Navbar() {
 
         {/* Desktop center links */}
         <div className="absolute left-1/2 -translate-x-1/2 hidden lg:flex items-center gap-5">
-          {!loading && centerLinks.map(renderDesktopLink)}
+          {centerLinks.map(renderDesktopLink)}
         </div>
 
         {/* Desktop right — social + auth */}
@@ -223,7 +223,7 @@ export default function Navbar() {
       {mobileOpen && (
         <div className="lg:hidden border-t border-border bg-white px-6 py-4 flex flex-col gap-1">
 
-          {!loading && centerLinks.map((item) => {
+          {centerLinks.map((item) => {
             if (item.dropdown) {
               return (
                 <div key={item.label} className="py-1">

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -6,7 +6,6 @@ import { usePathname } from 'next/navigation'
 import { socialLinks } from '@/config/socialLinks'
 import { useAuth } from '@/hooks/useAuth'
 import { signInWithGoogle } from '@/services/authService'
-import UserAvatar from '@/components/common/UserAvatar'
 
 const publicLinks = [
   { label: 'Home', href: '/' },
@@ -73,6 +72,37 @@ function IconChevron() {
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="w-3 h-3 mt-0.5 transition-transform duration-200 group-hover:rotate-180">
       <path d="M19 9l-7 7-7-7" />
     </svg>
+  )
+}
+
+const ROLE_STYLES = {
+  admin:     'bg-green-100 text-green-700',
+  executive: 'bg-purple-100 text-purple-700',
+  member:    'bg-accent/10 text-accent',
+  pending:   'bg-yellow-100 text-yellow-700',
+}
+
+function UserChip({ user, profile }) {
+  const role = profile?.role
+  const avatarUrl = user?.user_metadata?.avatar_url ?? profile?.avatar_url
+  const initial = (user?.email?.[0] ?? '?').toUpperCase()
+  const roleStyle = ROLE_STYLES[role] ?? 'bg-gray-100 text-gray-500'
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {avatarUrl ? (
+        <img src={avatarUrl} alt="" referrerPolicy="no-referrer" className="w-6 h-6 rounded-full shrink-0" />
+      ) : (
+        <div className="w-6 h-6 rounded-full bg-bg-elevated flex items-center justify-center text-[10px] font-medium text-text-secondary shrink-0">
+          {initial}
+        </div>
+      )}
+      {role && (
+        <span className={`px-1.5 py-0.5 rounded text-[11px] font-medium capitalize ${roleStyle}`}>
+          {role}
+        </span>
+      )}
+    </div>
   )
 }
 
@@ -189,17 +219,13 @@ export default function Navbar() {
           <div className="w-px h-5 bg-border mx-1" />
 
           {!loading && (user ? (
-            <div className="flex items-center gap-2">
-              <UserAvatar
-                avatarUrl={profile?.avatar_url}
-                name={profile?.name || user.email}
-                role={role}
-              />
+            <>
+              <UserChip user={user} profile={profile} />
               <button onClick={signOut}
                 className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
                 Log out
               </button>
-            </div>
+            </>
           ) : (
             <button onClick={handleLogIn}
               className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
@@ -293,13 +319,8 @@ export default function Navbar() {
           {/* Auth */}
           {!loading && (user ? (
             <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2 px-2 py-1">
-                <UserAvatar
-                  avatarUrl={profile?.avatar_url}
-                  name={profile?.name || user.email}
-                  role={role}
-                />
-                <span className="text-sm text-text-secondary truncate">{profile?.name || user.email}</span>
+              <div className="px-2 py-1">
+                <UserChip user={user} profile={profile} />
               </div>
               <button onClick={() => { signOut(); setMobileOpen(false) }}
                 className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -36,10 +36,17 @@ export function AuthProvider({ children }) {
     init()
 
     // When the browser restores this page from bfcache (back button after
-    // Google OAuth redirect), React state is frozen from before the redirect.
-    // Re-checking the session here ensures the auth buttons reflect reality.
+    // Google OAuth redirect), Supabase's in-memory PKCE verifier state is
+    // stale, which silently blocks any subsequent login attempt.
+    // If an OAuth flow was in progress, force a full reload so Supabase
+    // starts fresh. Otherwise just re-sync the session into React state.
     function handlePageShow(e) {
       if (!e.persisted) return
+      if (sessionStorage.getItem('oauth_pending')) {
+        sessionStorage.removeItem('oauth_pending')
+        window.location.reload()
+        return
+      }
       getSession()
         .then(session => {
           setUser(session?.user ?? null)

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -20,6 +20,9 @@ export function AuthProvider({ children }) {
     let initialized = false
 
     async function init() {
+      // Clear any stale OAuth flag left from a previous abandoned flow
+      // (covers the full-remount case where pageshow doesn't reload).
+      sessionStorage.removeItem('oauth_pending')
       try {
         const session = await getSession()
         setUser(session?.user ?? null)

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -35,6 +35,23 @@ export function AuthProvider({ children }) {
 
     init()
 
+    // When the browser restores this page from bfcache (back button after
+    // Google OAuth redirect), React state is frozen from before the redirect.
+    // Re-checking the session here ensures the auth buttons reflect reality.
+    function handlePageShow(e) {
+      if (!e.persisted) return
+      getSession()
+        .then(session => {
+          setUser(session?.user ?? null)
+          if (!session?.user) setProfile(null)
+        })
+        .catch(() => {
+          setUser(null)
+          setProfile(null)
+        })
+    }
+    window.addEventListener('pageshow', handlePageShow)
+
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (_event, session) => {
         // Skip INITIAL_SESSION — init() already handles it and setting state
@@ -55,7 +72,10 @@ export function AuthProvider({ children }) {
       }
     )
 
-    return () => subscription.unsubscribe()
+    return () => {
+      subscription.unsubscribe()
+      window.removeEventListener('pageshow', handlePageShow)
+    }
   }, [])
 
   async function refreshProfile() {

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -17,6 +17,8 @@ export function AuthProvider({ children }) {
   // intentionally mount-only.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
+    let initialized = false
+
     async function init() {
       try {
         const session = await getSession()
@@ -27,6 +29,7 @@ export function AuthProvider({ children }) {
         }
       } finally {
         setLoading(false)
+        initialized = true
       }
     }
 
@@ -34,17 +37,20 @@ export function AuthProvider({ children }) {
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (_event, session) => {
+        // Skip INITIAL_SESSION — init() already handles it and setting state
+        // here before init() completes causes a profile-null flash (navbar
+        // buttons disappear briefly).
+        if (!initialized) return
         setUser(session?.user ?? null)
         if (session?.user) {
           try {
             const p = await fetchProfile(session.user.id)
             setProfile(p)
-          } finally {
-            setLoading(false)
+          } catch {
+            setProfile(null)
           }
         } else {
           setProfile(null)
-          setLoading(false)
         }
       }
     )
@@ -62,7 +68,12 @@ export function AuthProvider({ children }) {
   }
 
   async function signOut() {
-    await authSignOut()
+    try {
+      await authSignOut()
+    } catch {
+      // Supabase sign-out may throw if the session is already expired;
+      // always clean up client state and redirect regardless.
+    }
     setUser(null)
     setProfile(null)
     sessionStorage.removeItem('join_modal_dismissed')

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,6 +1,10 @@
 import { supabase } from '@/lib/supabase'
 
 export async function signInWithGoogle(redirectTo) {
+  // Flag that an OAuth redirect is about to happen so the pageshow handler
+  // can force a reload if the user presses back (bfcache restoration would
+  // leave Supabase's PKCE verifier in a stale state, blocking a second attempt).
+  sessionStorage.setItem('oauth_pending', '1')
   const options = redirectTo ? { redirectTo } : {}
   const { error } = await supabase.auth.signInWithOAuth({ provider: 'google', options })
   if (error) throw error


### PR DESCRIPTION
## Summary

### #96 — Logout button unresponsive
`signOut()` had no error handling. If Supabase threw (expired session, network error), `setUser(null)` and `router.push('/')` never ran. Wrapped in try/catch so cleanup and redirect always execute.

### #97 — Navbar buttons disappear on page load
`onAuthStateChange` fires a `INITIAL_SESSION` event on mount before `init()` finishes, briefly setting `user` without a `profile`. Added an `initialized` guard so the listener skips that initial event and only handles real auth changes (login/logout) after init completes.

### #96 #97 follow-up — Nav links disappear after Google OAuth back-navigation
`!loading` was gating both the center nav links and the auth button. During any loading period (e.g. remount after back-navigation), everything disappeared. Public nav links don't depend on auth state — removed the loading gate from them entirely. Auth button loading gate also removed; `user` state alone determines which button to show.

### OAuth back-navigation & retry flow
When a user goes to Google, presses back, then tries to log in again, multiple things went wrong:

1. **bfcache freezes React state** — `loggingIn = true` is frozen, so clicking Log In hits the early-return guard and does nothing.
   - **Fix:** `pageshow` handler in Navbar resets `loggingIn = false` on `e.persisted`.

2. **Supabase PKCE verifier is stale in memory** — bfcache restores the Supabase client with its pre-redirect in-memory state, silently blocking a new OAuth flow.
   - **Fix:** `oauth_pending` flag set in sessionStorage before redirect; `pageshow` handler in AuthContext forces a full reload when the flag is present, clearing all stale state.

3. **Flag lingers on full remount** — if the page fully remounts instead of bfcache restore, the `pageshow` reload doesn't fire but the flag stays in sessionStorage.
   - **Fix:** `init()` always clears `oauth_pending` on fresh mount.

4. **Rapid login button clicks** — multiple simultaneous `signInWithOAuth` calls.
   - **Fix:** `loggingIn` state guard + disabled button + "Redirecting…" label while in-flight.

## Test plan
- [ ] Click Log out → verify redirect to home and session cleared
- [ ] Hard-refresh while logged in → verify navbar links appear immediately without flashing
- [ ] Click Log In → press back from Google → click Log In again → verify login works
- [ ] Repeat above multiple times → verify no degradation
- [ ] Rapid-click Log In → verify button disables after first click and shows "Redirecting…"

Closes #96
Closes #97