### PR TITLE
feat: split profiles name into first_name, last_name, nickname

### DIFF
--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -1,5 +1,4 @@
-import Link from 'next/link'
-import Button from '@/components/ui/Button'
+import JoinButton from '@/components/common/JoinButton'
 
 const senecaMembers = [
   { key: 'seneca_president', name: 'TBD', role: 'TBD' },
@@ -144,13 +143,7 @@ const AboutPage = () => {
             Join our community or meet the minds behind the code.</p>
         </div>
         <div className="flex-[0.5] w-full md:w-auto flex justify-center md:justify-end">
-          <Link href="/join" className="w-full sm:w-auto">
-              <Button
-                className="w-full sm:w-auto justify-center bg-brand-primary hover:bg-brand-hover px-8 py-4 flex items-center gap-2 shadow-xl"
-              >
-                Join Us <span>→</span>
-              </Button>
-            </Link>
+          <JoinButton className="w-full sm:w-auto justify-center bg-brand-primary hover:bg-brand-hover px-8 py-4 flex items-center gap-2 shadow-xl" />
         </div>
       </section>
 

--- a/src/app/join/page.js
+++ b/src/app/join/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation'
-
-export default function JoinPage() {
-  redirect('/')
-}

--- a/src/components/auth/RoleGuard.js
+++ b/src/components/auth/RoleGuard.js
@@ -40,7 +40,7 @@ const RoleGuard = ({ children }) => {
     if (loading) return
 
     if (!user) {
-      router.replace('/join')
+      router.replace('/')
       return
     }
 

--- a/src/components/common/JoinButton.js
+++ b/src/components/common/JoinButton.js
@@ -1,0 +1,15 @@
+'use client'
+
+import { signInWithGoogle } from '@/services/authService'
+import Button from '@/components/ui/Button'
+
+export default function JoinButton({ className }) {
+  return (
+    <Button
+      onClick={() => signInWithGoogle()}
+      className={className}
+    >
+      Join Us <span>→</span>
+    </Button>
+  )
+}

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -243,7 +243,7 @@ export default function JoinModal() {
               type="text"
               value={lastName}
               onChange={e => setLastName(e.target.value)}
-              placeholder="Kim"
+              placeholder="Doe"
               className={`${inputBase} ${inputFocus} ${errors.lastName ? 'border-red-400' : inputNormal}`}
             />
             {errors.lastName && <p className="mt-1 text-xs text-red-500">{errors.lastName}</p>}
@@ -257,7 +257,7 @@ export default function JoinModal() {
             type="text"
             value={nickname}
             onChange={e => setNickname(e.target.value)}
-            placeholder="e.g. JohnK"
+            placeholder="e.g. JohnD"
             className={`${inputBase} ${inputFocus} ${inputNormal}`}
           />
         </div>

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -103,8 +103,10 @@ export default function JoinModal() {
   useEffect(() => {
     if (isOpen && user) {
       const meta = user.user_metadata
-      setFirstName(meta?.given_name ?? '')
-      setLastName(meta?.family_name ?? '')
+      const fullName = meta?.full_name ?? meta?.name ?? ''
+      const parts = fullName.trim().split(' ')
+      setFirstName(meta?.given_name ?? parts[0] ?? '')
+      setLastName(meta?.family_name ?? parts.slice(1).join(' ') ?? '')
     }
   }, [isOpen, user])
 

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -68,7 +68,9 @@ export default function JoinModal() {
   const { isOpen, openModal, closeModal } = useJoinModal()
   const { user, profile, loading, refreshProfile } = useAuth()
   const router = useRouter()
-  const [name, setName] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [nickname, setNickname] = useState('')
   const [school, setSchool] = useState('')
   const [cohort, setCohort] = useState('')
   const [phone, setPhone] = useState('')
@@ -81,7 +83,7 @@ export default function JoinModal() {
   const cohorts = generateCohorts()
   const overlayRef = useRef(null)
 
-  const needsCompletion = !loading && !!user && !!profile && !profile.name
+  const needsCompletion = !loading && !!user && !!profile && !profile.first_name
 
   useEffect(() => {
     if (needsCompletion && !sessionStorage.getItem('join_modal_dismissed')) {
@@ -101,13 +103,16 @@ export default function JoinModal() {
   useEffect(() => {
     if (isOpen && user) {
       const meta = user.user_metadata
-      setName(meta?.full_name ?? meta?.name ?? '')
+      setFirstName(meta?.given_name ?? '')
+      setLastName(meta?.family_name ?? '')
     }
   }, [isOpen, user])
 
   useEffect(() => {
     if (!isOpen) {
-      setName('')
+      setFirstName('')
+      setLastName('')
+      setNickname('')
       setSchool('')
       setCohort('')
       setPhone('')
@@ -127,7 +132,8 @@ export default function JoinModal() {
 
   function validate() {
     const next = {}
-    if (!name.trim()) next.name = 'Please enter your name'
+    if (!firstName.trim()) next.firstName = 'Please enter your first name'
+    if (!lastName.trim()) next.lastName = 'Please enter your last name'
     if (!school) next.school = 'Please select a school'
     if (!cohort) next.cohort = 'Please select a cohort'
     if (!/^\(\d{3}\) \d{3}-\d{4}$/.test(phone)) next.phone = 'Enter a valid phone number: (XXX) XXX-XXXX'
@@ -143,7 +149,9 @@ export default function JoinModal() {
     try {
       await createProfile({
         id: user.id,
-        name: name.trim(),
+        first_name: firstName.trim(),
+        last_name: lastName.trim(),
+        nickname: nickname.trim(),
         email: user.email,
         avatarUrl: user.user_metadata?.avatar_url ?? '',
         school,
@@ -214,17 +222,42 @@ export default function JoinModal() {
           </div>
         )}
 
-        {/* Name */}
+        {/* First Name / Last Name */}
+        <div className="flex gap-3 mb-4">
+          <div className="flex-1">
+            <label className="block text-sm font-medium text-text-primary mb-1.5">First Name <span className="text-red-500">*</span></label>
+            <input
+              type="text"
+              value={firstName}
+              onChange={e => setFirstName(e.target.value)}
+              placeholder="John"
+              className={`${inputBase} ${inputFocus} ${errors.firstName ? 'border-red-400' : inputNormal}`}
+            />
+            {errors.firstName && <p className="mt-1 text-xs text-red-500">{errors.firstName}</p>}
+          </div>
+          <div className="flex-1">
+            <label className="block text-sm font-medium text-text-primary mb-1.5">Last Name <span className="text-red-500">*</span></label>
+            <input
+              type="text"
+              value={lastName}
+              onChange={e => setLastName(e.target.value)}
+              placeholder="Kim"
+              className={`${inputBase} ${inputFocus} ${errors.lastName ? 'border-red-400' : inputNormal}`}
+            />
+            {errors.lastName && <p className="mt-1 text-xs text-red-500">{errors.lastName}</p>}
+          </div>
+        </div>
+
+        {/* Nickname */}
         <div className="mb-4">
-          <label className="block text-sm font-medium text-text-primary mb-1.5">Name <span className="text-red-500">*</span></label>
+          <label className="block text-sm font-medium text-text-primary mb-1.5">Nickname <span className="text-text-hint font-normal">(optional)</span></label>
           <input
             type="text"
-            value={name}
-            onChange={e => setName(e.target.value)}
-            placeholder="Your full name"
-            className={`${inputBase} ${inputFocus} ${errors.name ? 'border-red-400' : inputNormal}`}
+            value={nickname}
+            onChange={e => setNickname(e.target.value)}
+            placeholder="e.g. JohnK"
+            className={`${inputBase} ${inputFocus} ${inputNormal}`}
           />
-          {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
         </div>
 
         {/* School */}

--- a/src/components/common/UserAvatar.js
+++ b/src/components/common/UserAvatar.js
@@ -7,10 +7,10 @@ const ROLE_BADGE = {
   admin:     { label: 'A', className: 'bg-red-100 text-red-600' },
 }
 
-export default function UserAvatar({ avatarUrl, name, role }) {
+export default function UserAvatar({ avatarUrl, firstName, role }) {
   const [imgError, setImgError] = useState(false)
   const badge = ROLE_BADGE[role] ?? null
-  const initial = (name || '?')[0].toUpperCase()
+  const initial = (firstName || '?')[0].toUpperCase()
 
   return (
     <div className="flex items-center gap-1.5">
@@ -18,7 +18,7 @@ export default function UserAvatar({ avatarUrl, name, role }) {
         {avatarUrl && !imgError ? (
           <img
             src={avatarUrl}
-            alt={name || 'avatar'}
+            alt={firstName || 'avatar'}
             className="h-full w-full object-cover"
             onError={() => setImgError(true)}
           />

--- a/src/components/members/MemberCard.js
+++ b/src/components/members/MemberCard.js
@@ -1,19 +1,12 @@
 import Image from 'next/image'
 import Link from 'next/link'
 
-function getInitials(name) {
-  return name
-    .split(' ')
-    .map((part) => part[0])
-    .slice(0, 2)
-    .join('')
-    .toUpperCase()
-}
-
 export default function MemberCard({ member }) {
   const {
     id,
-    name,
+    firstName,
+    lastName,
+    nickname,
     avatarUrl,
     school,
     occupation,
@@ -22,6 +15,10 @@ export default function MemberCard({ member }) {
     linkedinUrl,
     githubUrl,
   } = member
+
+  const fullName = `${firstName ?? ''} ${lastName ?? ''}`.trim()
+  const displayName = nickname ? `${fullName} (${nickname})` : fullName
+  const initial = (firstName?.[0] ?? '?').toUpperCase()
 
   const hasSocials = linkedinUrl || githubUrl
 
@@ -32,14 +29,14 @@ export default function MemberCard({ member }) {
         {avatarUrl ? (
           <Image
             src={avatarUrl}
-            alt={name}
+            alt={displayName}
             width={64}
             height={64}
             className="rounded-full object-cover group-hover:ring-2 group-hover:ring-accent"
           />
         ) : (
           <div className="w-16 h-16 rounded-full bg-gray-200 flex items-center justify-center text-gray-600 font-medium text-sm group-hover:ring-2 group-hover:ring-accent">
-            {getInitials(name)}
+            {initial}
           </div>
         )}
       </Link>
@@ -49,7 +46,7 @@ export default function MemberCard({ member }) {
         href={`/members/${id}`}
         className="mt-2.5 font-inter font-medium text-sm text-text-primary hover:underline"
       >
-        {name}
+        {displayName}
       </Link>
 
       {/* School */}
@@ -86,7 +83,7 @@ export default function MemberCard({ member }) {
               href={linkedinUrl}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label={`${name} on LinkedIn`}
+              aria-label={`${displayName} on LinkedIn`}
               className="text-text-secondary hover:text-link"
             >
               <svg
@@ -105,7 +102,7 @@ export default function MemberCard({ member }) {
               href={githubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label={`${name} on GitHub`}
+              aria-label={`${displayName} on GitHub`}
               className="text-text-secondary hover:text-text-primary"
             >
               <svg

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -32,11 +32,13 @@ export async function fetchProfile(userId) {
   return data ?? null
 }
 
-export async function createProfile({ id, name, email, avatarUrl, school, cohort, phone, status, occupation, linkedin, github }) {
+export async function createProfile({ id, first_name, last_name, nickname, email, avatarUrl, school, cohort, phone, status, occupation, linkedin, github }) {
   const { data, error } = await supabase
     .from('profiles')
     .update({
-      name,
+      first_name,
+      last_name,
+      nickname: nickname || null,
       email,
       avatar_url: avatarUrl,
       school,

--- a/src/services/membersService.js
+++ b/src/services/membersService.js
@@ -12,15 +12,17 @@ import { supabase } from '@/lib/supabase'
 export async function fetchMembers() {
   const { data, error } = await supabase
     .from('profiles')
-    .select('id, name, avatar_url, school, occupation, status, role, linkedin, github, cohort')
+    .select('id, first_name, last_name, nickname, avatar_url, school, occupation, status, role, linkedin, github, cohort')
     .neq('role', 'pending')
-    .order('name', { ascending: true })
+    .order('first_name', { ascending: true })
 
   if (error) throw error
 
   return (data ?? []).map((row) => ({
     id: row.id,
-    name: row.name,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    nickname: row.nickname,
     avatarUrl: row.avatar_url,
     school: row.school,
     occupation: row.occupation,

--- a/supabase/migrations/20260523220342_profiles_name_split.sql
+++ b/supabase/migrations/20260523220342_profiles_name_split.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.profiles
+ADD COLUMN first_name TEXT,
+ADD COLUMN last_name TEXT,
+ADD COLUMN nickname TEXT;
+
+UPDATE public.profiles SET first_name = name WHERE name IS NOT NULL;
+
+ALTER TABLE public.profiles DROP COLUMN name;


### PR DESCRIPTION
## Summary
- Removed `name` column from `profiles` table, replaced with `first_name`, `last_name`, `nickname`
- Existing `name` data migrated to `first_name` automatically
- JoinModal now pre-fills first/last name from Google OAuth (`given_name` / `family_name`)
- Nickname field added to JoinModal (optional)
- Members page displays `first_name last_name`, with `(nickname)` appended if set
- UserAvatar initial now uses `first_name`

## DB Changes
Migration `20260523220342_profiles_name_split.sql` applied to remote Supabase.

## Checklist
- [x] Tested locally with `supabase db reset`
- [x] Applied to remote with `supabase db push`
- [x] No console.log left
- [x] Follows code conventions