### PR TITLE
feat: add executive_roles table and executiveService

### DIFF
--- a/src/services/executiveService.js
+++ b/src/services/executiveService.js
@@ -1,0 +1,64 @@
+import { supabase } from '@/lib/supabase'
+
+// Returns all currently active executives (end_date IS NULL),
+// joined with their profile. Used by the About page.
+export async function getCurrentExecutives() {
+  const { data, error } = await supabase
+    .from('executive_roles')
+    .select(`
+      id,
+      title,
+      start_date,
+      term,
+      profiles (
+        id,
+        first_name,
+        last_name,
+        nickname,
+        avatar_url,
+        school,
+        linkedin,
+        github
+      )
+    `)
+    .is('end_date', null)
+    .order('created_at', { ascending: true })
+
+  if (error) throw error
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    title: row.title,
+    startDate: row.start_date,
+    term: row.term,
+    userId: row.profiles?.id,
+    firstName: row.profiles?.first_name,
+    lastName: row.profiles?.last_name,
+    nickname: row.profiles?.nickname,
+    avatarUrl: row.profiles?.avatar_url,
+    school: row.profiles?.school,
+    linkedinUrl: row.profiles?.linkedin,
+    githubUrl: row.profiles?.github,
+  }))
+}
+
+// Returns the full executive role history for a given user.
+// Used by member profile pages to display past/present titles.
+export async function getExecutiveHistory(userId) {
+  const { data, error } = await supabase
+    .from('executive_roles')
+    .select('id, title, start_date, end_date, term')
+    .eq('user_id', userId)
+    .order('start_date', { ascending: false })
+
+  if (error) throw error
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    title: row.title,
+    startDate: row.start_date,
+    endDate: row.end_date,
+    term: row.term,
+    isCurrent: row.end_date === null,
+  }))
+}

--- a/supabase/migrations/20260607000000_add_executive_roles.sql
+++ b/supabase/migrations/20260607000000_add_executive_roles.sql
@@ -1,0 +1,45 @@
+-- executive_roles: tracks which executive holds which title, with full tenure history.
+-- Querying end_date IS NULL returns currently active role holders.
+
+CREATE TABLE executive_roles (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  title      text        NOT NULL CHECK (title IN ('President', 'Vice President', 'Treasurer')),
+  start_date date        NOT NULL,
+  end_date   date,
+  term       text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Enforce at most one active holder per title at any point in time.
+CREATE UNIQUE INDEX executive_roles_active_title_idx
+  ON executive_roles (title)
+  WHERE end_date IS NULL;
+
+-- RLS
+ALTER TABLE executive_roles ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read executive info (needed for public About page)
+CREATE POLICY "Public can read executive roles"
+  ON executive_roles
+  FOR SELECT
+  USING (true);
+
+-- Only admins can insert, update, or delete
+CREATE POLICY "Admins can manage executive roles"
+  ON executive_roles
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- Supabase migration: creates `executive_roles` table to track President / Vice President / Treasurer per member, with full tenure history (`start_date`, `end_date`, `term`)
- Partial unique index enforces at most one active holder per title at a time (`WHERE end_date IS NULL`)
- RLS: public `SELECT` (About page), admin-only `INSERT / UPDATE / DELETE`
- `src/services/executiveService.js`: two query helpers
  - `getCurrentExecutives()` — returns active title holders joined with profile (for About page)
  - `getExecutiveHistory(userId)` — returns all past and present roles for a user (for member profile page)

## Related Issue
closes #149

## Checklist
- [x] Migration applied to remote Supabase via `supabase db push`
- [x] No console.log left
- [x] Follows code conventions (`services/` layer, camelCase mapping)