### PR TITLE
fix: show UserChip in mobile top bar next to hamburger

### DIFF
--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -338,13 +338,10 @@ export default function Navbar() {
 
           {/* Auth */}
           {user ? (
-            <div className="flex items-center gap-2">
-              <UserChip user={user} profile={profile} />
-              <button onClick={() => { signOut(); setMobileOpen(false) }}
-                className="flex-1 px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
-                Log out
-              </button>
-            </div>
+            <button onClick={() => { signOut(); setMobileOpen(false) }}
+              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
+              Log out
+            </button>
           ) : (
             <button onClick={() => { setMobileOpen(false); handleLogIn() }} disabled={loggingIn}
               className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center disabled:opacity-60 disabled:cursor-not-allowed">

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -256,18 +256,21 @@ export default function Navbar() {
           )}
         </div>
 
-        {/* Mobile — hamburger */}
-        <button
-          className="ml-auto lg:hidden p-2 text-text-secondary hover:text-text-primary transition-colors"
-          onClick={() => setMobileOpen((o) => !o)}
-          aria-label="Toggle menu"
-        >
+        {/* Mobile — avatar + hamburger */}
+        <div className="ml-auto lg:hidden flex items-center gap-2">
+          {user && <UserChip user={user} profile={profile} />}
+          <button
+            className="p-2 text-text-secondary hover:text-text-primary transition-colors"
+            onClick={() => setMobileOpen((o) => !o)}
+            aria-label="Toggle menu"
+          >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             {mobileOpen
               ? <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
               : <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />}
           </svg>
-        </button>
+          </button>
+        </div>
       </div>
 
       {/* Mobile menu */}


### PR DESCRIPTION
## Problem
On mobile, the avatar/role badge was only visible inside the hamburger menu drawer — not in the top bar itself.

## Fix
Wrap the hamburger button in a flex container with `ml-auto`, and place `UserChip` to its left when the user is logged in.

**Layout (mobile top bar):**
`[Logo]  ···  [Avatar] [Role badge] [☰]`