### PR TITLE
fix: sanitize contact form inputs and correct status filter value

### DIFF
--- a/src/app/api/contact/route.js
+++ b/src/app/api/contact/route.js
@@ -1,11 +1,29 @@
 import nodemailer from 'nodemailer'
 
+// Escape HTML entities to prevent HTML injection in email body
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+// Strip CR/LF to prevent SMTP header injection
+function sanitizeHeader(str) {
+  return String(str).replace(/[\r\n]/g, ' ').trim()
+}
+
 export async function POST(request) {
   const { email, name, school, message } = await request.json()
 
   if (!email || !name || !school || !message) {
     return Response.json({ error: 'All fields are required.' }, { status: 400 })
   }
+
+  const safeName = sanitizeHeader(name)
+  const safeSchool = sanitizeHeader(school)
+  const safeMessage = escapeHtml(message)
 
   // Gmail App Password required — not your account password
   // Generate at: myaccount.google.com/apppasswords
@@ -19,16 +37,16 @@ export async function POST(request) {
 
   try {
     await transporter.sendMail({
-      from: `"${name} via codeXperts" <${process.env.CONTACT_EMAIL_USER}>`,
+      from: `"${safeName} via codeXperts" <${process.env.CONTACT_EMAIL_USER}>`,
       to: 'codeXperts2024@gmail.com',
       replyTo: email,
-      subject: `Contact Form: ${name} (${school})`,
-      text: `From: ${name} <${email}>\nSchool: ${school}\n\n${message}`,
+      subject: `Contact Form: ${safeName} (${safeSchool})`,
+      text: `From: ${safeName} <${email}>\nSchool: ${safeSchool}\n\n${message}`,
       html: `
-      <p><strong>From:</strong> ${name} &lt;${email}&gt;</p>
-      <p><strong>School:</strong> ${school}</p>
+      <p><strong>From:</strong> ${escapeHtml(name)} &lt;${escapeHtml(email)}&gt;</p>
+      <p><strong>School:</strong> ${escapeHtml(school)}</p>
       <hr />
-      <p>${message.replace(/\n/g, '<br />')}</p>
+      <p>${safeMessage.replace(/\n/g, '<br />')}</p>
     `,
     })
   } catch {

--- a/src/app/members/page.js
+++ b/src/app/members/page.js
@@ -85,7 +85,7 @@ export default function MembersPage() {
             value={status} onChange={(e) => setStatus(e.target.value)}>
               <option value="">All Status</option>
               <option value="student">Student</option>
-              <option value="graduate">Graduate</option>
+              <option value="graduated">Graduate</option>
             </select>
 
             <select className="border border-border-strong rounded-md px-3 py-2 text-sm text-text-primary bg-bg-base focus:outline-none focus:ring-2 focus:ring-border"


### PR DESCRIPTION
## Summary

Fixes 3 issues flagged in PR #122 Copilot review.

### Changes

**Contact API — HTML & Header Injection**
- Added `escapeHtml()` to escape `&`, `<`, `>`, `"` in email body fields (`name`, `school`, `message`)
- Added `sanitizeHeader()` to strip CR/LF from `From`/`Subject` headers to prevent SMTP header injection

**Members Page — Status Filter**
- Fixed status filter option value: `'graduate'` → `'graduated'` to match DB stored values (Graduate filter was never matching)

## Checklist
- [x] No `console.log`
- [x] No `var`
- [x] No `.then().catch()`