### PR TITLE
fix: prevent double-submit in JoinModal

### DIFF
--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -138,7 +138,7 @@ export default function JoinModal() {
   }
 
   async function handleSubmit() {
-    if (!validate() || !user) return
+    if (submitting || !validate() || !user) return
     setSubmitting(true)
 
     try {
@@ -388,7 +388,11 @@ export default function JoinModal() {
           {submitting ? 'Submitting…' : 'Submit'}
         </Button>
 
-        {errors.submit && <p className="mt-2 text-xs text-center text-red-500">{errors.submit}</p>}
+        {errors.submit && (
+          <div className="mt-2 px-3 py-2 rounded-md bg-accent-bg border border-error/30 text-xs text-error text-center">
+            {errors.submit}
+          </div>
+        )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add `submitting` guard at the top of `handleSubmit` to block re-entry before React state updates
- Replace small inline error text with a visible red banner for `errors.submit`

## Root Cause
`handleSubmit` had no re-entry guard. Since React state updates are asynchronous, a rapid double-click (or any scenario that triggers the function twice before `setSubmitting(true)` re-renders) would call `createProfile` twice. The second call hits Supabase with a profile that was just created/updated, potentially throwing a constraint error that silently overrides the success flow.

## Related Issue
JoinModal submit not proceeding when LinkedIn or GitHub fields are filled in.

## Checklist
- [x] Tested locally
- [x] No console.log left
- [x] Follows code conventions