### PR TITLE
chore: add week, due_date, school columns to problems table

### DIFF
--- a/supabase/migrations/20260523212248_add_problems_columns.sql
+++ b/supabase/migrations/20260523212248_add_problems_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.problems
+ADD COLUMN week INTEGER,
+ADD COLUMN due_date TIMESTAMPTZ,
+ADD COLUMN school TEXT;


### PR DESCRIPTION
## Summary
- Added `week` (INTEGER), `due_date` (TIMESTAMPTZ), `school` (TEXT) columns to `problems` table
- These columns are already referenced in the problems page UI but were missing from the DB schema
- Migration applied to remote Supabase

## Checklist
- [x] Tested locally with `supabase db reset`
- [x] Applied to remote with `supabase db push`
- [x] Follows code conventions