### PR TITLE
fix: allow executive role to access admin routes

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,4 +13,4 @@ const MEMBER_ROUTE_BLOCKED = [ROLES.PENDING]
 
 export const canAccessMemberRoutes = (role) => !!role && !MEMBER_ROUTE_BLOCKED.includes(role)
 
-export const canAccessAdminRoutes = (role) => role === ROLES.ADMIN
+export const canAccessAdminRoutes = (role) => [ROLES.ADMIN, ROLES.EXECUTIVE].includes(role)


### PR DESCRIPTION
## Summary
- \`canAccessAdminRoutes\` was restricting \`/admin\` to \`admin\` role only
- DB RLS already grants \`executive\` write access to problems, sessions, and announcements
- This fix aligns the frontend guard with the existing DB policies

## Change
\`\`\`js
// Before
export const canAccessAdminRoutes = (role) => role === ROLES.ADMIN

// After
export const canAccessAdminRoutes = (role) => [ROLES.ADMIN, ROLES.EXECUTIVE].includes(role)
\`\`\`

## Permission split
| Feature | Executive | Admin |
|---------|-----------|-------|
| Announcements CRUD | ✅ | ✅ |
| Problems CRUD | ✅ | ✅ |
| Events CRUD | ✅ | ✅ |
| Badge assignment | ✅ | ✅ |
| Attendance session | ✅ | ✅ |
| Approve member (pending → member) | ✅ | ✅ |
| Reject / delete member | ❌ | ✅ |
| Change member role | ❌ | ✅ |

Closes #77
Resolves Copilot comment on PR #74