### PR TITLE
fix: add Google CDN hostname to next/image config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,10 @@ const nextConfig = {
         hostname: 'fwvsdoxwtzlxidozyiwr.supabase.co',
         pathname: '/storage/v1/object/public/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+      },
     ],
   },
 }


### PR DESCRIPTION
## Summary
Members page avatar images are served from Google OAuth CDN (`lh3.googleusercontent.com`), which was not registered in `next.config.mjs`.

**Error:**
```
Invalid src prop on next/image, hostname "lh3.googleusercontent.com" is not configured
```

**Fix:**
Added `lh3.googleusercontent.com` to `images.remotePatterns` in `next.config.mjs`.

Follows up on #105.