### PR TITLE
fix: allow executive role to access admin routes (issue #77)

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -15,4 +15,6 @@ const MEMBER_ROUTE_BLOCKED = [ROLES.PENDING]
 
 export const canAccessMemberRoutes = (role) => !!role && !MEMBER_ROUTE_BLOCKED.includes(role)
 
-export const canAccessAdminRoutes = (role) => role === ROLES.ADMIN
+const ADMIN_ROLES = [ROLES.ADMIN, ROLES.EXECUTIVE]
+
+export const canAccessAdminRoutes = (role) => ADMIN_ROLES.includes(role)


### PR DESCRIPTION
## Summary

- Updates `canAccessAdminRoutes` in `src/utils/constants.js` to include `executive` role
- Adds `ADMIN_ROLES` constant following existing `MEMBER_ROUTE_BLOCKED` pattern
- Resolves mismatch between DB RLS policies (executive has write access) and frontend RoleGuard (admin only)

Closes #77

## Changes

`src/utils/constants.js`
```js
// Before
export const canAccessAdminRoutes = (role) => role === ROLES.ADMIN

// After
const ADMIN_ROLES = [ROLES.ADMIN, ROLES.EXECUTIVE]
export const canAccessAdminRoutes = (role) => ADMIN_ROLES.includes(role)
```

## Test plan
- [ ] Executive user can access `/admin` route
- [ ] Admin user can still access `/admin` route
- [ ] Member/pending user is still blocked from `/admin`