### PR TITLE
fix: contact API error handling and AuthContext async convention

### DIFF
--- a/src/app/api/contact/route.js
+++ b/src/app/api/contact/route.js
@@ -17,19 +17,23 @@ export async function POST(request) {
     },
   })
 
-  await transporter.sendMail({
-    from: `"${name} via codeXperts" <${process.env.CONTACT_EMAIL_USER}>`,
-    to: 'codeXperts2024@gmail.com',
-    replyTo: email,
-    subject: `Contact Form: ${name} (${school})`,
-    text: `From: ${name} <${email}>\nSchool: ${school}\n\n${message}`,
-    html: `
+  try {
+    await transporter.sendMail({
+      from: `"${name} via codeXperts" <${process.env.CONTACT_EMAIL_USER}>`,
+      to: 'codeXperts2024@gmail.com',
+      replyTo: email,
+      subject: `Contact Form: ${name} (${school})`,
+      text: `From: ${name} <${email}>\nSchool: ${school}\n\n${message}`,
+      html: `
       <p><strong>From:</strong> ${name} &lt;${email}&gt;</p>
       <p><strong>School:</strong> ${school}</p>
       <hr />
       <p>${message.replace(/\n/g, '<br />')}</p>
     `,
-  })
+    })
+  } catch {
+    return Response.json({ error: 'Failed to send message. Please try again later.' }, { status: 500 })
+  }
 
   return Response.json({ ok: true })
 }

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -48,15 +48,16 @@ export function AuthProvider({ children }) {
         window.location.reload()
         return
       }
-      getSession()
-        .then(session => {
+      ;(async () => {
+        try {
+          const session = await getSession()
           setUser(session?.user ?? null)
           if (!session?.user) setProfile(null)
-        })
-        .catch(() => {
+        } catch {
           setUser(null)
           setProfile(null)
-        })
+        }
+      })()
     }
     window.addEventListener('pageshow', handlePageShow)
 


### PR DESCRIPTION
## Summary
- Add try-catch around `sendMail` in contact API — previously threw unhandled 500 if SMTP auth failed or env vars were missing
- Replace `.then().catch()` chain in `AuthContext` bfcache handler with async IIFE — brings it in line with the project async/await convention

## Checklist
- [x] Tested locally (build passes)
- [x] No console.log left
- [x] Follows code conventions