### PR TITLE
fix: render HTML formatting in schedule event description modal

### DIFF
--- a/src/app/api/calendar/route.js
+++ b/src/app/api/calendar/route.js
@@ -40,9 +40,13 @@ const parseIcsDate = (raw) => {
 const unfoldLines = (text) =>
   text.replace(/\r\n[ \t]/g, '').replace(/\n[ \t]/g, '');
 
-// Clean escaped characters from a summary string
+// Clean escaped characters from a summary/title string (plain text)
 const cleanText = (s) =>
   s.replace(/\\n/g, ' ').replace(/\\,/g, ',').replace(/\\/g, '');
+
+// Clean description strings — preserves HTML tags and converts \n to <br>
+const cleanDescription = (s) =>
+  s.replace(/\\n/g, '<br>').replace(/\\,/g, ',').replace(/\\/g, '');
 
 // Strip TZID/VALUE prefix and return the bare datetime string
 // e.g. "America/Toronto:20260525T180000" → "20260525T180000"
@@ -233,7 +237,7 @@ const parseEvents = (icsText, year, month) => {
 
     // Extract additional event fields
     const location = get('LOCATION') ? cleanText(get('LOCATION')) : null;
-    const description = get('DESCRIPTION') ? cleanText(get('DESCRIPTION')) : null;
+    const description = get('DESCRIPTION') ? cleanDescription(get('DESCRIPTION')) : null;
 
     // Extract start/end times directly from raw iCal strings to avoid timezone conversion.
     // All occurrences of a recurring event share the same clock time, so we derive

--- a/src/app/schedule/page.js
+++ b/src/app/schedule/page.js
@@ -116,7 +116,10 @@ const EventModal = ({ event, onClose }) => {
               style={{ boxShadow: '0 1px 2px rgba(0,0,0,0.19), 0 2px 4px rgba(0,0,0,0.08)' }}
             >
               <AlignLeft size={15} className="shrink-0 mt-0.5 text-text-secondary" />
-              <span className="font-inter text-sm text-text-secondary">{event.description}</span>
+              <span
+                className="font-inter text-sm text-text-secondary [&_a]:text-accent [&_a]:underline [&_a]:underline-offset-2 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_li]:mt-1 [&_strong]:font-semibold [&_b]:font-semibold"
+                dangerouslySetInnerHTML={{ __html: event.description }}
+              />
             </div>
           )}
           {!event.location && !event.description && (


### PR DESCRIPTION
## Summary
- Google Calendar event descriptions can include HTML markup (bold, lists, links via the rich-text editor), but these were previously displayed as raw escaped strings in the event detail modal
- Added `cleanDescription()` in the ICS parser to preserve HTML tags and convert `\n` to `<br>` instead of collapsing them to spaces
- Updated `EventModal` to use `dangerouslySetInnerHTML` so formatting renders correctly
- Applied Tailwind child-selector utilities (`[&_a]`, `[&_ul]`, `[&_li]`, `[&_strong]`, `[&_b]`) for consistent link and list styling inside the description block

## Screenshots
| Before | After |
|--------|-------|
| `<ul><li><b>Location: TBD</b></li>...` shown as raw text | Bold, bullet list, and links rendered correctly |

## Checklist
- [x] Tested locally
- [x] No console.log left
- [x] Follows code conventions