### PR TITLE
fix: replace router.push with window.location.href in signOut

### DIFF
--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,7 +1,6 @@
 'use client'
 
 import { createContext, useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import { getSession, fetchProfile, signOut as authSignOut } from '@/services/authService'
 
@@ -11,7 +10,6 @@ export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
   const [profile, setProfile] = useState(null)
   const [loading, setLoading] = useState(true)
-  const router = useRouter()
 
   // getSession, fetchProfile, supabase are stable module-level references;
   // intentionally mount-only.
@@ -107,7 +105,7 @@ export function AuthProvider({ children }) {
     setUser(null)
     setProfile(null)
     sessionStorage.removeItem('join_modal_dismissed')
-    router.push('/')
+    window.location.href = '/'
   }
 
   return (


### PR DESCRIPTION
## Problem
`signOut()` was using `router.push('/')` (client-side navigation), which does **not** unmount `AuthProvider`. This left Supabase's internal token refresh timer alive, and in some timing windows `onAuthStateChange` could restore a new session immediately after sign-out.

## Fix
Replace `router.push('/')` with `window.location.href = '/'` to force a full page reload, which fully reinitializes the Supabase client and clears all in-memory state.

Also removes the now-unused `useRouter` import and `const router` declaration.

## Root cause connection
This is also linked to the JoinModal Submit doing nothing — session expiry mid-form → `onAuthStateChange` → `user = null` → `handleSubmit` exits silently.