### PR TITLE
fix: cohort display and filter on members page, add company to card

### DIFF
--- a/src/app/members/page.js
+++ b/src/app/members/page.js
@@ -1,8 +1,9 @@
 'use client'
 import RoleGuard from '@/components/auth/RoleGuard'
 import MemberCard from '@/components/members/MemberCard'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { fetchMembers } from '@/services/membersService'
+import { cohortLabel } from '@/utils/cohort'
 
 
 export default function MembersPage() {
@@ -29,6 +30,11 @@ export default function MembersPage() {
     load()
     return () => { cancelled = true }
   }, [])
+
+  const cohortOptions = useMemo(() => {
+    const nums = [...new Set(members.map(m => m.cohort).filter(Boolean))]
+    return nums.sort((a, b) => Number(a) - Number(b))
+  }, [members])
 
   const filteredMembers = members.filter((m) => {
     if (cohort && m.cohort !== cohort) return false
@@ -63,11 +69,9 @@ export default function MembersPage() {
             <select className="border border-border-strong rounded-md px-3 py-2 text-sm text-text-primary bg-bg-base focus:outline-none focus:ring-2 focus:ring-border"
             value={cohort} onChange={(e) => setCohort(e.target.value)}>
               <option value="">All Cohorts</option>
-              <option value="Fall 2024">1st Cohort</option>
-              <option value="Winter 2025">2nd Cohort</option>
-              <option value="Fall 2025">3rd Cohort</option>
-              <option value="Winter 2026">4th Cohort</option>
-              <option value="Summer 2026">5th Cohort</option>
+              {cohortOptions.map(n => (
+                <option key={n} value={n}>{cohortLabel(n)}</option>
+              ))}
             </select>
 
             <select className="border border-border-strong rounded-md px-3 py-2 text-sm text-text-primary bg-bg-base focus:outline-none focus:ring-2 focus:ring-border"

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -6,22 +6,13 @@ import { useJoinModal } from '@/contexts/JoinModalContext'
 import { useAuth } from '@/hooks/useAuth'
 import { createProfile } from '@/services/authService'
 import Button from '@/components/ui/Button'
+import { cohortLabel } from '@/utils/cohort'
 
 const SCHOOLS = ['Seneca College', 'York University']
 
 const FIRST_COHORT = { season: 'Fall', year: 2024 }
 const SKIPPED_TERMS = new Set(['Summer 2025'])
 const SEASON_ORDER = ['Winter', 'Summer', 'Fall']
-
-function ordinal(n) {
-  if (n % 100 >= 11 && n % 100 <= 13) return `${n}th`
-  switch (n % 10) {
-    case 1: return `${n}st`
-    case 2: return `${n}nd`
-    case 3: return `${n}rd`
-    default: return `${n}th`
-  }
-}
 
 function getCurrentTerm() {
   const month = new Date().getMonth() + 1
@@ -44,7 +35,7 @@ function generateCohorts() {
       const num = cohorts.length + 1
       cohorts.push({
         value: String(num),
-        label: `${ordinal(num)} Cohort (Joined ${term}${isCurrent ? ' ← now' : ''})`,
+        label: `${cohortLabel(num)} (Joined ${term}${isCurrent ? ' ← now' : ''})`,
       })
     }
 

--- a/src/components/members/MemberCard.js
+++ b/src/components/members/MemberCard.js
@@ -57,7 +57,7 @@ export default function MemberCard({ member }) {
 
       {/* Cohort */}
       {cohort && (
-        <p className="mt-0.5 font-inter text-xs text-text-hint">{cohortLabel(cohort)}</p>
+        <p className="mt-0.5 font-inter text-xs text-text-secondary">{cohortLabel(cohort)}</p>
       )}
 
       {/* Company */}

--- a/src/components/members/MemberCard.js
+++ b/src/components/members/MemberCard.js
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import { cohortLabel } from '@/utils/cohort'
 
 export default function MemberCard({ member }) {
   const {
@@ -9,6 +10,8 @@ export default function MemberCard({ member }) {
     nickname,
     avatarUrl,
     school,
+    cohort,
+    company,
     occupation,
     status,
     role,
@@ -52,7 +55,17 @@ export default function MemberCard({ member }) {
       {/* School */}
       <p className="mt-1 font-inter text-xs text-text-secondary">{school}</p>
 
-      {/* Work — only if set */}
+      {/* Cohort */}
+      {cohort && (
+        <p className="mt-0.5 font-inter text-xs text-text-hint">{cohortLabel(cohort)}</p>
+      )}
+
+      {/* Company */}
+      {company && (
+        <p className="mt-0.5 font-inter text-xs text-text-secondary">{company}</p>
+      )}
+
+      {/* Occupation */}
       {occupation && (
         <p className="mt-0.5 font-inter text-xs text-text-secondary">{occupation}</p>
       )}

--- a/src/services/membersService.js
+++ b/src/services/membersService.js
@@ -12,7 +12,7 @@ import { supabase } from '@/lib/supabase'
 export async function fetchMembers() {
   const { data, error } = await supabase
     .from('profiles')
-    .select('id, first_name, last_name, nickname, avatar_url, school, occupation, status, role, linkedin, github, cohort')
+    .select('id, first_name, last_name, nickname, avatar_url, school, company, occupation, status, role, linkedin, github, cohort')
     .neq('role', 'pending')
     .order('first_name', { ascending: true })
 
@@ -25,6 +25,7 @@ export async function fetchMembers() {
     nickname: row.nickname,
     avatarUrl: row.avatar_url,
     school: row.school,
+    company: row.company,
     occupation: row.occupation,
     status: row.status,
     role: row.role,

--- a/src/utils/cohort.js
+++ b/src/utils/cohort.js
@@ -1,0 +1,17 @@
+/**
+ * Returns the ordinal label for a cohort number stored in the DB.
+ * e.g. cohortLabel("1") → "1st Cohort"
+ *      cohortLabel("3") → "3rd Cohort"
+ *      cohortLabel("4") → "4th Cohort"
+ */
+export function cohortLabel(n) {
+  const num = Number(n)
+  if (!num) return ''
+  if (num % 100 >= 11 && num % 100 <= 13) return `${num}th Cohort`
+  switch (num % 10) {
+    case 1: return `${num}st Cohort`
+    case 2: return `${num}nd Cohort`
+    case 3: return `${num}rd Cohort`
+    default: return `${num}th Cohort`
+  }
+}


### PR DESCRIPTION
## Summary
- **Extract** `ordinal()` from `JoinModal.js` to `src/utils/cohort.js` as shared `cohortLabel()`
  - `cohortLabel("1")` → `"1st Cohort"`, `"4"` → `"4th Cohort"`
- **JoinModal**: remove local `ordinal()`, import `cohortLabel` from utils (no behavior change)
- **membersService**: add `company` to Supabase select and camelCase mapping
- **members/page.js**: fix broken cohort filter
  - Was: hardcoded `value="Fall 2024"` etc. — never matched DB values (`"1"`, `"2"`)
  - Now: options derived dynamically from member data using `cohortLabel()`
- **MemberCard**: display `cohort`, `company`, `occupation` below school in that order

## Card display order after this change
```
Name (Nickname)
School
1st Cohort      
Company         ← new
Occupation
[badges]
[socials]
```

## Checklist
- [x] Tested locally
- [x] No console.log left
- [x] Follows code conventions
- [x] Build passes with no errors