### PR TITLE
fix: graduate badge color

### DIFF
--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -35,7 +35,7 @@ function ExecutiveBadge() {
 function StatusBadge({ status }) {
   const isStudent = status === 'student'
   return (
-    <span className={`text-xs font-medium px-2 py-0.5 rounded ${isStudent ? 'bg-link-bg text-link' : 'bg-bg-elevated text-text-secondary'}`}>
+    <span className={`text-xs font-medium px-2 py-0.5 rounded ${isStudent ? 'bg-link-bg text-link' : 'bg-link-bg text-gold'}`}>
       {isStudent ? 'Student' : 'Graduate'}
     </span>
   )

--- a/src/components/members/MemberCard.js
+++ b/src/components/members/MemberCard.js
@@ -75,7 +75,7 @@ export default function MemberCard({ member }) {
         className={`mt-2 text-[11px] px-2 py-0.5 rounded ${
           status === 'student'
             ? 'bg-link-bg text-link'
-            : 'bg-bg-elevated text-text-secondary'
+            : 'bg-link-bg text-gold'
         }`}
       >
         {status === 'student' ? 'Student' : 'Graduate'}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,6 +41,7 @@ module.exports = {
           bg: '#EAF4F0',
         },
         warning: '#B45309',
+        gold: '#B8860B',
         link: {
           DEFAULT: '#1A6FBF',
           bg: '#F0F4FF',


### PR DESCRIPTION
## Summary
- Graduate badge was using `bg-bg-elevated` (#232323 dark background) — wrong token for a badge
- Fixed to match Student badge background with gold text for distinction

## Before / After
| | Before | After |
|---|---|---|
| Graduate | `bg-bg-elevated text-text-secondary` (dark bg) | `bg-link-bg text-gold` (light blue bg, gold text) |
| Student | `bg-link-bg text-link` | unchanged |

## Changes
- `tailwind.config.js`: add `gold: '#B8860B'` token
- `MemberCard.js`: Graduate badge color fix
- `members/[id]/page.js`: StatusBadge color fix

## Checklist
- [x] Tested locally
- [x] No console.log left
- [x] Follows code conventions