### PR TITLE
feat: add GitHub org link to navbar social icons

### DIFF
--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -48,6 +48,14 @@ function IconDiscord() {
   )
 }
 
+function IconGitHub() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+    </svg>
+  )
+}
+
 function IconEmail() {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
@@ -165,6 +173,10 @@ export default function Navbar() {
       <a href={socialLinks.linkedin.url} target="_blank" rel="noopener noreferrer"
         className="p-1.5 text-text-secondary hover:text-text-primary transition-colors">
         <IconLinkedIn />
+      </a>
+      <a href={socialLinks.github.url} target="_blank" rel="noopener noreferrer"
+        className="p-1.5 text-text-secondary hover:text-text-primary transition-colors">
+        <IconGitHub />
       </a>
       {isMember && <SocialDropdown icon={<IconDiscord />} items={socialLinks.discord} />}
       <button onClick={scrollToContact}

--- a/src/config/socialLinks.js
+++ b/src/config/socialLinks.js
@@ -3,6 +3,9 @@ export const socialLinks = {
   linkedin: {
     url: 'https://linkedin.com/company/codexperts2024',
   },
+  github: {
+    url: 'https://github.com/codexperts2024',
+  },
   email: {
     url: 'mailto:codexperts2024@gmail.com',
   },


### PR DESCRIPTION
## Summary
- Added codeXperts GitHub org URL to `socialLinks` config (`src/config/socialLinks.js`)
- Added `IconGitHub` SVG component to `Navbar.js`
- Rendered the GitHub icon link in the social icons row, between LinkedIn and Discord/email

## Related Issue
closes #136

## Checklist
- [x] Tested locally
- [x] No console.log left
- [x] Follows code conventions