### PR TITLE
fix: move adminApproval to server-side API route to bypass RLS

### DIFF
--- a/src/app/api/admin/approve/route.js
+++ b/src/app/api/admin/approve/route.js
@@ -1,0 +1,58 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Service role client — bypasses RLS. Server-side only.
+function getServiceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  )
+}
+
+export async function POST(request) {
+  const authHeader = request.headers.get('authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const token = authHeader.slice(7)
+  const serviceClient = getServiceClient()
+
+  // Verify the caller's JWT and get their profile
+  const { data: { user }, error: authError } = await serviceClient.auth.getUser(token)
+  if (authError || !user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: callerProfile, error: profileError } = await serviceClient
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (profileError || !callerProfile) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (callerProfile.role !== 'admin' && callerProfile.role !== 'executive') {
+    return Response.json({ error: 'Forbidden: admin or executive role required' }, { status: 403 })
+  }
+
+  const { userId } = await request.json()
+  if (!userId) {
+    return Response.json({ error: 'userId is required' }, { status: 400 })
+  }
+
+  // Update the target user's role using service role (bypasses RLS)
+  const { data, error } = await serviceClient
+    .from('profiles')
+    .update({ role: 'member' })
+    .eq('id', userId)
+    .select()
+    .single()
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 })
+  }
+
+  return Response.json({ ok: true, profile: data })
+}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -71,24 +71,19 @@ export async function updateProfile(userId, fields) {
 }
 
 export async function adminApproval(userID) {
-  const session = await getSession();
+  const session = await getSession()
+  if (!session) throw new Error('Unauthorized: No active session found.')
 
-  if (!session) {
-    throw new Error('Unauthorized: No active session found.');
-  }
+  const res = await fetch('/api/admin/approve', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify({ userId: userID }),
+  })
 
-  const profile = await fetchProfile(session.user.id);
-  if (profile?.role !== 'admin') {
-    throw new Error('Unauthorized: Only admins can approve users.');
-  }
-
-  const { data, error } = await supabase
-    .from('profiles')
-    .update({ role: 'member' })
-    .eq('id', userID)
-    .select()
-    .single();
-
-  if (error) throw error
-  return data;
+  const json = await res.json()
+  if (!res.ok) throw new Error(json.error ?? 'Failed to approve user.')
+  return json.profile
 }


### PR DESCRIPTION
## Summary

Fixes the RLS issue flagged in PR #122 Copilot review (comment on `authService.js:93`).

## Problem

`adminApproval()` was calling Supabase directly from the client using the logged-in user's session. The `profiles_update_own` RLS policy only allows users to update their own row — so when an admin tries to update another user's role, the call is silently rejected by RLS.

This would cause the approve button on the future Admin Page to silently fail.

## Solution

- Add `/api/admin/approve` — a server-side Next.js route that:
  - Verifies the caller's JWT via `supabase.auth.getUser(token)`
  - Checks that caller has `admin` or `executive` role
  - Updates the target user's role using the **service role client** (bypasses RLS)
- `adminApproval()` in `authService.js` now calls this endpoint with the session Bearer token

## Why service role is safe here
The service role key lives only in `SUPABASE_SERVICE_ROLE_KEY` (server env, never exposed to client). The route enforces its own auth check before using it.

## Checklist
- [x] No `console.log`
- [x] No `var`
- [x] No `.then().catch()`
- [x] `SUPABASE_SERVICE_ROLE_KEY` already in Vercel env vars (existing)