### PR TITLE
feat: add school column to executive_roles for per-school executive tracking

### DIFF
--- a/docs/schema/schema.sql
+++ b/docs/schema/schema.sql
@@ -7,3 +7,4 @@ SET search_path TO public;
 \i ./tables/announcements.sql
 \i ./tables/submissions.sql
 \i ./tables/attendances.sql
+\i ./tables/executive_roles.sql

--- a/docs/schema/tables/executive_roles.sql
+++ b/docs/schema/tables/executive_roles.sql
@@ -1,0 +1,15 @@
+CREATE TABLE executive_roles (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  title      text        NOT NULL CHECK (title IN ('President', 'Vice President', 'Treasurer')),
+  school     text        NOT NULL DEFAULT 'Seneca College',
+  start_date date        NOT NULL,
+  end_date   date,
+  term       text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- At most one active holder per title per school
+CREATE UNIQUE INDEX executive_roles_active_title_school_idx
+  ON executive_roles (title, school)
+  WHERE end_date IS NULL;

--- a/src/services/executiveService.js
+++ b/src/services/executiveService.js
@@ -8,6 +8,7 @@ export async function getCurrentExecutives() {
     .select(`
       id,
       title,
+      school,
       start_date,
       term,
       profiles (
@@ -29,6 +30,7 @@ export async function getCurrentExecutives() {
   return (data ?? []).map((row) => ({
     id: row.id,
     title: row.title,
+    school: row.school,
     startDate: row.start_date,
     term: row.term,
     userId: row.profiles?.id,

--- a/supabase/migrations/20260607010000_executive_roles_add_school.sql
+++ b/supabase/migrations/20260607010000_executive_roles_add_school.sql
@@ -1,0 +1,14 @@
+-- Add school column to executive_roles so each school can have its own
+-- President / Vice President / Treasurer independently.
+-- Also fixes the unique index to scope uniqueness per (title, school).
+
+ALTER TABLE executive_roles
+  ADD COLUMN school text NOT NULL DEFAULT 'Seneca College';
+
+-- Drop the old index that only constrained by title
+DROP INDEX IF EXISTS executive_roles_active_title_idx;
+
+-- New index: at most one active holder per title per school
+CREATE UNIQUE INDEX executive_roles_active_title_school_idx
+  ON executive_roles (title, school)
+  WHERE end_date IS NULL;

--- a/supabase/migrations/20260607020000_executive_roles_title_enum.sql
+++ b/supabase/migrations/20260607020000_executive_roles_title_enum.sql
@@ -1,0 +1,17 @@
+-- Convert executive_roles.title from text+CHECK to a proper ENUM type
+-- so Supabase Table Editor shows a dropdown for the title field.
+-- The unique index must be dropped and recreated around the type change.
+
+DROP INDEX IF EXISTS executive_roles_active_title_school_idx;
+
+CREATE TYPE executive_title AS ENUM ('President', 'Vice President', 'Treasurer');
+
+ALTER TABLE executive_roles
+  DROP CONSTRAINT IF EXISTS executive_roles_title_check,
+  ALTER COLUMN title TYPE executive_title
+    USING title::executive_title,
+  ALTER COLUMN title SET NOT NULL;
+
+CREATE UNIQUE INDEX executive_roles_active_title_school_idx
+  ON executive_roles (title, school)
+  WHERE end_date IS NULL;


### PR DESCRIPTION
## Summary
- Each school (Seneca, York) needs independent President / VP / Treasurer roles
- Added `school` column (`NOT NULL DEFAULT 'Seneca College'`) to `executive_roles`
- Replaced unique index `(title)` with `(title, school) WHERE end_date IS NULL` — prevents duplicate active title per school while allowing the same title across schools
- Updated `executiveService.js` to return `school` field so the About page can filter/group by school

## Related Issue
closes #138 (partial — DB layer ready for About page implementation)

## Checklist
- [x] Migration applied to remote Supabase via `supabase db push`
- [x] Existing Seneca rows backfilled with `DEFAULT 'Seneca College'`
- [x] No console.log left
- [x] Follows code conventions