### PR TITLE
fix: change GitHub/LinkedIn inputs to username-only with prefix label

### DIFF
--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -162,8 +162,8 @@ export default function JoinModal() {
         phone,
         status,
         occupation,
-        linkedin,
-        github,
+        linkedin: linkedin ? `https://linkedin.com/in/${linkedin}` : null,
+        github: github ? `https://github.com/${github}` : null,
       })
 
       sessionStorage.removeItem('join_modal_dismissed')
@@ -334,25 +334,35 @@ export default function JoinModal() {
         {/* LinkedIn */}
         <div className="mb-4">
           <label className="block text-sm font-medium text-text-primary mb-1.5">LinkedIn <span className="text-text-hint font-normal">(optional)</span></label>
-          <input
-            type="text"
-            value={linkedin}
-            onChange={e => setLinkedin(e.target.value)}
-            placeholder="https://linkedin.com/in/..."
-            className={`${inputBase} ${inputFocus} ${inputNormal}`}
-          />
+          <div className="flex items-center">
+            <span className={`px-3 py-2 text-sm font-inter text-text-hint bg-bg-elevated border border-border-strong border-r-0 rounded-l-md whitespace-nowrap`}>
+              linkedin.com/in/
+            </span>
+            <input
+              type="text"
+              value={linkedin}
+              onChange={e => setLinkedin(e.target.value.trim())}
+              placeholder="username"
+              className={`${inputBase} ${inputFocus} ${inputNormal} rounded-l-none`}
+            />
+          </div>
         </div>
 
         {/* GitHub */}
         <div className="mb-6">
           <label className="block text-sm font-medium text-text-primary mb-1.5">GitHub <span className="text-text-hint font-normal">(optional)</span></label>
-          <input
-            type="text"
-            value={github}
-            onChange={e => setGithub(e.target.value)}
-            placeholder="https://github.com/..."
-            className={`${inputBase} ${inputFocus} ${inputNormal}`}
-          />
+          <div className="flex items-center">
+            <span className={`px-3 py-2 text-sm font-inter text-text-hint bg-bg-elevated border border-border-strong border-r-0 rounded-l-md whitespace-nowrap`}>
+              github.com/
+            </span>
+            <input
+              type="text"
+              value={github}
+              onChange={e => setGithub(e.target.value.trim())}
+              placeholder="username"
+              className={`${inputBase} ${inputFocus} ${inputNormal} rounded-l-none`}
+            />
+          </div>
         </div>
 
         {/* Submit */}

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -162,7 +162,7 @@ export default function JoinModal() {
         phone,
         status,
         occupation,
-        linkedin: linkedin ? `https://linkedin.com/in/${linkedin}` : null,
+        linkedin: linkedin ? `https://www.linkedin.com/in/${linkedin}` : null,
         github: github ? `https://github.com/${github}` : null,
       })
 
@@ -334,16 +334,16 @@ export default function JoinModal() {
         {/* LinkedIn */}
         <div className="mb-4">
           <label className="block text-sm font-medium text-text-primary mb-1.5">LinkedIn <span className="text-text-hint font-normal">(optional)</span></label>
-          <div className="flex items-center">
-            <span className={`px-3 py-2 text-sm font-inter text-text-hint bg-bg-elevated border border-border-strong border-r-0 rounded-l-md whitespace-nowrap`}>
-              linkedin.com/in/
+          <div className={`flex items-center rounded-md border bg-bg-input transition-colors ${inputNormal} focus-within:border-accent focus-within:ring-1 focus-within:ring-accent/20`}>
+            <span className="pl-3 py-2 text-sm font-inter text-text-primary whitespace-nowrap select-none pointer-events-none shrink-0">
+              https://www.linkedin.com/in/
             </span>
             <input
               type="text"
               value={linkedin}
               onChange={e => setLinkedin(e.target.value.trim())}
               placeholder="username"
-              className={`${inputBase} ${inputFocus} ${inputNormal} rounded-l-none`}
+              className="flex-1 min-w-0 py-2 pr-3 bg-transparent outline-none text-sm font-inter text-text-primary placeholder:text-text-hint"
             />
           </div>
         </div>
@@ -351,16 +351,16 @@ export default function JoinModal() {
         {/* GitHub */}
         <div className="mb-6">
           <label className="block text-sm font-medium text-text-primary mb-1.5">GitHub <span className="text-text-hint font-normal">(optional)</span></label>
-          <div className="flex items-center">
-            <span className={`px-3 py-2 text-sm font-inter text-text-hint bg-bg-elevated border border-border-strong border-r-0 rounded-l-md whitespace-nowrap`}>
-              github.com/
+          <div className={`flex items-center rounded-md border bg-bg-input transition-colors ${inputNormal} focus-within:border-accent focus-within:ring-1 focus-within:ring-accent/20`}>
+            <span className="pl-3 py-2 text-sm font-inter text-text-primary whitespace-nowrap select-none pointer-events-none shrink-0">
+              https://github.com/
             </span>
             <input
               type="text"
               value={github}
               onChange={e => setGithub(e.target.value.trim())}
               placeholder="username"
-              className={`${inputBase} ${inputFocus} ${inputNormal} rounded-l-none`}
+              className="flex-1 min-w-0 py-2 pr-3 bg-transparent outline-none text-sm font-inter text-text-primary placeholder:text-text-hint"
             />
           </div>
         </div>

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -46,8 +46,8 @@ export async function createProfile({ id, first_name, last_name, nickname, email
       phone,
       status,
       occupation,
-      linkedin,
-      github,
+      linkedin: linkedin || null,
+      github: github || null,
     })
     .eq('id', id)
     .select()


### PR DESCRIPTION
## Summary
- Replace free-text URL inputs for GitHub and LinkedIn with a **prefix label + username-only** pattern
  - GitHub: `github.com/` prefix, user types username only
  - LinkedIn: `linkedin.com/in/` prefix, user types username only
- On submit, full URL is assembled before sending to Supabase (e.g. `https://github.com/paulkim`)
- Empty username stores `null` in DB instead of empty string
- Added `|| null` normalization in `authService.createProfile` as a safety layer

## Root Cause
Pasting a full URL from the browser address bar caused the Supabase update to fail. Switching to username-only input structurally prevents invalid URL values from reaching the DB.

## Related Issue
N/A

## Screenshots (if UI changes)
| Before | After |
|--------|-------|
| Full URL text input (placeholder: `https://github.com/...`) | Prefix label `github.com/` + username input |

## Checklist
- [x] Tested locally
- [x] No console.log left
- [x] Follows code conventions
- [x] Build passes with no errors