### PR TITLE
feat: member profile page with GitHub-style layout and inline edit

### DIFF
--- a/docs/schema/tables/profiles.sql
+++ b/docs/schema/tables/profiles.sql
@@ -9,16 +9,25 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TABLE profiles (
-  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
-  name TEXT,
-  email TEXT UNIQUE NOT NULL,
-  role member_role NOT NULL DEFAULT 'pending',
-  school TEXT,
-  linkedin TEXT,
-  github TEXT,
-  avatar_url TEXT,
-  created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+  id              UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  first_name      TEXT,
+  last_name       TEXT,
+  nickname        TEXT,
+  email           TEXT UNIQUE NOT NULL,
+  role            member_role NOT NULL DEFAULT 'pending',
+  school          TEXT,
+  cohort          TEXT,
+  status          TEXT,
+  occupation      TEXT,
+  company         TEXT,
+  phone           TEXT,
+  linkedin        TEXT,
+  github          TEXT,
+  avatar_url      TEXT,
+  bio             TEXT,
+  profile_visibility JSONB NOT NULL DEFAULT '{"bio": true, "linkedin": true, "github": true}',
+  created_at      TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  updated_at      TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TRIGGER set_profiles_updated_at

--- a/src/app/auth/callback/page.js
+++ b/src/app/auth/callback/page.js
@@ -25,7 +25,9 @@ export default function AuthCallbackPage() {
       }
 
       if (isApprovedRole(profile.role)) {
-        router.replace('/')
+        const redirect = localStorage.getItem('auth_redirect') || '/'
+        localStorage.removeItem('auth_redirect')
+        router.replace(redirect)
       } else {
         router.replace('/pending')
       }

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -10,11 +10,13 @@ import { IconLinkedIn, IconGitHub } from '@/components/ui/SocialIcons'
 
 function Avatar({ member }) {
   const initial = (member?.firstName?.[0] ?? '?').toUpperCase()
+  // Google profile photos include a size param (e.g. =s96-c). Bump to s400 for higher quality.
+  const src = member.avatarUrl?.replace(/=s\d+-c$/, '=s400-c') ?? member.avatarUrl
   return (
     <div className="w-full aspect-square rounded-full overflow-hidden bg-bg-layer1 flex items-center justify-center">
-      {member.avatarUrl ? (
+      {src ? (
         <img
-          src={member.avatarUrl}
+          src={src}
           alt={`${member.firstName} ${member.lastName}`}
           referrerPolicy="no-referrer"
           className="w-full h-full object-cover"
@@ -41,33 +43,23 @@ function ExecutiveBadge() {
   )
 }
 
-function VisibilityToggle({ visible, onChange }) {
+function SegmentedToggle({ options, value, onChange }) {
   return (
-    <button
-      type="button"
-      onClick={() => onChange(!visible)}
-      className={`text-[11px] flex items-center gap-1 px-2 py-0.5 rounded border transition-colors ${
-        visible ? 'border-border text-text-secondary hover:border-border-strong' : 'border-border text-text-hint bg-bg-layer1'
-      }`}
-    >
-      {visible ? '👁 Visible' : '🔒 Hidden'}
-    </button>
-  )
-}
-
-function StatusToggle({ value, onChange }) {
-  const isStudent = value !== 'graduate'
-  return (
-    <div className="flex items-center gap-2">
-      <span className={`text-sm ${isStudent ? 'text-[#1A6FBF] font-medium' : 'text-text-hint'}`}>Student</span>
-      <button
-        type="button"
-        onClick={() => onChange(isStudent ? 'graduate' : 'student')}
-        className={`relative w-10 h-5 rounded-full transition-colors duration-200 ${isStudent ? 'bg-[#1A6FBF]' : 'bg-text-secondary'}`}
-      >
-        <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform duration-200 ${isStudent ? 'translate-x-0.5' : 'translate-x-5'}`} />
-      </button>
-      <span className={`text-sm ${!isStudent ? 'text-text-secondary font-medium' : 'text-text-hint'}`}>Graduate</span>
+    <div className="inline-flex rounded-full border border-border overflow-hidden text-xs font-medium">
+      {options.map((opt, i) => (
+        <button
+          key={String(opt.value)}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          className={`px-3 py-1 transition-colors ${i > 0 ? 'border-l border-border' : ''} ${
+            value === opt.value
+              ? 'bg-text-primary text-bg-base'
+              : 'text-text-hint hover:text-text-secondary bg-transparent'
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
     </div>
   )
 }
@@ -186,13 +178,21 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
 
       <div className="flex flex-col gap-2">
         <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Status</label>
-        <StatusToggle value={form.status} onChange={(v) => setForm(f => ({ ...f, status: v }))} />
+        <SegmentedToggle
+          options={[{ value: 'student', label: 'Student' }, { value: 'graduate', label: 'Graduate' }]}
+          value={form.status}
+          onChange={(v) => setForm(f => ({ ...f, status: v }))}
+        />
       </div>
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Bio</label>
-          <VisibilityToggle visible={visibility.bio} onChange={setVis('bio')} />
+          <SegmentedToggle
+            options={[{ value: true, label: 'Visible' }, { value: false, label: 'Hidden' }]}
+            value={visibility.bio}
+            onChange={setVis('bio')}
+          />
         </div>
         <textarea value={form.bio} onChange={(e) => setForm(f => ({ ...f, bio: e.target.value.slice(0, 300) }))}
           placeholder="Tell others about yourself..."
@@ -204,7 +204,11 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">LinkedIn</label>
-          <VisibilityToggle visible={visibility.linkedin} onChange={setVis('linkedin')} />
+          <SegmentedToggle
+            options={[{ value: true, label: 'Visible' }, { value: false, label: 'Hidden' }]}
+            value={visibility.linkedin}
+            onChange={setVis('linkedin')}
+          />
         </div>
         <input type="url" value={form.linkedin} onChange={setField('linkedin')}
           placeholder="https://linkedin.com/in/..."
@@ -214,7 +218,11 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">GitHub</label>
-          <VisibilityToggle visible={visibility.github} onChange={setVis('github')} />
+          <SegmentedToggle
+            options={[{ value: true, label: 'Visible' }, { value: false, label: 'Hidden' }]}
+            value={visibility.github}
+            onChange={setVis('github')}
+          />
         </div>
         <input type="url" value={form.github} onChange={setField('github')}
           placeholder="https://github.com/..."

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -158,14 +158,14 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
           {v.github !== false && member.githubUrl && (
             <a href={member.githubUrl} target="_blank" rel="noopener noreferrer"
               className="flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors">
-              <IconGitHub className="size-4 shrink-0" />
+              <IconGitHub className="size-4 shrink-0 text-text-primary" />
               <span className="truncate">GitHub</span>
             </a>
           )}
           {v.linkedin !== false && member.linkedinUrl && (
             <a href={member.linkedinUrl} target="_blank" rel="noopener noreferrer"
               className="flex items-center gap-2 text-sm text-text-secondary hover:text-[#0A66C2] transition-colors">
-              <IconLinkedIn className="size-4 shrink-0" />
+              <IconLinkedIn className="size-4 shrink-0 text-[#0A66C2]" />
               <span className="truncate">LinkedIn</span>
             </a>
           )}
@@ -380,7 +380,7 @@ export default function ProfilePage({ params }) {
           github: member.githubUrl ? pv.github !== false : false,
           company: member.company ? pv.company !== false : false,
           occupation: member.occupation ? pv.occupation !== false : false,
-          phone: false,
+          phone: member.phone ? pv.phone === true : false,
         },
       })
     }

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -16,14 +16,9 @@ function Avatar({ member }) {
   return (
     <div className="w-full aspect-square rounded-full overflow-hidden bg-bg-layer1 flex items-center justify-center">
       {src ? (
-        <img
-          src={src}
-          alt={`${member.firstName} ${member.lastName}`}
-          referrerPolicy="no-referrer"
-          className="w-full h-full object-cover"
-        />
+        <img src={src} alt={`${member.firstName} ${member.lastName}`} referrerPolicy="no-referrer" className="w-full h-full object-cover" />
       ) : (
-        <span className="font-montserrat font-bold text-5xl text-text-secondary">{initial}</span>
+        <span className="font-montserrat font-bold text-5xl text-text-secondary">{(member?.firstName?.[0] ?? '?').toUpperCase()}</span>
       )}
     </div>
   )
@@ -39,12 +34,9 @@ function StatusBadge({ status }) {
 }
 
 function ExecutiveBadge() {
-  return (
-    <span className="text-xs font-medium px-2 py-0.5 rounded bg-success-bg text-success">Executive</span>
-  )
+  return <span className="text-xs font-medium px-2 py-0.5 rounded bg-success-bg text-success">Executive</span>
 }
 
-// Sliding segmented toggle (equal-width buttons, colored sliding background)
 function SlidingSegmented({ value, options, onChange }) {
   const idx = options.findIndex(o => o.value === value)
   const colors = ['bg-[#1A6FBF]', 'bg-orange-400']
@@ -61,16 +53,10 @@ function SlidingSegmented({ value, options, onChange }) {
   )
 }
 
-// iOS-style toggle switch
 function Toggle({ value, onChange, colorOn = 'bg-[#1A6FBF]', colorOff = 'bg-gray-300' }) {
   return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={value}
-      onClick={() => onChange(!value)}
-      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none ${value ? colorOn : colorOff}`}
-    >
+    <button type="button" role="switch" aria-checked={value} onClick={() => onChange(!value)}
+      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none ${value ? colorOn : colorOff}`}>
       <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform duration-200 ${value ? 'translate-x-5' : 'translate-x-0.5'}`} />
     </button>
   )
@@ -79,8 +65,42 @@ function Toggle({ value, onChange, colorOn = 'bg-[#1A6FBF]', colorOff = 'bg-gray
 function IconMonitor({ className = 'size-4' }) {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <rect x="2" y="3" width="20" height="14" rx="2" />
-      <path d="M8 21h8M12 17v4" />
+      <rect x="2" y="3" width="20" height="14" rx="2" /><path d="M8 21h8M12 17v4" />
+    </svg>
+  )
+}
+function IconBriefcase({ className = 'size-4' }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <rect x="2" y="7" width="20" height="14" rx="2" /><path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
+    </svg>
+  )
+}
+function IconBuilding({ className = 'size-4' }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M3 21h18M9 8h1M9 12h1M9 16h1M14 8h1M14 12h1M14 16h1" /><path d="M3 21V5a2 2 0 012-2h14a2 2 0 012 2v16" />
+    </svg>
+  )
+}
+function IconGradCap({ className = 'size-4' }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M22 10v6M2 10l10-5 10 5-10 5z" /><path d="M6 12v5c3 3 9 3 12 0v-5" />
+    </svg>
+  )
+}
+function IconPhone({ className = 'size-4' }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 11a19.79 19.79 0 01-3.07-8.67A2 2 0 012 .18h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 14.92z" />
+    </svg>
+  )
+}
+function IconCalendar({ className = 'size-4' }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <rect x="3" y="4" width="18" height="18" rx="2" /><path d="M16 2v4M8 2v4M3 10h18" />
     </svg>
   )
 }
@@ -90,53 +110,63 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
   const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
   const v = member.profileVisibility ?? {}
 
+  const infoItems = [
+    v.occupation !== false && member.occupation && { icon: <IconBriefcase className="size-4" />, text: member.occupation },
+    v.company !== false && member.company && { icon: <IconBuilding className="size-4" />, text: member.company },
+    member.school && { icon: <IconGradCap className="size-4" />, text: member.school },
+    member.cohort && { icon: <IconCalendar className="size-4" />, text: cohortLabel(member.cohort) },
+    v.phone !== false && member.phone && { icon: <IconPhone className="size-4" />, text: member.phone },
+  ].filter(Boolean)
+
   return (
     <aside className="flex flex-col gap-4">
       <Avatar member={member} />
 
       <div>
         <h1 className="font-montserrat font-bold text-2xl text-text-primary leading-tight">{fullName}</h1>
-        {member.nickname && (
-          <p className="text-text-hint text-base mt-0.5">{member.nickname}</p>
-        )}
+        {member.nickname && <p className="text-text-hint text-base mt-0.5">{member.nickname}</p>}
       </div>
 
-      <div className="flex flex-wrap gap-1.5">
-        <StatusBadge status={member.status} />
-        {isExec && <ExecutiveBadge />}
-      </div>
-
+      {/* Bio before badges */}
       {v.bio !== false && (
         <p className="text-sm text-text-secondary leading-relaxed min-h-[1.25rem] whitespace-pre-wrap">
           {member.bio ?? ''}
         </p>
       )}
 
-      <div className="flex flex-col gap-1 text-sm text-text-secondary">
-        {v.occupation !== false && member.occupation && <span>{member.occupation}</span>}
-        {v.company !== false && member.company && <span>{member.company}</span>}
-        {member.school && <span>{member.school}</span>}
-        {member.cohort && <span>{cohortLabel(member.cohort)}</span>}
+      {/* Status / role badges */}
+      <div className="flex flex-wrap gap-1.5">
+        <StatusBadge status={member.status} />
+        {isExec && <ExecutiveBadge />}
       </div>
 
-      {v.phone !== false && member.phone && (
-        <span className="text-sm text-text-secondary">{member.phone}</span>
+      {/* Info items with icons */}
+      {infoItems.length > 0 && (
+        <div className="flex flex-col gap-2 pt-1">
+          {infoItems.map((item, i) => (
+            <div key={i} className="flex items-center gap-2.5 text-sm text-text-secondary">
+              <span className="text-text-hint shrink-0">{item.icon}</span>
+              <span>{item.text}</span>
+            </div>
+          ))}
+        </div>
       )}
 
+      {/* Social links */}
       {((v.linkedin !== false && member.linkedinUrl) || (v.github !== false && member.githubUrl)) && (
-        <div className="flex flex-col gap-2 pt-1">
-          {v.linkedin !== false && member.linkedinUrl && (
-            <a href={member.linkedinUrl} target="_blank" rel="noopener noreferrer"
-              className="flex items-center gap-2 text-sm text-text-secondary hover:text-[#0A66C2] transition-colors">
-              <IconLinkedIn className="size-4 shrink-0" />
-              <span className="truncate">LinkedIn</span>
-            </a>
-          )}
+        <div className="flex flex-col gap-2">
           {v.github !== false && member.githubUrl && (
             <a href={member.githubUrl} target="_blank" rel="noopener noreferrer"
               className="flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors">
               <IconGitHub className="size-4 shrink-0" />
               <span className="truncate">GitHub</span>
+            </a>
+          )}
+          {v.linkedin !== false && member.linkedinUrl && (
+            <a href={member.linkedinUrl} target="_blank" rel="noopener noreferrer"
+              className="flex items-center gap-2 text-sm text-text-secondary hover:text-[#0A66C2] transition-colors">
+              <IconLinkedIn className="size-4 shrink-0" />
+              <span className="truncate">LinkedIn</span>
             </a>
           )}
         </div>
@@ -145,12 +175,12 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
       {isOwn && (
         <>
           <div className="flex flex-col gap-1 text-xs text-text-hint">
-            {v.bio === false && member.bio && <span>🔒 Bio hidden from others</span>}
-            {v.occupation === false && member.occupation && <span>🔒 Occupation hidden from others</span>}
-            {v.company === false && member.company && <span>🔒 Company hidden from others</span>}
-            {v.phone === false && member.phone && <span>🔒 Phone hidden from others</span>}
-            {v.linkedin === false && member.linkedinUrl && <span>🔒 LinkedIn hidden from others</span>}
-            {v.github === false && member.githubUrl && <span>🔒 GitHub hidden from others</span>}
+            {v.bio === false && member.bio && <span>🔒 Bio hidden</span>}
+            {v.occupation === false && member.occupation && <span>🔒 Occupation hidden</span>}
+            {v.company === false && member.company && <span>🔒 Company hidden</span>}
+            {v.phone === false && member.phone && <span>🔒 Phone hidden</span>}
+            {v.linkedin === false && member.linkedinUrl && <span>🔒 LinkedIn hidden</span>}
+            {v.github === false && member.githubUrl && <span>🔒 GitHub hidden</span>}
           </div>
           <button type="button" onClick={onEdit}
             className="w-full mt-1 px-4 py-1.5 rounded border border-border text-sm text-text-secondary hover:border-border-strong hover:text-text-primary transition-colors">
@@ -162,10 +192,27 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
   )
 }
 
+function FieldLabel({ children }) {
+  return <label className="text-xs font-medium text-text-hint tracking-wide">{children}</label>
+}
+
+function VisibilityRow({ label, vis, onChange }) {
+  return (
+    <div className="flex items-center justify-between">
+      <FieldLabel>{label}</FieldLabel>
+      <div className="flex items-center gap-2">
+        <Toggle value={vis} onChange={onChange} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
+        <span className={`text-xs font-medium w-10 ${vis ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
+          {vis ? 'Visible' : 'Hidden'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
 // Edit view — controlled by parent draft state, own profile only
 function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave, saving, saveError }) {
   const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
-
   const setField = (key) => (e) => onDraftChange({ ...draft, [key]: e.target.value })
   const setVis = (key) => (val) => onDraftChange({ ...draft, vis: { ...draft.vis, [key]: val } })
 
@@ -182,21 +229,22 @@ function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave
     school: draft.school || null,
   })
 
+  const inputCls = "w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent"
+
   return (
     <aside className="flex flex-col gap-5">
       <Avatar member={member} />
 
-      <p className="font-montserrat font-bold text-2xl text-text-primary leading-tight">{fullName}</p>
-
       <div className="flex flex-col gap-1">
-        <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Nickname</label>
+        <p className="font-montserrat font-bold text-2xl text-text-primary leading-tight">{fullName}</p>
         <input type="text" value={draft.nickname} onChange={setField('nickname')}
-          placeholder="Add a nickname..."
-          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+          placeholder="Nickname"
+          className={inputCls} />
       </div>
 
+      {/* Status */}
       <div className="flex flex-col gap-2">
-        <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Status</label>
+        <FieldLabel>Status</FieldLabel>
         <SlidingSegmented
           options={[{ value: 'student', label: 'Student' }, { value: 'graduate', label: 'Graduate' }]}
           value={draft.status}
@@ -204,110 +252,66 @@ function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave
         />
       </div>
 
+      {/* Bio */}
       <div className="flex flex-col gap-1">
-        <div className="flex items-center justify-between">
-          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Occupation</label>
-          <div className="flex items-center gap-2">
-            <Toggle value={draft.vis.occupation} onChange={setVis('occupation')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
-            <span className={`text-xs font-medium w-10 ${draft.vis.occupation ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
-              {draft.vis.occupation ? 'Visible' : 'Hidden'}
-            </span>
-          </div>
-        </div>
-        <input type="text" value={draft.occupation} onChange={setField('occupation')}
-          placeholder="e.g. Software Developer"
-          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+        <VisibilityRow label="Bio" vis={draft.vis.bio} onChange={setVis('bio')} />
+        <textarea value={draft.bio} onChange={(e) => onDraftChange({ ...draft, bio: e.target.value.slice(0, 300) })}
+          placeholder="Tell others about yourself..."
+          rows={4}
+          className={`${inputCls} resize-none`} />
+        <p className="text-xs text-text-hint text-right">{draft.bio.length} / 300</p>
       </div>
 
+      {/* School */}
       <div className="flex flex-col gap-1">
-        <div className="flex items-center justify-between">
-          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Company</label>
-          <div className="flex items-center gap-2">
-            <Toggle value={draft.vis.company} onChange={setVis('company')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
-            <span className={`text-xs font-medium w-10 ${draft.vis.company ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
-              {draft.vis.company ? 'Visible' : 'Hidden'}
-            </span>
-          </div>
-        </div>
-        <input type="text" value={draft.company} onChange={setField('company')}
-          placeholder="e.g. Google"
-          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <label className="text-xs font-medium text-text-hint uppercase tracking-wide">School</label>
-        <select value={draft.school} onChange={setField('school')}
-          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent">
+        <FieldLabel>School</FieldLabel>
+        <select value={draft.school} onChange={setField('school')} className={inputCls}>
           <option value="">Select school...</option>
           {SCHOOLS.map(s => <option key={s} value={s}>{s}</option>)}
         </select>
       </div>
 
+      {/* Phone */}
       <div className="flex flex-col gap-1">
-        <div className="flex items-center justify-between">
-          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Bio</label>
-          <div className="flex items-center gap-2">
-            <Toggle value={draft.vis.bio} onChange={setVis('bio')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
-            <span className={`text-xs font-medium w-10 ${draft.vis.bio ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
-              {draft.vis.bio ? 'Visible' : 'Hidden'}
-            </span>
-          </div>
-        </div>
-        <textarea value={draft.bio} onChange={(e) => onDraftChange({ ...draft, bio: e.target.value.slice(0, 300) })}
-          placeholder="Tell others about yourself..."
-          rows={4}
-          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary resize-none focus:outline-none focus:border-accent" />
-        <p className="text-xs text-text-hint text-right">{draft.bio.length} / 300</p>
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center justify-between">
-          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Phone</label>
-          <div className="flex items-center gap-2">
-            <Toggle value={draft.vis.phone} onChange={setVis('phone')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
-            <span className={`text-xs font-medium w-10 ${draft.vis.phone ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
-              {draft.vis.phone ? 'Visible' : 'Hidden'}
-            </span>
-          </div>
-        </div>
+        <VisibilityRow label="Phone" vis={draft.vis.phone} onChange={setVis('phone')} />
         <input type="tel" value={draft.phone} onChange={setField('phone')}
           placeholder="+1 (416) 000-0000"
-          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+          className={inputCls} />
       </div>
 
+      {/* Company */}
       <div className="flex flex-col gap-1">
-        <div className="flex items-center justify-between">
-          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">LinkedIn</label>
-          <div className="flex items-center gap-2">
-            <Toggle value={draft.vis.linkedin} onChange={setVis('linkedin')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
-            <span className={`text-xs font-medium w-10 ${draft.vis.linkedin ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
-              {draft.vis.linkedin ? 'Visible' : 'Hidden'}
-            </span>
-          </div>
-        </div>
-        <input type="url" value={draft.linkedin} onChange={setField('linkedin')}
-          placeholder="https://linkedin.com/in/..."
-          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+        <VisibilityRow label="Company" vis={draft.vis.company} onChange={setVis('company')} />
+        <input type="text" value={draft.company} onChange={setField('company')}
+          placeholder="e.g. Google"
+          className={inputCls} />
       </div>
 
+      {/* Occupation */}
       <div className="flex flex-col gap-1">
-        <div className="flex items-center justify-between">
-          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">GitHub</label>
-          <div className="flex items-center gap-2">
-            <Toggle value={draft.vis.github} onChange={setVis('github')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
-            <span className={`text-xs font-medium w-10 ${draft.vis.github ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
-              {draft.vis.github ? 'Visible' : 'Hidden'}
-            </span>
-          </div>
-        </div>
+        <VisibilityRow label="Occupation" vis={draft.vis.occupation} onChange={setVis('occupation')} />
+        <input type="text" value={draft.occupation} onChange={setField('occupation')}
+          placeholder="e.g. Software Developer"
+          className={inputCls} />
+      </div>
+
+      {/* GitHub */}
+      <div className="flex flex-col gap-1">
+        <VisibilityRow label="GitHub" vis={draft.vis.github} onChange={setVis('github')} />
         <input type="url" value={draft.github} onChange={setField('github')}
           placeholder="https://github.com/..."
-          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+          className={inputCls} />
       </div>
 
-      {saveError && (
-        <p className="text-xs text-accent px-1">{saveError}</p>
-      )}
+      {/* LinkedIn */}
+      <div className="flex flex-col gap-1">
+        <VisibilityRow label="LinkedIn" vis={draft.vis.linkedin} onChange={setVis('linkedin')} />
+        <input type="url" value={draft.linkedin} onChange={setField('linkedin')}
+          placeholder="https://linkedin.com/in/..."
+          className={inputCls} />
+      </div>
+
+      {saveError && <p className="text-xs text-accent px-1">{saveError}</p>}
 
       <div className="flex flex-col gap-2 pt-1">
         <button type="button" onClick={handleSave} disabled={saving}
@@ -335,11 +339,9 @@ export default function ProfilePage({ params }) {
   const [member, setMember] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
-  // 'edit' | 'preview' | 'read'
   const [mode, setMode] = useState('read')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState(null)
-  // Lifted form state — persists across edit/preview switches
   const [draft, setDraft] = useState(null)
   const initializedRef = useRef(false)
 
@@ -359,7 +361,6 @@ export default function ProfilePage({ params }) {
     return () => { cancelled = true }
   }, [id])
 
-  // Initialize draft from member data (once on load, reset after save)
   useEffect(() => {
     if (member && draft === null) {
       const pv = member.profileVisibility ?? {}
@@ -379,13 +380,12 @@ export default function ProfilePage({ params }) {
           github: member.githubUrl ? pv.github !== false : false,
           company: member.company ? pv.company !== false : false,
           occupation: member.occupation ? pv.occupation !== false : false,
-          phone: false, // phone always hidden by default
+          phone: false,
         },
       })
     }
   }, [member, draft])
 
-  // Auto-enter edit mode once we confirm own profile
   useEffect(() => {
     if (!initializedRef.current && member && user && user.id === id) {
       setMode('edit')
@@ -396,7 +396,6 @@ export default function ProfilePage({ params }) {
   const isOwn = user?.id === id
   const isExec = member?.role === 'executive' || member?.role === 'admin'
 
-  // In preview mode, show draft values instead of saved DB values
   const displayMember = (mode === 'preview' && draft && member)
     ? {
         ...member,
@@ -420,7 +419,7 @@ export default function ProfilePage({ params }) {
       await updateMyProfile(fields)
       const updated = await fetchMemberById(id)
       setMember(updated)
-      setDraft(null) // triggers re-init from updated member data
+      setDraft(null)
       setMode('edit')
     } catch (err) {
       console.error('Failed to save profile:', err)
@@ -428,6 +427,12 @@ export default function ProfilePage({ params }) {
     } finally {
       setSaving(false)
     }
+  }
+
+  // Cancel discards unsaved changes by resetting draft to DB state
+  const handleCancel = () => {
+    setDraft(null)
+    setMode('read')
   }
 
   return (
@@ -465,7 +470,7 @@ export default function ProfilePage({ params }) {
                         draft={draft}
                         onDraftChange={setDraft}
                         onPreview={() => setMode('preview')}
-                        onCancel={() => setMode('read')}
+                        onCancel={handleCancel}
                         onSave={handleSave}
                         saving={saving}
                         saveError={saveError}

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -8,6 +8,8 @@ import { fetchMemberById, updateMyProfile } from '@/services/membersService'
 import { cohortLabel } from '@/utils/cohort'
 import { IconLinkedIn, IconGitHub } from '@/components/ui/SocialIcons'
 
+const SCHOOLS = ['Seneca College', 'York University']
+
 function Avatar({ member }) {
   const initial = (member?.firstName?.[0] ?? '?').toUpperCase()
   const src = member.avatarUrl?.replace(/=s\d+-c$/, '=s400-c') ?? member.avatarUrl
@@ -42,15 +44,16 @@ function ExecutiveBadge() {
   )
 }
 
-// Sliding segmented toggle for two named options (e.g. Student/Graduate)
+// Sliding segmented toggle (equal-width buttons, colored sliding background)
 function SlidingSegmented({ value, options, onChange }) {
   const idx = options.findIndex(o => o.value === value)
+  const colors = ['bg-[#1A6FBF]', 'bg-orange-400']
   return (
-    <div className="relative inline-flex rounded-full border border-border overflow-hidden text-xs font-medium">
-      <span className={`absolute inset-y-0 w-1/2 transition-all duration-200 ${idx === 0 ? 'left-0' : 'left-1/2'} ${idx === 0 ? 'bg-[#1A6FBF]' : 'bg-orange-400'}`} />
+    <div className="relative flex w-full rounded-full border border-border overflow-hidden text-xs font-medium">
+      <span className={`absolute inset-y-0 w-1/2 transition-all duration-200 ${idx === 0 ? 'left-0' : 'left-1/2'} ${colors[idx] ?? 'bg-[#1A6FBF]'}`} />
       {options.map((opt, i) => (
         <button key={String(opt.value)} type="button" onClick={() => onChange(opt.value)}
-          className={`relative z-10 px-4 py-1.5 transition-colors ${i > 0 ? 'border-l border-border' : ''} ${opt.value === value ? 'text-white' : 'text-text-hint'}`}>
+          className={`relative z-10 flex-1 text-center py-1.5 transition-colors ${i > 0 ? 'border-l border-border' : ''} ${opt.value === value ? 'text-white' : 'text-text-hint'}`}>
           {opt.label}
         </button>
       ))}
@@ -83,7 +86,7 @@ function IconMonitor({ className = 'size-4' }) {
 }
 
 // Read view — shown to other members, or as "Preview" for own profile
-function ReadSidebar({ member, isOwn, isPreview, isExec, onEdit }) {
+function ReadSidebar({ member, isOwn, isExec, onEdit }) {
   const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
   const v = member.profileVisibility ?? {}
 
@@ -103,18 +106,22 @@ function ReadSidebar({ member, isOwn, isPreview, isExec, onEdit }) {
         {isExec && <ExecutiveBadge />}
       </div>
 
-      {v.bio !== false ? (
+      {v.bio !== false && (
         <p className="text-sm text-text-secondary leading-relaxed min-h-[1.25rem] whitespace-pre-wrap">
           {member.bio ?? ''}
         </p>
-      ) : isPreview && member.bio ? (
-        <p className="text-xs text-text-hint italic">🔒 Bio is hidden from others</p>
-      ) : null}
+      )}
 
       <div className="flex flex-col gap-1 text-sm text-text-secondary">
+        {v.occupation !== false && member.occupation && <span>{member.occupation}</span>}
+        {v.company !== false && member.company && <span>{member.company}</span>}
         {member.school && <span>{member.school}</span>}
         {member.cohort && <span>{cohortLabel(member.cohort)}</span>}
       </div>
+
+      {v.phone !== false && member.phone && (
+        <span className="text-sm text-text-secondary">{member.phone}</span>
+      )}
 
       {((v.linkedin !== false && member.linkedinUrl) || (v.github !== false && member.githubUrl)) && (
         <div className="flex flex-col gap-2 pt-1">
@@ -139,6 +146,9 @@ function ReadSidebar({ member, isOwn, isPreview, isExec, onEdit }) {
         <>
           <div className="flex flex-col gap-1 text-xs text-text-hint">
             {v.bio === false && member.bio && <span>🔒 Bio hidden from others</span>}
+            {v.occupation === false && member.occupation && <span>🔒 Occupation hidden from others</span>}
+            {v.company === false && member.company && <span>🔒 Company hidden from others</span>}
+            {v.phone === false && member.phone && <span>🔒 Phone hidden from others</span>}
             {v.linkedin === false && member.linkedinUrl && <span>🔒 LinkedIn hidden from others</span>}
             {v.github === false && member.githubUrl && <span>🔒 GitHub hidden from others</span>}
           </div>
@@ -166,16 +176,17 @@ function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave
     github: draft.github || null,
     status: draft.status,
     profile_visibility: draft.vis,
+    company: draft.company || null,
+    occupation: draft.occupation || null,
+    phone: draft.phone || null,
+    school: draft.school || null,
   })
 
   return (
     <aside className="flex flex-col gap-5">
       <Avatar member={member} />
 
-      <div>
-        <p className="font-montserrat font-bold text-2xl text-text-primary leading-tight">{fullName}</p>
-        <p className="text-xs text-text-hint mt-0.5">Name is managed by admin</p>
-      </div>
+      <p className="font-montserrat font-bold text-2xl text-text-primary leading-tight">{fullName}</p>
 
       <div className="flex flex-col gap-1">
         <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Nickname</label>
@@ -195,14 +206,48 @@ function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
+          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Occupation</label>
+          <div className="flex items-center gap-2">
+            <Toggle value={draft.vis.occupation} onChange={setVis('occupation')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
+            <span className={`text-xs font-medium w-10 ${draft.vis.occupation ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
+              {draft.vis.occupation ? 'Visible' : 'Hidden'}
+            </span>
+          </div>
+        </div>
+        <input type="text" value={draft.occupation} onChange={setField('occupation')}
+          placeholder="e.g. Software Developer"
+          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Company</label>
+          <div className="flex items-center gap-2">
+            <Toggle value={draft.vis.company} onChange={setVis('company')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
+            <span className={`text-xs font-medium w-10 ${draft.vis.company ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
+              {draft.vis.company ? 'Visible' : 'Hidden'}
+            </span>
+          </div>
+        </div>
+        <input type="text" value={draft.company} onChange={setField('company')}
+          placeholder="e.g. Google"
+          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-text-hint uppercase tracking-wide">School</label>
+        <select value={draft.school} onChange={setField('school')}
+          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent">
+          <option value="">Select school...</option>
+          {SCHOOLS.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Bio</label>
           <div className="flex items-center gap-2">
-            <Toggle
-              value={draft.vis.bio}
-              onChange={setVis('bio')}
-              colorOn="bg-[#1A6FBF]"
-              colorOff="bg-gray-300"
-            />
+            <Toggle value={draft.vis.bio} onChange={setVis('bio')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
             <span className={`text-xs font-medium w-10 ${draft.vis.bio ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
               {draft.vis.bio ? 'Visible' : 'Hidden'}
             </span>
@@ -217,14 +262,24 @@ function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
+          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Phone</label>
+          <div className="flex items-center gap-2">
+            <Toggle value={draft.vis.phone} onChange={setVis('phone')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
+            <span className={`text-xs font-medium w-10 ${draft.vis.phone ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
+              {draft.vis.phone ? 'Visible' : 'Hidden'}
+            </span>
+          </div>
+        </div>
+        <input type="tel" value={draft.phone} onChange={setField('phone')}
+          placeholder="+1 (416) 000-0000"
+          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">LinkedIn</label>
           <div className="flex items-center gap-2">
-            <Toggle
-              value={draft.vis.linkedin}
-              onChange={setVis('linkedin')}
-              colorOn="bg-[#1A6FBF]"
-              colorOff="bg-gray-300"
-            />
+            <Toggle value={draft.vis.linkedin} onChange={setVis('linkedin')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
             <span className={`text-xs font-medium w-10 ${draft.vis.linkedin ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
               {draft.vis.linkedin ? 'Visible' : 'Hidden'}
             </span>
@@ -239,12 +294,7 @@ function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">GitHub</label>
           <div className="flex items-center gap-2">
-            <Toggle
-              value={draft.vis.github}
-              onChange={setVis('github')}
-              colorOn="bg-[#1A6FBF]"
-              colorOff="bg-gray-300"
-            />
+            <Toggle value={draft.vis.github} onChange={setVis('github')} colorOn="bg-[#1A6FBF]" colorOff="bg-gray-300" />
             <span className={`text-xs font-medium w-10 ${draft.vis.github ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
               {draft.vis.github ? 'Visible' : 'Hidden'}
             </span>
@@ -319,11 +369,17 @@ export default function ProfilePage({ params }) {
         linkedin: member.linkedinUrl ?? '',
         github: member.githubUrl ?? '',
         status: member.status ?? 'student',
+        company: member.company ?? '',
+        occupation: member.occupation ?? '',
+        phone: member.phone ?? '',
+        school: member.school ?? '',
         vis: {
           bio: pv.bio !== false,
-          // Default to hidden if no value has been saved yet for empty fields
           linkedin: member.linkedinUrl ? pv.linkedin !== false : false,
           github: member.githubUrl ? pv.github !== false : false,
+          company: member.company ? pv.company !== false : false,
+          occupation: member.occupation ? pv.occupation !== false : false,
+          phone: false, // phone always hidden by default
         },
       })
     }
@@ -349,6 +405,10 @@ export default function ProfilePage({ params }) {
         linkedinUrl: draft.linkedin || null,
         githubUrl: draft.github || null,
         status: draft.status,
+        company: draft.company || null,
+        occupation: draft.occupation || null,
+        phone: draft.phone || null,
+        school: draft.school || null,
         profileVisibility: draft.vis,
       }
     : member
@@ -414,7 +474,6 @@ export default function ProfilePage({ params }) {
                       <ReadSidebar
                         member={displayMember}
                         isOwn={isOwn && mode === 'read'}
-                        isPreview={isOwn && mode === 'preview'}
                         isExec={isExec}
                         onEdit={() => setMode('edit')}
                       />

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -42,6 +42,22 @@ function ExecutiveBadge() {
   )
 }
 
+// Sliding segmented toggle for two named options (e.g. Student/Graduate)
+function SlidingSegmented({ value, options, onChange }) {
+  const idx = options.findIndex(o => o.value === value)
+  return (
+    <div className="relative inline-flex rounded-full border border-border overflow-hidden text-xs font-medium">
+      <span className={`absolute inset-y-0 w-1/2 transition-all duration-200 ${idx === 0 ? 'left-0' : 'left-1/2'} ${idx === 0 ? 'bg-[#1A6FBF]' : 'bg-orange-400'}`} />
+      {options.map((opt, i) => (
+        <button key={String(opt.value)} type="button" onClick={() => onChange(opt.value)}
+          className={`relative z-10 px-4 py-1.5 transition-colors ${i > 0 ? 'border-l border-border' : ''} ${opt.value === value ? 'text-white' : 'text-text-hint'}`}>
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
 // iOS-style toggle switch
 function Toggle({ value, onChange, colorOn = 'bg-[#1A6FBF]', colorOff = 'bg-gray-300' }) {
   return (
@@ -67,7 +83,7 @@ function IconMonitor({ className = 'size-4' }) {
 }
 
 // Read view — shown to other members, or as "Preview" for own profile
-function ReadSidebar({ member, isOwn, isExec, onEdit }) {
+function ReadSidebar({ member, isOwn, isPreview, isExec, onEdit }) {
   const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
   const v = member.profileVisibility ?? {}
 
@@ -87,12 +103,13 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
         {isExec && <ExecutiveBadge />}
       </div>
 
-      {/* Bio always shown when visibility is on, even if empty */}
-      {v.bio !== false && (
+      {v.bio !== false ? (
         <p className="text-sm text-text-secondary leading-relaxed min-h-[1.25rem] whitespace-pre-wrap">
           {member.bio ?? ''}
         </p>
-      )}
+      ) : isPreview && member.bio ? (
+        <p className="text-xs text-text-hint italic">🔒 Bio is hidden from others</p>
+      ) : null}
 
       <div className="flex flex-col gap-1 text-sm text-text-secondary">
         {member.school && <span>{member.school}</span>}
@@ -167,19 +184,13 @@ function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave
           className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
       </div>
 
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-2">
         <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Status</label>
-        <div className="flex items-center gap-2">
-          <Toggle
-            value={draft.status === 'student'}
-            onChange={(v) => onDraftChange({ ...draft, status: v ? 'student' : 'graduate' })}
-            colorOn="bg-[#1A6FBF]"
-            colorOff="bg-orange-400"
-          />
-          <span className={`text-xs font-medium w-14 ${draft.status === 'student' ? 'text-[#1A6FBF]' : 'text-orange-500'}`}>
-            {draft.status === 'student' ? 'Student' : 'Graduate'}
-          </span>
-        </div>
+        <SlidingSegmented
+          options={[{ value: 'student', label: 'Student' }, { value: 'graduate', label: 'Graduate' }]}
+          value={draft.status}
+          onChange={(v) => onDraftChange({ ...draft, status: v })}
+        />
       </div>
 
       <div className="flex flex-col gap-1">
@@ -403,6 +414,7 @@ export default function ProfilePage({ params }) {
                       <ReadSidebar
                         member={displayMember}
                         isOwn={isOwn && mode === 'read'}
+                        isPreview={isOwn && mode === 'preview'}
                         isExec={isExec}
                         onEdit={() => setMode('edit')}
                       />

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -42,15 +42,16 @@ function ExecutiveBadge() {
   )
 }
 
-// Sliding pill toggle — thumb slides between two options
-function SlidingToggle({ options, value, onChange }) {
-  const idx = options.findIndex(o => o.value === value)
+function SegmentedToggle({ options, value, onChange }) {
   return (
-    <div className="relative inline-flex rounded-full border border-border overflow-hidden text-xs font-medium">
-      <span className={`absolute inset-y-0 w-1/2 bg-text-primary transition-all duration-200 ${idx === 0 ? 'left-0' : 'left-1/2'}`} />
-      {options.map((opt) => (
+    <div className="inline-flex rounded-full border border-border overflow-hidden text-xs font-medium">
+      {options.map((opt, i) => (
         <button key={String(opt.value)} type="button" onClick={() => onChange(opt.value)}
-          className={`relative z-10 px-3 py-1 transition-colors ${opt.value === value ? 'text-bg-base' : 'text-text-hint'}`}>
+          className={`px-3 py-1 transition-colors ${i > 0 ? 'border-l border-border' : ''} ${
+            opt.value === value
+              ? 'bg-link-bg text-link'
+              : 'bg-transparent text-text-hint hover:text-text-secondary'
+          }`}>
           {opt.label}
         </button>
       ))}
@@ -78,10 +79,6 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
         <StatusBadge status={member.status} />
         {isExec && <ExecutiveBadge />}
       </div>
-
-      {v.bio !== false && member.bio && (
-        <p className="text-sm text-text-secondary leading-relaxed">{member.bio}</p>
-      )}
 
       <div className="flex flex-col gap-1 text-sm text-text-secondary">
         {member.school && <span>{member.school}</span>}
@@ -191,13 +188,13 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving, saveError })
 
       <div className="flex flex-col gap-2">
         <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Status</label>
-        <SlidingToggle options={STATUS_OPTIONS} value={form.status} onChange={(v) => setForm(f => ({ ...f, status: v }))} />
+        <SegmentedToggle options={STATUS_OPTIONS} value={form.status} onChange={(v) => setForm(f => ({ ...f, status: v }))} />
       </div>
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Bio</label>
-          <SlidingToggle options={VIS_OPTIONS} value={visibility.bio} onChange={setVis('bio')} />
+          <SegmentedToggle options={VIS_OPTIONS} value={visibility.bio} onChange={setVis('bio')} />
         </div>
         <textarea value={form.bio} onChange={(e) => setForm(f => ({ ...f, bio: e.target.value.slice(0, 300) }))}
           placeholder="Tell others about yourself..."
@@ -209,7 +206,7 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving, saveError })
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">LinkedIn</label>
-          <SlidingToggle options={VIS_OPTIONS} value={visibility.linkedin} onChange={setVis('linkedin')} />
+          <SegmentedToggle options={VIS_OPTIONS} value={visibility.linkedin} onChange={setVis('linkedin')} />
         </div>
         <input type="url" value={form.linkedin} onChange={setField('linkedin')}
           placeholder="https://linkedin.com/in/..."
@@ -219,7 +216,7 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving, saveError })
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">GitHub</label>
-          <SlidingToggle options={VIS_OPTIONS} value={visibility.github} onChange={setVis('github')} />
+          <SegmentedToggle options={VIS_OPTIONS} value={visibility.github} onChange={setVis('github')} />
         </div>
         <input type="url" value={form.github} onChange={setField('github')}
           placeholder="https://github.com/..."
@@ -317,6 +314,10 @@ export default function ProfilePage({ params }) {
     setMode('preview')
   }
 
+  const showBio = mode !== 'edit'
+    && displayMember?.bio
+    && displayMember?.profileVisibility?.bio !== false
+
   return (
     <RoleGuard>
       <main className="min-h-screen bg-bg-base">
@@ -363,6 +364,11 @@ export default function ProfilePage({ params }) {
                   </div>
 
                   <div className="flex-1 min-w-0 flex flex-col gap-8">
+                    {showBio && (
+                      <section>
+                        <p className="text-sm text-text-secondary leading-relaxed">{displayMember.bio}</p>
+                      </section>
+                    )}
                     <section>
                       <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Activity</h2>
                       <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -30,7 +30,7 @@ function Avatar({ member }) {
 function StatusBadge({ status }) {
   const isStudent = status !== 'graduate'
   return (
-    <span className={`text-xs font-medium px-2 py-0.5 rounded ${isStudent ? 'bg-[#F0F4FF] text-[#1A6FBF]' : 'bg-[#F3F3F3] text-[#555555]'}`}>
+    <span className={`text-xs font-medium px-2 py-0.5 rounded ${isStudent ? 'bg-[#F0F4FF] text-[#1A6FBF]' : 'bg-[#FFF4EC] text-orange-500'}`}>
       {isStudent ? 'Student' : 'Graduate'}
     </span>
   )
@@ -42,20 +42,27 @@ function ExecutiveBadge() {
   )
 }
 
-function SegmentedToggle({ options, value, onChange }) {
+// iOS-style toggle switch
+function Toggle({ value, onChange, colorOn = 'bg-[#1A6FBF]', colorOff = 'bg-gray-300' }) {
   return (
-    <div className="inline-flex rounded-full border border-border overflow-hidden text-xs font-medium">
-      {options.map((opt, i) => (
-        <button key={String(opt.value)} type="button" onClick={() => onChange(opt.value)}
-          className={`px-3 py-1 transition-colors ${i > 0 ? 'border-l border-border' : ''} ${
-            opt.value === value
-              ? 'bg-link-bg text-link'
-              : 'bg-transparent text-text-hint hover:text-text-secondary'
-          }`}>
-          {opt.label}
-        </button>
-      ))}
-    </div>
+    <button
+      type="button"
+      role="switch"
+      aria-checked={value}
+      onClick={() => onChange(!value)}
+      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none ${value ? colorOn : colorOff}`}
+    >
+      <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform duration-200 ${value ? 'translate-x-5' : 'translate-x-0.5'}`} />
+    </button>
+  )
+}
+
+function IconMonitor({ className = 'size-4' }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8M12 17v4" />
+    </svg>
   )
 }
 
@@ -79,6 +86,13 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
         <StatusBadge status={member.status} />
         {isExec && <ExecutiveBadge />}
       </div>
+
+      {/* Bio always shown when visibility is on, even if empty */}
+      {v.bio !== false && (
+        <p className="text-sm text-text-secondary leading-relaxed min-h-[1.25rem] whitespace-pre-wrap">
+          {member.bio ?? ''}
+        </p>
+      )}
 
       <div className="flex flex-col gap-1 text-sm text-text-secondary">
         {member.school && <span>{member.school}</span>}
@@ -121,53 +135,20 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
   )
 }
 
-const STATUS_OPTIONS = [
-  { value: 'student', label: 'Student' },
-  { value: 'graduate', label: 'Graduate' },
-]
-const VIS_OPTIONS = [
-  { value: true, label: 'Visible' },
-  { value: false, label: 'Hidden' },
-]
-
-// Edit view — own profile only
-function EditSidebar({ member, onCancel, onPreview, onSave, saving, saveError }) {
+// Edit view — controlled by parent draft state, own profile only
+function EditSidebar({ member, draft, onDraftChange, onPreview, onCancel, onSave, saving, saveError }) {
   const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
-  const defaultVisibility = member.profileVisibility ?? { bio: true, linkedin: true, github: true }
 
-  const [form, setForm] = useState({
-    nickname: member.nickname ?? '',
-    bio: member.bio ?? '',
-    linkedin: member.linkedinUrl ?? '',
-    github: member.githubUrl ?? '',
-    status: member.status ?? 'student',
-  })
-  const [visibility, setVisibility] = useState({
-    bio: defaultVisibility.bio !== false,
-    linkedin: defaultVisibility.linkedin !== false,
-    github: defaultVisibility.github !== false,
-  })
-
-  const setField = (key) => (e) => setForm(f => ({ ...f, [key]: e.target.value }))
-  const setVis = (key) => (val) => setVisibility(v => ({ ...v, [key]: val }))
+  const setField = (key) => (e) => onDraftChange({ ...draft, [key]: e.target.value })
+  const setVis = (key) => (val) => onDraftChange({ ...draft, vis: { ...draft.vis, [key]: val } })
 
   const handleSave = () => onSave({
-    nickname: form.nickname || null,
-    bio: form.bio || null,
-    linkedin: form.linkedin || null,
-    github: form.github || null,
-    status: form.status,
-    profile_visibility: visibility,
-  })
-
-  // Pass current form state to parent so preview reflects unsaved changes
-  const handlePreview = () => onPreview({
-    nickname: form.nickname || null,
-    bio: form.bio || null,
-    linkedinUrl: form.linkedin || null,
-    githubUrl: form.github || null,
-    status: form.status,
-    profileVisibility: visibility,
+    nickname: draft.nickname || null,
+    bio: draft.bio || null,
+    linkedin: draft.linkedin || null,
+    github: draft.github || null,
+    status: draft.status,
+    profile_visibility: draft.vis,
   })
 
   return (
@@ -181,34 +162,64 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving, saveError })
 
       <div className="flex flex-col gap-1">
         <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Nickname</label>
-        <input type="text" value={form.nickname} onChange={setField('nickname')}
+        <input type="text" value={draft.nickname} onChange={setField('nickname')}
           placeholder="Add a nickname..."
           className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
       </div>
 
-      <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
         <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Status</label>
-        <SegmentedToggle options={STATUS_OPTIONS} value={form.status} onChange={(v) => setForm(f => ({ ...f, status: v }))} />
+        <div className="flex items-center gap-2">
+          <Toggle
+            value={draft.status === 'student'}
+            onChange={(v) => onDraftChange({ ...draft, status: v ? 'student' : 'graduate' })}
+            colorOn="bg-[#1A6FBF]"
+            colorOff="bg-orange-400"
+          />
+          <span className={`text-xs font-medium w-14 ${draft.status === 'student' ? 'text-[#1A6FBF]' : 'text-orange-500'}`}>
+            {draft.status === 'student' ? 'Student' : 'Graduate'}
+          </span>
+        </div>
       </div>
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Bio</label>
-          <SegmentedToggle options={VIS_OPTIONS} value={visibility.bio} onChange={setVis('bio')} />
+          <div className="flex items-center gap-2">
+            <Toggle
+              value={draft.vis.bio}
+              onChange={setVis('bio')}
+              colorOn="bg-[#1A6FBF]"
+              colorOff="bg-gray-300"
+            />
+            <span className={`text-xs font-medium w-10 ${draft.vis.bio ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
+              {draft.vis.bio ? 'Visible' : 'Hidden'}
+            </span>
+          </div>
         </div>
-        <textarea value={form.bio} onChange={(e) => setForm(f => ({ ...f, bio: e.target.value.slice(0, 300) }))}
+        <textarea value={draft.bio} onChange={(e) => onDraftChange({ ...draft, bio: e.target.value.slice(0, 300) })}
           placeholder="Tell others about yourself..."
           rows={4}
           className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary resize-none focus:outline-none focus:border-accent" />
-        <p className="text-xs text-text-hint text-right">{form.bio.length} / 300</p>
+        <p className="text-xs text-text-hint text-right">{draft.bio.length} / 300</p>
       </div>
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">LinkedIn</label>
-          <SegmentedToggle options={VIS_OPTIONS} value={visibility.linkedin} onChange={setVis('linkedin')} />
+          <div className="flex items-center gap-2">
+            <Toggle
+              value={draft.vis.linkedin}
+              onChange={setVis('linkedin')}
+              colorOn="bg-[#1A6FBF]"
+              colorOff="bg-gray-300"
+            />
+            <span className={`text-xs font-medium w-10 ${draft.vis.linkedin ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
+              {draft.vis.linkedin ? 'Visible' : 'Hidden'}
+            </span>
+          </div>
         </div>
-        <input type="url" value={form.linkedin} onChange={setField('linkedin')}
+        <input type="url" value={draft.linkedin} onChange={setField('linkedin')}
           placeholder="https://linkedin.com/in/..."
           className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
       </div>
@@ -216,9 +227,19 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving, saveError })
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">GitHub</label>
-          <SegmentedToggle options={VIS_OPTIONS} value={visibility.github} onChange={setVis('github')} />
+          <div className="flex items-center gap-2">
+            <Toggle
+              value={draft.vis.github}
+              onChange={setVis('github')}
+              colorOn="bg-[#1A6FBF]"
+              colorOff="bg-gray-300"
+            />
+            <span className={`text-xs font-medium w-10 ${draft.vis.github ? 'text-[#1A6FBF]' : 'text-text-hint'}`}>
+              {draft.vis.github ? 'Visible' : 'Hidden'}
+            </span>
+          </div>
         </div>
-        <input type="url" value={form.github} onChange={setField('github')}
+        <input type="url" value={draft.github} onChange={setField('github')}
           placeholder="https://github.com/..."
           className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
       </div>
@@ -233,7 +254,7 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving, saveError })
           {saving ? 'Saving…' : 'Save Changes'}
         </button>
         <div className="flex gap-2">
-          <button type="button" onClick={handlePreview}
+          <button type="button" onClick={onPreview}
             className="flex-1 px-4 py-2 rounded border border-border text-sm text-text-secondary hover:border-border-strong transition-colors">
             Preview
           </button>
@@ -257,7 +278,8 @@ export default function ProfilePage({ params }) {
   const [mode, setMode] = useState('read')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState(null)
-  const [previewDraft, setPreviewDraft] = useState(null)
+  // Lifted form state — persists across edit/preview switches
+  const [draft, setDraft] = useState(null)
   const initializedRef = useRef(false)
 
   useEffect(() => {
@@ -276,6 +298,26 @@ export default function ProfilePage({ params }) {
     return () => { cancelled = true }
   }, [id])
 
+  // Initialize draft from member data (once on load, reset after save)
+  useEffect(() => {
+    if (member && draft === null) {
+      const pv = member.profileVisibility ?? {}
+      setDraft({
+        nickname: member.nickname ?? '',
+        bio: member.bio ?? '',
+        linkedin: member.linkedinUrl ?? '',
+        github: member.githubUrl ?? '',
+        status: member.status ?? 'student',
+        vis: {
+          bio: pv.bio !== false,
+          // Default to hidden if no value has been saved yet for empty fields
+          linkedin: member.linkedinUrl ? pv.linkedin !== false : false,
+          github: member.githubUrl ? pv.github !== false : false,
+        },
+      })
+    }
+  }, [member, draft])
+
   // Auto-enter edit mode once we confirm own profile
   useEffect(() => {
     if (!initializedRef.current && member && user && user.id === id) {
@@ -287,9 +329,17 @@ export default function ProfilePage({ params }) {
   const isOwn = user?.id === id
   const isExec = member?.role === 'executive' || member?.role === 'admin'
 
-  // In preview mode, merge saved member with unsaved form values
-  const displayMember = (mode === 'preview' && previewDraft)
-    ? { ...member, ...previewDraft }
+  // In preview mode, show draft values instead of saved DB values
+  const displayMember = (mode === 'preview' && draft && member)
+    ? {
+        ...member,
+        nickname: draft.nickname || null,
+        bio: draft.bio || null,
+        linkedinUrl: draft.linkedin || null,
+        githubUrl: draft.github || null,
+        status: draft.status,
+        profileVisibility: draft.vis,
+      }
     : member
 
   const handleSave = async (fields) => {
@@ -299,7 +349,7 @@ export default function ProfilePage({ params }) {
       await updateMyProfile(fields)
       const updated = await fetchMemberById(id)
       setMember(updated)
-      setPreviewDraft(null)
+      setDraft(null) // triggers re-init from updated member data
       setMode('edit')
     } catch (err) {
       console.error('Failed to save profile:', err)
@@ -308,15 +358,6 @@ export default function ProfilePage({ params }) {
       setSaving(false)
     }
   }
-
-  const handlePreview = (draft) => {
-    setPreviewDraft(draft)
-    setMode('preview')
-  }
-
-  const showBio = mode !== 'edit'
-    && displayMember?.bio
-    && displayMember?.profileVisibility?.bio !== false
 
   return (
     <RoleGuard>
@@ -334,7 +375,10 @@ export default function ProfilePage({ params }) {
               <>
                 {isOwn && mode === 'preview' && (
                   <div className="mb-6 flex items-center justify-between px-4 py-2.5 rounded-lg bg-bg-layer1 border border-border text-sm">
-                    <span className="text-text-secondary">👁 This is how others see your profile</span>
+                    <span className="flex items-center gap-2 text-text-secondary">
+                      <IconMonitor className="size-4 shrink-0" />
+                      This is how others see your profile
+                    </span>
                     <button type="button" onClick={() => setMode('edit')}
                       className="text-accent font-medium hover:opacity-80 transition-opacity">
                       ← Back to Edit
@@ -344,10 +388,12 @@ export default function ProfilePage({ params }) {
 
                 <div className="flex flex-col md:flex-row gap-8 md:gap-12 md:items-start">
                   <div className="w-full md:w-64 lg:w-72 md:flex-shrink-0">
-                    {isOwn && mode === 'edit' ? (
+                    {isOwn && mode === 'edit' && draft ? (
                       <EditSidebar
                         member={member}
-                        onPreview={handlePreview}
+                        draft={draft}
+                        onDraftChange={setDraft}
+                        onPreview={() => setMode('preview')}
                         onCancel={() => setMode('read')}
                         onSave={handleSave}
                         saving={saving}
@@ -364,11 +410,6 @@ export default function ProfilePage({ params }) {
                   </div>
 
                   <div className="flex-1 min-w-0 flex flex-col gap-8">
-                    {showBio && (
-                      <section>
-                        <p className="text-sm text-text-secondary leading-relaxed">{displayMember.bio}</p>
-                      </section>
-                    )}
                     <section>
                       <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Activity</h2>
                       <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -1,207 +1,331 @@
 'use client'
+import { useState, useEffect } from 'react'
+import React from 'react'
+import Link from 'next/link'
 import RoleGuard from '@/components/auth/RoleGuard'
-import React, { useEffect, useState } from 'react'
-import { fetchMemberById } from '@/services/membersService' //TODO: verify 'badges' column exists in supabase and add fetchMemberBadges()
-import { cohortLabel } from '@/utils/cohort'
 import { useAuth } from '@/hooks/useAuth'
+import { fetchMemberById, updateMyProfile } from '@/services/membersService'
+import { cohortLabel } from '@/utils/cohort'
+import { IconLinkedIn, IconGitHub } from '@/components/ui/SocialIcons'
 
 function Avatar({ member }) {
-    const initial = (member?.firstName?.[0] ?? '?').toUpperCase()
-    return (
-    <div className="relative w-24 h-24 rounded-full flex-shrink-0 group">
+  const initial = (member?.firstName?.[0] ?? '?').toUpperCase()
+  return (
+    <div className="w-full aspect-square rounded-full overflow-hidden bg-bg-layer1 flex items-center justify-center">
       {member.avatarUrl ? (
         <img
           src={member.avatarUrl}
           alt={`${member.firstName} ${member.lastName}`}
-          className="w-full h-full rounded-full object-cover ring-2 ring-transparent group-hover:ring-accent transition-all"
+          referrerPolicy="no-referrer"
+          className="w-full h-full object-cover"
         />
       ) : (
-        <div className="w-full h-full rounded-full bg-bg-elevated flex items-center justify-center font-montserrat font-bold text-2xl text-text-secondary ring-2 ring-transparent group-hover:ring-accent transition-all">
-          {initial}
-        </div>
+        <span className="font-montserrat font-bold text-5xl text-text-secondary">{initial}</span>
       )}
     </div>
   )
 }
 
-function ExecutiveBadge() {
-  return (
-    <span className="text-xs font-medium px-2 py-0.5 rounded bg-success-bg text-success">
-      Executive
-    </span>
-  )
-}
-
 function StatusBadge({ status }) {
-  const isStudent = status === 'student'
+  const isStudent = status !== 'graduate'
   return (
-    <span className={`text-xs font-medium px-2 py-0.5 rounded ${isStudent ? 'bg-link-bg text-link' : 'bg-link-bg text-gold'}`}>
+    <span className={`text-xs font-medium px-2 py-0.5 rounded ${isStudent ? 'bg-[#F0F4FF] text-[#1A6FBF]' : 'bg-[#F3F3F3] text-[#555555]'}`}>
       {isStudent ? 'Student' : 'Graduate'}
     </span>
   )
 }
 
-// function BadgeCard({ badge }) {
-//   return (
-//     <div
-//       className="flex flex-col items-center gap-2 p-4 rounded-lg bg-bg-base border border-border relative"
-//       style={{ opacity: badge.unlocked ? 1 : 0.35 }}
-//     >
-//       <span className="text-2xl">{badge.icon}</span>
-//       <span className="text-xs text-center font-medium text-text-secondary">{badge.label}</span>
-//       {!badge.unlocked && (
-//         <span className="absolute top-2 right-2 text-xs text-text-hint">🔒</span>
-//       )}
-//     </div>
-//   )
-// }
+function ExecutiveBadge() {
+  return (
+    <span className="text-xs font-medium px-2 py-0.5 rounded bg-success-bg text-success">Executive</span>
+  )
+}
+
+function VisibilityToggle({ visible, onChange }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!visible)}
+      className={`text-[11px] flex items-center gap-1 px-2 py-0.5 rounded border transition-colors ${
+        visible ? 'border-border text-text-secondary hover:border-border-strong' : 'border-border text-text-hint bg-bg-layer1'
+      }`}
+    >
+      {visible ? '👁 Visible' : '🔒 Hidden'}
+    </button>
+  )
+}
+
+function StatusToggle({ value, onChange }) {
+  const isStudent = value !== 'graduate'
+  return (
+    <div className="flex items-center gap-2">
+      <span className={`text-sm ${isStudent ? 'text-[#1A6FBF] font-medium' : 'text-text-hint'}`}>Student</span>
+      <button
+        type="button"
+        onClick={() => onChange(isStudent ? 'graduate' : 'student')}
+        className={`relative w-10 h-5 rounded-full transition-colors duration-200 ${isStudent ? 'bg-[#1A6FBF]' : 'bg-text-secondary'}`}
+      >
+        <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform duration-200 ${isStudent ? 'translate-x-0.5' : 'translate-x-5'}`} />
+      </button>
+      <span className={`text-sm ${!isStudent ? 'text-text-secondary font-medium' : 'text-text-hint'}`}>Graduate</span>
+    </div>
+  )
+}
+
+function ReadSidebar({ member, isOwn, isExec, onEdit }) {
+  const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
+  const v = member.profileVisibility
+
+  return (
+    <aside className="flex flex-col gap-4">
+      <Avatar member={member} />
+
+      <div>
+        <h1 className="font-montserrat font-bold text-2xl text-text-primary leading-tight">{fullName}</h1>
+        {member.nickname && (
+          <p className="text-text-hint text-base mt-0.5">{member.nickname}</p>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        <StatusBadge status={member.status} />
+        {isExec && <ExecutiveBadge />}
+      </div>
+
+      {v.bio !== false && member.bio && (
+        <p className="text-sm text-text-secondary leading-relaxed">{member.bio}</p>
+      )}
+
+      <div className="flex flex-col gap-1 text-sm text-text-secondary">
+        {member.school && <span>{member.school}</span>}
+        {member.cohort && <span>{cohortLabel(member.cohort)}</span>}
+      </div>
+
+      {(v.linkedin !== false && member.linkedinUrl) || (v.github !== false && member.githubUrl) ? (
+        <div className="flex flex-col gap-2 pt-1">
+          {v.linkedin !== false && member.linkedinUrl && (
+            <a href={member.linkedinUrl} target="_blank" rel="noopener noreferrer"
+              className="flex items-center gap-2 text-sm text-text-secondary hover:text-[#0A66C2] transition-colors">
+              <IconLinkedIn className="size-4 shrink-0" />
+              <span className="truncate">LinkedIn</span>
+            </a>
+          )}
+          {v.github !== false && member.githubUrl && (
+            <a href={member.githubUrl} target="_blank" rel="noopener noreferrer"
+              className="flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors">
+              <IconGitHub className="size-4 shrink-0" />
+              <span className="truncate">GitHub</span>
+            </a>
+          )}
+        </div>
+      ) : null}
+
+      {isOwn && (
+        <div className="flex flex-col gap-1 text-xs text-text-hint">
+          {v.bio === false && member.bio && <span>🔒 Bio hidden from others</span>}
+          {v.linkedin === false && member.linkedinUrl && <span>🔒 LinkedIn hidden from others</span>}
+          {v.github === false && member.githubUrl && <span>🔒 GitHub hidden from others</span>}
+        </div>
+      )}
+
+      {isOwn && (
+        <button onClick={onEdit}
+          className="w-full mt-1 px-4 py-1.5 rounded border border-border text-sm text-text-secondary hover:border-border-strong hover:text-text-primary transition-colors">
+          Edit Profile
+        </button>
+      )}
+    </aside>
+  )
+}
+
+function EditSidebar({ member, onCancel, onSave, saving }) {
+  const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
+  const [form, setForm] = useState({
+    nickname: member.nickname ?? '',
+    bio: member.bio ?? '',
+    linkedin: member.linkedinUrl ?? '',
+    github: member.githubUrl ?? '',
+    status: member.status ?? 'student',
+  })
+  const [visibility, setVisibility] = useState({
+    bio: member.profileVisibility.bio !== false,
+    linkedin: member.profileVisibility.linkedin !== false,
+    github: member.profileVisibility.github !== false,
+  })
+
+  const setField = (key) => (e) => setForm(f => ({ ...f, [key]: e.target.value }))
+  const setVis = (key) => (val) => setVisibility(v => ({ ...v, [key]: val }))
+
+  const handleSave = () => onSave({
+    nickname: form.nickname || null,
+    bio: form.bio || null,
+    linkedin: form.linkedin || null,
+    github: form.github || null,
+    status: form.status,
+    profile_visibility: visibility,
+  })
+
+  return (
+    <aside className="flex flex-col gap-5">
+      <Avatar member={member} />
+
+      <div>
+        <p className="font-montserrat font-bold text-2xl text-text-primary leading-tight">{fullName}</p>
+        <p className="text-xs text-text-hint mt-0.5">Name is managed by admin</p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Nickname</label>
+        <input type="text" value={form.nickname} onChange={setField('nickname')}
+          placeholder="Add a nickname..."
+          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Status</label>
+        <StatusToggle value={form.status} onChange={(v) => setForm(f => ({ ...f, status: v }))} />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Bio</label>
+          <VisibilityToggle visible={visibility.bio} onChange={setVis('bio')} />
+        </div>
+        <textarea value={form.bio} onChange={(e) => setForm(f => ({ ...f, bio: e.target.value.slice(0, 300) }))}
+          placeholder="Tell others about yourself..."
+          rows={4}
+          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary resize-none focus:outline-none focus:border-accent" />
+        <p className="text-xs text-text-hint text-right">{form.bio.length} / 300</p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">LinkedIn</label>
+          <VisibilityToggle visible={visibility.linkedin} onChange={setVis('linkedin')} />
+        </div>
+        <input type="url" value={form.linkedin} onChange={setField('linkedin')}
+          placeholder="https://linkedin.com/in/..."
+          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <label className="text-xs font-medium text-text-hint uppercase tracking-wide">GitHub</label>
+          <VisibilityToggle visible={visibility.github} onChange={setVis('github')} />
+        </div>
+        <input type="url" value={form.github} onChange={setField('github')}
+          placeholder="https://github.com/..."
+          className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
+      </div>
+
+      <div className="flex gap-2 pt-1">
+        <button type="button" onClick={onCancel}
+          className="flex-1 px-4 py-2 rounded border border-border text-sm text-text-secondary hover:border-border-strong transition-colors">
+          Cancel
+        </button>
+        <button type="button" onClick={handleSave} disabled={saving}
+          className="flex-1 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50">
+          {saving ? 'Saving…' : 'Save Changes'}
+        </button>
+      </div>
+    </aside>
+  )
+}
 
 export default function ProfilePage({ params }) {
-    const { id } = React.use(params)
-    const { user } = useAuth()
-    const [member, setMember] = useState(null)
-    const [badges, setBadges] = useState([])
-    const [loading, setLoading] = useState(true)
-    const [error, setError] = useState(null)
-    const fullName = `${member?.firstName ?? ''} ${member?.lastName ?? ''}`.trim()
-    const displayName = member?.nickname ? `${fullName} (${member.nickname})` : fullName
+  const { id } = React.use(params)
+  const { user } = useAuth()
+  const [member, setMember] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [editing, setEditing] = useState(false)
+  const [saving, setSaving] = useState(false)
 
-    useEffect(() => {
-        let cancelled = false
-        async function load() {
-            try {
-                // TODO: add fetchMemberBadges() later
-                const memberData = await fetchMemberById(id)
-                if (!cancelled) setMember(memberData)
-            }
-            catch (err) {
-                if (!cancelled) setError(err)
-            }
-            finally {
-                if (!cancelled) setLoading(false)
-            }
-        }
-        load()
-        return () => { cancelled = true }
-    }, [id])
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const data = await fetchMemberById(id)
+        if (!cancelled) setMember(data)
+      } catch (err) {
+        if (!cancelled) setError(err)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [id])
 
-    const isOwn = user?.id === id
-    const isExec = member?.role?.toLowerCase() === 'executive' || member?.role?.toLowerCase() === 'admin'
-    const visibility = member?.profile_visibility ?? {}
+  const isOwn = user?.id === id
+  const isExec = member?.role === 'executive' || member?.role === 'admin'
 
-    return (
-        <RoleGuard>
-            <main className="min-h-screen bg-bg-base">
-                {/*HEADER SECTION*/}
-                <section className="bg-bg-base border-b border-border py-8 px-6">
-                    <div className="max-w-[1200px] mx-auto">
-                        {loading && <p className="text-text-secondary">Loading profile…</p>}
-                        {error && <p className="text-accent">Couldn't load profile. Try refreshing.</p>}
-                        {!loading && !error && member && (
-                            <div className="flex items-start gap-6">
-                                <Avatar member={member} />
-                                <div className="flex-1 min-w-0">
-                                    {/* Name + badges */}
-                                    <div className="flex flex-wrap items-center gap-2 mb-1">
-                                        <h1 className="font-montserrat font-bold text-3xl text-text-primary">
-                                        {displayName}
-                                        </h1>
-                                        <StatusBadge status={member.status} />
-                                        {isExec && <ExecutiveBadge />}
-                                    </div>
-                
-                                    {/* School · Cohort */}
-                                    <p className="text-sm text-text-secondary mb-3">
-                                        {member.school}{member.cohort ? ` · ${cohortLabel(member.cohort)}` : ''}
-                                    </p>
-                    
-                                    {/* Social icons */}
-                                    <div className="flex items-center gap-3">
-                                        {visibility.linkedin !== false && member.linkedinUrl && (
-                                        <a
-                                            href={member.linkedinUrl}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            aria-label={`${displayName} on LinkedIn`}
-                                            className="text-text-secondary hover:text-link transition-colors"
-                                        >
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="M19 0h-14C2.2 0 0 2.2 0 5v14c0 2.8 2.2 5 5 5h14c2.8 0 5-2.2 5-5V5c0-2.8-2.2-5-5-5zM8 19H5V8h3v11zM6.5 6.7c-1 0-1.7-.8-1.7-1.7s.8-1.7 1.7-1.7 1.7.8 1.7 1.7-.7 1.7-1.7 1.7zM20 19h-3v-5.6c0-1.4-.5-2.3-1.8-2.3-1 0-1.6.7-1.8 1.3-.1.2-.1.5-.1.8V19h-3V8h3v1.3c.4-.6 1.1-1.5 2.7-1.5 2 0 3.5 1.3 3.5 4.1V19z" />
-                                            </svg>
-                                        </a>
-                                        )}
-                                        {visibility.github !== false && member.githubUrl && (
-                                        <a
-                                            href={member.githubUrl}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            aria-label={`${displayName} on GitHub`}
-                                            className="text-text-secondary hover:text-text-primary transition-colors"
-                                        >
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1-.7.1-.7.1-.7 1.2 0 1.9 1.2 1.9 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.7-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.2.5-2.3 1.3-3.1-.2-.4-.6-1.6 0-3.2 0 0 1-.3 3.4 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.7 1.6.2 2.8.1 3.2.7.9 1.3 1.9 1.3 3.2 0 4.6-2.8 5.6-5.5 5.9.5.4.9 1 .9 2.2v3.3c0 .3.1.7.8.6A12 12 0 0 0 12 .3" />
-                                            </svg>
-                                        </a>
-                                        )}
-                                    </div>
-                                </div>
-                                {/* Edit button — own profile only */}
-                                {isOwn && (
-                                    <button className="flex-shrink-0 text-sm font-medium px-4 py-2 rounded border border-border-strong text-text-secondary bg-transparent hover:border-text-primary hover:text-text-primary transition-colors">
-                                        Edit Profile
-                                    </button>
-                                )}
-                            </div>
-                        )}
+  const handleSave = async (fields) => {
+    setSaving(true)
+    try {
+      await updateMyProfile(fields)
+      const updated = await fetchMemberById(id)
+      setMember(updated)
+      setEditing(false)
+    } catch (err) {
+      console.error('Failed to save profile:', err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <RoleGuard>
+      <main className="min-h-screen bg-bg-base">
+        <div className="max-w-[1200px] mx-auto px-4 sm:px-6 pt-6 pb-16">
+          <Link href="/members" className="text-sm text-text-secondary hover:text-text-primary transition-colors">
+            ← Members
+          </Link>
+
+          <div className="mt-8">
+            {loading && <p className="text-text-secondary">Loading…</p>}
+            {error && <p className="text-accent">Couldn't load profile. Try refreshing.</p>}
+
+            {!loading && !error && member && (
+              <div className="flex flex-col md:flex-row gap-8 md:gap-12 md:items-start">
+                <div className="w-full md:w-64 lg:w-72 md:flex-shrink-0">
+                  {editing ? (
+                    <EditSidebar
+                      member={member}
+                      onCancel={() => setEditing(false)}
+                      onSave={handleSave}
+                      saving={saving}
+                    />
+                  ) : (
+                    <ReadSidebar
+                      member={member}
+                      isOwn={isOwn}
+                      isExec={isExec}
+                      onEdit={() => setEditing(true)}
+                    />
+                  )}
+                </div>
+
+                <div className="flex-1 min-w-0 flex flex-col gap-8">
+                  <section>
+                    <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Activity</h2>
+                    <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">
+                      <p className="text-sm text-text-hint">Coming soon</p>
                     </div>
-                </section>
+                  </section>
 
-                {!loading && !error && member && (
-                    <>
-                        {/* BIO */}
-                        {visibility.bio !== false && (
-                            <section className="border-b border-border py-8 px-6">
-                                <div className="max-w-[1200px] mx-auto">
-                                    <h2 className="font-montserrat font-semibold text-xl text-text-primary mb-3">About</h2>
-                                    {member.bio ? (
-                                        <p className="text-base leading-relaxed text-text-secondary">{member.bio}</p>
-                                    ) : (
-                                        <p className="text-base italic text-text-hint">This member hasn't added a bio yet.</p>
-                                    )}
-                                </div>
-                            </section>
-                        )}
-            
-                        {/* ACTIVITY HEATMAP — placeholder */}
-                        <section className="border-b border-border py-8 px-6">
-                            <div className="max-w-[1200px] mx-auto">
-                                <h2 className="font-montserrat font-semibold text-xl text-text-primary mb-3">Activity</h2>
-                                <div className="w-full rounded-lg bg-bg-elevated flex items-center justify-center py-10">
-                                <p className="text-sm text-text-hint">Coming soon</p>
-                                </div>
-                            </div>
-                        </section>
-            
-                        {/* BADGES */}
-                        <section className="py-8 px-6">
-                            <div className="max-w-[1200px] mx-auto">
-                                <h2 className="font-montserrat font-semibold text-xl text-text-primary mb-4">Achievements</h2>
-                                <p className="text-sm text-text-hint">Coming soon</p>
-                                {/* TODO: uncomment badge render when available */}
-                                {/* {badges.length === 0 ? (
-                                    <p className="text-sm italic text-text-hint">No achievements yet. Keep going!</p>
-                                    ) : (
-                                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
-                                        {badges.map((badge) => (
-                                            <BadgeCard key={badge.id} badge={badge} />
-                                        ))}
-                                    </div>
-                                )} */}
-                            </div>
-                        </section>
-                    </>
-                )}   
-            </main>
-        </RoleGuard>
-    )
+                  <section>
+                    <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Achievements</h2>
+                    <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">
+                      <p className="text-sm text-text-hint">Coming soon</p>
+                    </div>
+                  </section>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </main>
+    </RoleGuard>
+  )
 }

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -10,7 +10,6 @@ import { IconLinkedIn, IconGitHub } from '@/components/ui/SocialIcons'
 
 function Avatar({ member }) {
   const initial = (member?.firstName?.[0] ?? '?').toUpperCase()
-  // Google profile photos include a size param (e.g. =s96-c). Bump to s400 for higher quality.
   const src = member.avatarUrl?.replace(/=s\d+-c$/, '=s400-c') ?? member.avatarUrl
   return (
     <div className="w-full aspect-square rounded-full overflow-hidden bg-bg-layer1 flex items-center justify-center">
@@ -43,20 +42,15 @@ function ExecutiveBadge() {
   )
 }
 
-function SegmentedToggle({ options, value, onChange }) {
+// Sliding pill toggle — thumb slides between two options
+function SlidingToggle({ options, value, onChange }) {
+  const idx = options.findIndex(o => o.value === value)
   return (
-    <div className="inline-flex rounded-full border border-border overflow-hidden text-xs font-medium">
-      {options.map((opt, i) => (
-        <button
-          key={String(opt.value)}
-          type="button"
-          onClick={() => onChange(opt.value)}
-          className={`px-3 py-1 transition-colors ${i > 0 ? 'border-l border-border' : ''} ${
-            value === opt.value
-              ? 'bg-text-primary text-bg-base'
-              : 'text-text-hint hover:text-text-secondary bg-transparent'
-          }`}
-        >
+    <div className="relative inline-flex rounded-full border border-border overflow-hidden text-xs font-medium">
+      <span className={`absolute inset-y-0 w-1/2 bg-text-primary transition-all duration-200 ${idx === 0 ? 'left-0' : 'left-1/2'}`} />
+      {options.map((opt) => (
+        <button key={String(opt.value)} type="button" onClick={() => onChange(opt.value)}
+          className={`relative z-10 px-3 py-1 transition-colors ${opt.value === value ? 'text-bg-base' : 'text-text-hint'}`}>
           {opt.label}
         </button>
       ))}
@@ -130,8 +124,17 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
   )
 }
 
+const STATUS_OPTIONS = [
+  { value: 'student', label: 'Student' },
+  { value: 'graduate', label: 'Graduate' },
+]
+const VIS_OPTIONS = [
+  { value: true, label: 'Visible' },
+  { value: false, label: 'Hidden' },
+]
+
 // Edit view — own profile only
-function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
+function EditSidebar({ member, onCancel, onPreview, onSave, saving, saveError }) {
   const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
   const defaultVisibility = member.profileVisibility ?? { bio: true, linkedin: true, github: true }
 
@@ -160,6 +163,16 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
     profile_visibility: visibility,
   })
 
+  // Pass current form state to parent so preview reflects unsaved changes
+  const handlePreview = () => onPreview({
+    nickname: form.nickname || null,
+    bio: form.bio || null,
+    linkedinUrl: form.linkedin || null,
+    githubUrl: form.github || null,
+    status: form.status,
+    profileVisibility: visibility,
+  })
+
   return (
     <aside className="flex flex-col gap-5">
       <Avatar member={member} />
@@ -178,21 +191,13 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
 
       <div className="flex flex-col gap-2">
         <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Status</label>
-        <SegmentedToggle
-          options={[{ value: 'student', label: 'Student' }, { value: 'graduate', label: 'Graduate' }]}
-          value={form.status}
-          onChange={(v) => setForm(f => ({ ...f, status: v }))}
-        />
+        <SlidingToggle options={STATUS_OPTIONS} value={form.status} onChange={(v) => setForm(f => ({ ...f, status: v }))} />
       </div>
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">Bio</label>
-          <SegmentedToggle
-            options={[{ value: true, label: 'Visible' }, { value: false, label: 'Hidden' }]}
-            value={visibility.bio}
-            onChange={setVis('bio')}
-          />
+          <SlidingToggle options={VIS_OPTIONS} value={visibility.bio} onChange={setVis('bio')} />
         </div>
         <textarea value={form.bio} onChange={(e) => setForm(f => ({ ...f, bio: e.target.value.slice(0, 300) }))}
           placeholder="Tell others about yourself..."
@@ -204,11 +209,7 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">LinkedIn</label>
-          <SegmentedToggle
-            options={[{ value: true, label: 'Visible' }, { value: false, label: 'Hidden' }]}
-            value={visibility.linkedin}
-            onChange={setVis('linkedin')}
-          />
+          <SlidingToggle options={VIS_OPTIONS} value={visibility.linkedin} onChange={setVis('linkedin')} />
         </div>
         <input type="url" value={form.linkedin} onChange={setField('linkedin')}
           placeholder="https://linkedin.com/in/..."
@@ -218,25 +219,24 @@ function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
       <div className="flex flex-col gap-1">
         <div className="flex items-center justify-between">
           <label className="text-xs font-medium text-text-hint uppercase tracking-wide">GitHub</label>
-          <SegmentedToggle
-            options={[{ value: true, label: 'Visible' }, { value: false, label: 'Hidden' }]}
-            value={visibility.github}
-            onChange={setVis('github')}
-          />
+          <SlidingToggle options={VIS_OPTIONS} value={visibility.github} onChange={setVis('github')} />
         </div>
         <input type="url" value={form.github} onChange={setField('github')}
           placeholder="https://github.com/..."
           className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
       </div>
 
-      {/* Action buttons */}
+      {saveError && (
+        <p className="text-xs text-accent px-1">{saveError}</p>
+      )}
+
       <div className="flex flex-col gap-2 pt-1">
         <button type="button" onClick={handleSave} disabled={saving}
           className="w-full px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50">
           {saving ? 'Saving…' : 'Save Changes'}
         </button>
         <div className="flex gap-2">
-          <button type="button" onClick={onPreview}
+          <button type="button" onClick={handlePreview}
             className="flex-1 px-4 py-2 rounded border border-border text-sm text-text-secondary hover:border-border-strong transition-colors">
             Preview
           </button>
@@ -259,6 +259,8 @@ export default function ProfilePage({ params }) {
   // 'edit' | 'preview' | 'read'
   const [mode, setMode] = useState('read')
   const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState(null)
+  const [previewDraft, setPreviewDraft] = useState(null)
   const initializedRef = useRef(false)
 
   useEffect(() => {
@@ -288,18 +290,31 @@ export default function ProfilePage({ params }) {
   const isOwn = user?.id === id
   const isExec = member?.role === 'executive' || member?.role === 'admin'
 
+  // In preview mode, merge saved member with unsaved form values
+  const displayMember = (mode === 'preview' && previewDraft)
+    ? { ...member, ...previewDraft }
+    : member
+
   const handleSave = async (fields) => {
     setSaving(true)
+    setSaveError(null)
     try {
       await updateMyProfile(fields)
       const updated = await fetchMemberById(id)
       setMember(updated)
+      setPreviewDraft(null)
       setMode('edit')
     } catch (err) {
       console.error('Failed to save profile:', err)
+      setSaveError(err?.message ?? 'Failed to save. Please try again.')
     } finally {
       setSaving(false)
     }
+  }
+
+  const handlePreview = (draft) => {
+    setPreviewDraft(draft)
+    setMode('preview')
   }
 
   return (
@@ -315,46 +330,54 @@ export default function ProfilePage({ params }) {
             {error && <p className="text-accent">Couldn't load profile. Try refreshing.</p>}
 
             {!loading && !error && member && (
-              <div className="flex flex-col md:flex-row gap-8 md:gap-12 md:items-start">
-                <div className="w-full md:w-64 lg:w-72 md:flex-shrink-0">
-                  {isOwn && mode === 'edit' ? (
-                    <EditSidebar
-                      member={member}
-                      onPreview={() => setMode('preview')}
-                      onCancel={() => setMode('edit')}
-                      onSave={handleSave}
-                      saving={saving}
-                    />
-                  ) : (
-                    <ReadSidebar
-                      member={member}
-                      isOwn={isOwn && mode === 'preview'}
-                      isExec={isExec}
-                      onEdit={() => setMode('edit')}
-                    />
-                  )}
-                </div>
+              <>
+                {isOwn && mode === 'preview' && (
+                  <div className="mb-6 flex items-center justify-between px-4 py-2.5 rounded-lg bg-bg-layer1 border border-border text-sm">
+                    <span className="text-text-secondary">👁 This is how others see your profile</span>
+                    <button type="button" onClick={() => setMode('edit')}
+                      className="text-accent font-medium hover:opacity-80 transition-opacity">
+                      ← Back to Edit
+                    </button>
+                  </div>
+                )}
 
-                <div className="flex-1 min-w-0 flex flex-col gap-8">
-                  {isOwn && mode === 'preview' && (
-                    <div className="px-3 py-2 rounded bg-bg-layer1 border border-border text-sm text-text-secondary">
-                      👁 This is how others see your profile
-                    </div>
-                  )}
-                  <section>
-                    <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Activity</h2>
-                    <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">
-                      <p className="text-sm text-text-hint">Coming soon</p>
-                    </div>
-                  </section>
-                  <section>
-                    <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Achievements</h2>
-                    <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">
-                      <p className="text-sm text-text-hint">Coming soon</p>
-                    </div>
-                  </section>
+                <div className="flex flex-col md:flex-row gap-8 md:gap-12 md:items-start">
+                  <div className="w-full md:w-64 lg:w-72 md:flex-shrink-0">
+                    {isOwn && mode === 'edit' ? (
+                      <EditSidebar
+                        member={member}
+                        onPreview={handlePreview}
+                        onCancel={() => setMode('read')}
+                        onSave={handleSave}
+                        saving={saving}
+                        saveError={saveError}
+                      />
+                    ) : (
+                      <ReadSidebar
+                        member={displayMember}
+                        isOwn={isOwn && mode === 'read'}
+                        isExec={isExec}
+                        onEdit={() => setMode('edit')}
+                      />
+                    )}
+                  </div>
+
+                  <div className="flex-1 min-w-0 flex flex-col gap-8">
+                    <section>
+                      <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Activity</h2>
+                      <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">
+                        <p className="text-sm text-text-hint">Coming soon</p>
+                      </div>
+                    </section>
+                    <section>
+                      <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Achievements</h2>
+                      <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">
+                        <p className="text-sm text-text-hint">Coming soon</p>
+                      </div>
+                    </section>
+                  </div>
                 </div>
-              </div>
+              </>
             )}
           </div>
         </div>

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import React from 'react'
 import Link from 'next/link'
 import RoleGuard from '@/components/auth/RoleGuard'
@@ -72,9 +72,10 @@ function StatusToggle({ value, onChange }) {
   )
 }
 
+// Read view — shown to other members, or as "Preview" for own profile
 function ReadSidebar({ member, isOwn, isExec, onEdit }) {
   const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
-  const v = member.profileVisibility
+  const v = member.profileVisibility ?? {}
 
   return (
     <aside className="flex flex-col gap-4">
@@ -101,7 +102,7 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
         {member.cohort && <span>{cohortLabel(member.cohort)}</span>}
       </div>
 
-      {(v.linkedin !== false && member.linkedinUrl) || (v.github !== false && member.githubUrl) ? (
+      {((v.linkedin !== false && member.linkedinUrl) || (v.github !== false && member.githubUrl)) && (
         <div className="flex flex-col gap-2 pt-1">
           {v.linkedin !== false && member.linkedinUrl && (
             <a href={member.linkedinUrl} target="_blank" rel="noopener noreferrer"
@@ -118,28 +119,30 @@ function ReadSidebar({ member, isOwn, isExec, onEdit }) {
             </a>
           )}
         </div>
-      ) : null}
-
-      {isOwn && (
-        <div className="flex flex-col gap-1 text-xs text-text-hint">
-          {v.bio === false && member.bio && <span>🔒 Bio hidden from others</span>}
-          {v.linkedin === false && member.linkedinUrl && <span>🔒 LinkedIn hidden from others</span>}
-          {v.github === false && member.githubUrl && <span>🔒 GitHub hidden from others</span>}
-        </div>
       )}
 
       {isOwn && (
-        <button onClick={onEdit}
-          className="w-full mt-1 px-4 py-1.5 rounded border border-border text-sm text-text-secondary hover:border-border-strong hover:text-text-primary transition-colors">
-          Edit Profile
-        </button>
+        <>
+          <div className="flex flex-col gap-1 text-xs text-text-hint">
+            {v.bio === false && member.bio && <span>🔒 Bio hidden from others</span>}
+            {v.linkedin === false && member.linkedinUrl && <span>🔒 LinkedIn hidden from others</span>}
+            {v.github === false && member.githubUrl && <span>🔒 GitHub hidden from others</span>}
+          </div>
+          <button type="button" onClick={onEdit}
+            className="w-full mt-1 px-4 py-1.5 rounded border border-border text-sm text-text-secondary hover:border-border-strong hover:text-text-primary transition-colors">
+            ← Edit Profile
+          </button>
+        </>
       )}
     </aside>
   )
 }
 
-function EditSidebar({ member, onCancel, onSave, saving }) {
+// Edit view — own profile only
+function EditSidebar({ member, onCancel, onPreview, onSave, saving }) {
   const fullName = `${member.firstName ?? ''} ${member.lastName ?? ''}`.trim()
+  const defaultVisibility = member.profileVisibility ?? { bio: true, linkedin: true, github: true }
+
   const [form, setForm] = useState({
     nickname: member.nickname ?? '',
     bio: member.bio ?? '',
@@ -148,9 +151,9 @@ function EditSidebar({ member, onCancel, onSave, saving }) {
     status: member.status ?? 'student',
   })
   const [visibility, setVisibility] = useState({
-    bio: member.profileVisibility.bio !== false,
-    linkedin: member.profileVisibility.linkedin !== false,
-    github: member.profileVisibility.github !== false,
+    bio: defaultVisibility.bio !== false,
+    linkedin: defaultVisibility.linkedin !== false,
+    github: defaultVisibility.github !== false,
   })
 
   const setField = (key) => (e) => setForm(f => ({ ...f, [key]: e.target.value }))
@@ -218,15 +221,22 @@ function EditSidebar({ member, onCancel, onSave, saving }) {
           className="w-full px-3 py-1.5 rounded border border-border bg-bg-base text-sm text-text-primary focus:outline-none focus:border-accent" />
       </div>
 
-      <div className="flex gap-2 pt-1">
-        <button type="button" onClick={onCancel}
-          className="flex-1 px-4 py-2 rounded border border-border text-sm text-text-secondary hover:border-border-strong transition-colors">
-          Cancel
-        </button>
+      {/* Action buttons */}
+      <div className="flex flex-col gap-2 pt-1">
         <button type="button" onClick={handleSave} disabled={saving}
-          className="flex-1 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50">
+          className="w-full px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50">
           {saving ? 'Saving…' : 'Save Changes'}
         </button>
+        <div className="flex gap-2">
+          <button type="button" onClick={onPreview}
+            className="flex-1 px-4 py-2 rounded border border-border text-sm text-text-secondary hover:border-border-strong transition-colors">
+            Preview
+          </button>
+          <button type="button" onClick={onCancel}
+            className="flex-1 px-4 py-2 rounded border border-border text-sm text-text-secondary hover:border-border-strong transition-colors">
+            Cancel
+          </button>
+        </div>
       </div>
     </aside>
   )
@@ -238,8 +248,10 @@ export default function ProfilePage({ params }) {
   const [member, setMember] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
-  const [editing, setEditing] = useState(false)
+  // 'edit' | 'preview' | 'read'
+  const [mode, setMode] = useState('read')
   const [saving, setSaving] = useState(false)
+  const initializedRef = useRef(false)
 
   useEffect(() => {
     let cancelled = false
@@ -257,6 +269,14 @@ export default function ProfilePage({ params }) {
     return () => { cancelled = true }
   }, [id])
 
+  // Auto-enter edit mode once we confirm own profile
+  useEffect(() => {
+    if (!initializedRef.current && member && user && user.id === id) {
+      setMode('edit')
+      initializedRef.current = true
+    }
+  }, [member, user, id])
+
   const isOwn = user?.id === id
   const isExec = member?.role === 'executive' || member?.role === 'admin'
 
@@ -266,7 +286,7 @@ export default function ProfilePage({ params }) {
       await updateMyProfile(fields)
       const updated = await fetchMemberById(id)
       setMember(updated)
-      setEditing(false)
+      setMode('edit')
     } catch (err) {
       console.error('Failed to save profile:', err)
     } finally {
@@ -289,31 +309,36 @@ export default function ProfilePage({ params }) {
             {!loading && !error && member && (
               <div className="flex flex-col md:flex-row gap-8 md:gap-12 md:items-start">
                 <div className="w-full md:w-64 lg:w-72 md:flex-shrink-0">
-                  {editing ? (
+                  {isOwn && mode === 'edit' ? (
                     <EditSidebar
                       member={member}
-                      onCancel={() => setEditing(false)}
+                      onPreview={() => setMode('preview')}
+                      onCancel={() => setMode('edit')}
                       onSave={handleSave}
                       saving={saving}
                     />
                   ) : (
                     <ReadSidebar
                       member={member}
-                      isOwn={isOwn}
+                      isOwn={isOwn && mode === 'preview'}
                       isExec={isExec}
-                      onEdit={() => setEditing(true)}
+                      onEdit={() => setMode('edit')}
                     />
                   )}
                 </div>
 
                 <div className="flex-1 min-w-0 flex flex-col gap-8">
+                  {isOwn && mode === 'preview' && (
+                    <div className="px-3 py-2 rounded bg-bg-layer1 border border-border text-sm text-text-secondary">
+                      👁 This is how others see your profile
+                    </div>
+                  )}
                   <section>
                     <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Activity</h2>
                     <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">
                       <p className="text-sm text-text-hint">Coming soon</p>
                     </div>
                   </section>
-
                   <section>
                     <h2 className="font-montserrat font-semibold text-lg text-text-primary mb-4">Achievements</h2>
                     <div className="w-full rounded-lg bg-bg-layer1 border border-border flex items-center justify-center py-12">

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -213,8 +213,14 @@ export default function Navbar() {
           )}
         </div>
 
-        {/* Mobile: hamburger only */}
-        <div className="ml-auto lg:hidden">
+        {/* Mobile: Login (if logged out) + hamburger */}
+        <div className="ml-auto lg:hidden flex items-center gap-1">
+          {!loading && !user && (
+            <button onClick={handleLogIn} disabled={loggingIn}
+              className="px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60">
+              {loggingIn ? '…' : 'Log In'}
+            </button>
+          )}
           <button
             className="p-2 text-text-secondary hover:text-text-primary transition-colors"
             onClick={() => setMobileOpen((o) => !o)}
@@ -245,8 +251,27 @@ export default function Navbar() {
 
           <div className="my-2 h-px bg-border" />
 
-          {user ? (
+          {/* Social icons row */}
+          <div className="flex items-center gap-1 px-2 py-1">
+            <SocialDropdown icon={<IconInstagram />} items={socialLinks.instagram} />
+            <a href={socialLinks.linkedin.url} target="_blank" rel="noopener noreferrer"
+              className="p-1.5 text-[#0A66C2] hover:opacity-80 transition-opacity">
+              <IconLinkedIn />
+            </a>
+            <a href={socialLinks.github.url} target="_blank" rel="noopener noreferrer"
+              className="p-1.5 text-text-primary hover:opacity-70 transition-opacity">
+              <IconGitHub />
+            </a>
+            {isMember && <SocialDropdown icon={<IconDiscord />} items={socialLinks.discord} />}
+            <button onClick={() => { scrollToContact(); setMobileOpen(false) }}
+              className="p-1.5 text-text-secondary hover:text-text-primary transition-colors">
+              <IconEmail />
+            </button>
+          </div>
+
+          {user && (
             <>
+              <div className="my-2 h-px bg-border" />
               <Link href={`/members/${user.id}`} onClick={() => setMobileOpen(false)}
                 className="block px-2 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-layer1 rounded-md transition-colors">
                 My Profile
@@ -262,11 +287,6 @@ export default function Navbar() {
                 Log out
               </button>
             </>
-          ) : (
-            <button onClick={() => { setMobileOpen(false); handleLogIn() }} disabled={loggingIn}
-              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center disabled:opacity-60 disabled:cursor-not-allowed">
-              {loggingIn ? 'Redirecting…' : 'Log In'}
-            </button>
           )}
         </div>
       )}

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -195,7 +195,7 @@ export default function Navbar() {
           <div className="w-px h-5 bg-border mx-1" />
           {user ? (
             <div className="flex items-center gap-2">
-              <UserChip user={user} profile={profile} />
+              <Link href={`/members/${user.id}`}><UserChip user={user} profile={profile} /></Link>
               <button onClick={signOut}
                 className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
                 Log out
@@ -218,7 +218,7 @@ export default function Navbar() {
           {socialIconsRow}
           {user && (
             <div className="ml-1">
-              <UserChip user={user} profile={profile} />
+              <Link href={`/members/${user.id}`}><UserChip user={user} profile={profile} /></Link>
             </div>
           )}
           <button

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -142,6 +142,7 @@ export default function Navbar() {
   async function handleLogIn() {
     if (loggingIn) return
     setLoggingIn(true)
+    localStorage.setItem('auth_redirect', window.location.pathname)
     try {
       await signInWithGoogle(`${window.location.origin}/auth/callback`)
     } catch {

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -213,9 +213,8 @@ export default function Navbar() {
           )}
         </div>
 
-        {/* Mobile: social icons + UserChip + hamburger */}
+        {/* Mobile: UserChip + hamburger */}
         <div className="ml-auto lg:hidden flex items-center gap-1">
-          {socialIconsRow}
           {user && (
             <div className="ml-1">
               <Link href={`/members/${user.id}`}><UserChip user={user} profile={profile} /></Link>

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -213,13 +213,8 @@ export default function Navbar() {
           )}
         </div>
 
-        {/* Mobile: UserChip + hamburger */}
-        <div className="ml-auto lg:hidden flex items-center gap-1">
-          {user && (
-            <div className="ml-1">
-              <Link href={`/members/${user.id}`}><UserChip user={user} profile={profile} /></Link>
-            </div>
-          )}
+        {/* Mobile: hamburger only */}
+        <div className="ml-auto lg:hidden">
           <button
             className="p-2 text-text-secondary hover:text-text-primary transition-colors"
             onClick={() => setMobileOpen((o) => !o)}
@@ -236,7 +231,7 @@ export default function Navbar() {
 
       {/* Mobile menu */}
       {mobileOpen && (
-        <div className="lg:hidden border-t border-border bg-bg-surface px-6 py-4 flex flex-col gap-1">
+        <div className="lg:hidden border-t border-border bg-bg-surface px-6 py-4 flex flex-col gap-1 relative z-50">
           {allLinks.map(({ href, label }) => (
             <Link key={href} href={href} onClick={() => setMobileOpen(false)}
               className={`block px-2 py-2 text-sm rounded-md transition-colors ${
@@ -251,10 +246,22 @@ export default function Navbar() {
           <div className="my-2 h-px bg-border" />
 
           {user ? (
-            <button onClick={() => { signOut(); setMobileOpen(false) }}
-              className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
-              Log out
-            </button>
+            <>
+              <Link href={`/members/${user.id}`} onClick={() => setMobileOpen(false)}
+                className="block px-2 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-layer1 rounded-md transition-colors">
+                My Profile
+              </Link>
+              {isAdmin && (
+                <Link href="/admin" onClick={() => setMobileOpen(false)}
+                  className="block px-2 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-layer1 rounded-md transition-colors">
+                  Admin
+                </Link>
+              )}
+              <button onClick={() => { signOut(); setMobileOpen(false) }}
+                className="w-full mt-1 px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center">
+                Log out
+              </button>
+            </>
           ) : (
             <button onClick={() => { setMobileOpen(false); handleLogIn() }} disabled={loggingIn}
               className="w-full px-4 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors text-center disabled:opacity-60 disabled:cursor-not-allowed">

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -214,14 +214,16 @@ export default function Navbar() {
           )}
         </div>
 
-        {/* Mobile: Login (if logged out) + hamburger */}
-        <div className="ml-auto lg:hidden flex items-center gap-1">
-          {!loading && !user && (
+        {/* Mobile: avatar (if logged in) or Login button + hamburger */}
+        <div className="ml-auto lg:hidden flex items-center gap-2">
+          {!loading && (user ? (
+            <Link href={`/members/${user.id}`}><UserChip user={user} profile={profile} /></Link>
+          ) : (
             <button onClick={handleLogIn} disabled={loggingIn}
               className="px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60">
               {loggingIn ? '…' : 'Log In'}
             </button>
-          )}
+          ))}
           <button
             className="p-2 text-text-secondary hover:text-text-primary transition-colors"
             onClick={() => setMobileOpen((o) => !o)}

--- a/src/services/membersService.js
+++ b/src/services/membersService.js
@@ -1,6 +1,6 @@
 import { supabase } from '@/lib/supabase'
 
-const MEMBER_FIELDS = 'id, first_name, last_name, nickname, avatar_url, school, company, occupation, status, role, linkedin, github, cohort, bio, profile_visibility'
+const MEMBER_FIELDS = 'id, first_name, last_name, nickname, avatar_url, school, company, occupation, phone, status, role, linkedin, github, cohort, bio, profile_visibility'
 
 function mapMember(row) {
   return {
@@ -12,6 +12,7 @@ function mapMember(row) {
     school: row.school,
     company: row.company,
     occupation: row.occupation,
+    phone: row.phone,
     status: row.status,
     role: row.role,
     linkedinUrl: row.linkedin,
@@ -43,11 +44,11 @@ export async function fetchMemberById(id) {
   return mapMember(data)
 }
 
-export async function updateMyProfile({ nickname, bio, linkedin, github, status, profile_visibility }) {
+export async function updateMyProfile({ nickname, bio, linkedin, github, status, profile_visibility, company, occupation, phone, school }) {
   const { data: { user } } = await supabase.auth.getUser()
   const { error } = await supabase
     .from('profiles')
-    .update({ nickname, bio, linkedin, github, status, profile_visibility })
+    .update({ nickname, bio, linkedin, github, status, profile_visibility, company, occupation, phone, school })
     .eq('id', user.id)
   if (error) throw error
 }

--- a/src/services/membersService.js
+++ b/src/services/membersService.js
@@ -1,24 +1,9 @@
 import { supabase } from '@/lib/supabase'
 
-/**
- * Fetches all approved members from the profiles table.
- * Maps DB columns (snake_case) to MemberCard's expected prop shape (camelCase).
- *
- * TODO: When backend adds an `approval_status` column, swap the `.neq('role', 'pending')`
- *       filter for `.eq('approval_status', 'approved')`.
- * TODO: Sort by activity score (submissions + attendance, last 90 days) once those tables exist.
- *       For now, sorted alphabetically by name.
- */
-export async function fetchMembers() {
-  const { data, error } = await supabase
-    .from('profiles')
-    .select('id, first_name, last_name, nickname, avatar_url, school, company, occupation, status, role, linkedin, github, cohort')
-    .neq('role', 'pending')
-    .order('first_name', { ascending: true })
+const MEMBER_FIELDS = 'id, first_name, last_name, nickname, avatar_url, school, company, occupation, status, role, linkedin, github, cohort, bio, profile_visibility'
 
-  if (error) throw error
-
-  return (data ?? []).map((row) => ({
+function mapMember(row) {
+  return {
     id: row.id,
     firstName: row.first_name,
     lastName: row.last_name,
@@ -32,40 +17,37 @@ export async function fetchMembers() {
     linkedinUrl: row.linkedin,
     githubUrl: row.github,
     cohort: row.cohort,
-  }))
+    bio: row.bio,
+    profileVisibility: row.profile_visibility ?? { bio: true, linkedin: true, github: true },
+  }
+}
+
+export async function fetchMembers() {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select(MEMBER_FIELDS)
+    .neq('role', 'pending')
+    .order('first_name', { ascending: true })
+
+  if (error) throw error
+  return (data ?? []).map(mapMember)
 }
 
 export async function fetchMemberById(id) {
   const { data, error } = await supabase
     .from('profiles')
-    .select('id, first_name, last_name, nickname, avatar_url, school, company, occupation, status, role, linkedin, github, cohort')
+    .select(MEMBER_FIELDS)
     .eq('id', id)
     .single()
   if (error) throw error
-
-  return {
-    id: data.id,
-    firstName: data.first_name,
-    lastName: data.last_name,
-    nickname: data.nickname,
-    avatarUrl: data.avatar_url,
-    school: data.school,
-    company: data.company,
-    occupation: data.occupation,
-    status: data.status,
-    role: data.role,
-    linkedinUrl: data.linkedin,
-    githubUrl: data.github,
-    cohort: data.cohort
-  }
+  return mapMember(data)
 }
 
-// export async function fetchMemberBadges(id) {
-//   const { data, error } = await supabase
-//     .from('user_badges')
-//     .select('*, badges(*)')
-//     .eq('user_id', id)
-//   if (error) throw error
-
-//   return data ?? []
-// }
+export async function updateMyProfile({ nickname, bio, linkedin, github, status, profile_visibility }) {
+  const { data: { user } } = await supabase.auth.getUser()
+  const { error } = await supabase
+    .from('profiles')
+    .update({ nickname, bio, linkedin, github, status, profile_visibility })
+    .eq('id', user.id)
+  if (error) throw error
+}

--- a/supabase/migrations/20260608000000_profiles_add_bio_visibility.sql
+++ b/supabase/migrations/20260608000000_profiles_add_bio_visibility.sql
@@ -1,0 +1,17 @@
+-- Add bio and per-field visibility settings to profiles.
+-- bio: plain text, 300 char limit enforced at app layer.
+-- profile_visibility: JSONB controls which fields are shown to other members.
+-- Default is all visible so existing rows are unaffected.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS bio TEXT,
+  ADD COLUMN IF NOT EXISTS profile_visibility JSONB
+    NOT NULL DEFAULT '{"bio": true, "linkedin": true, "github": true}';
+
+-- Allow members to update their own editable fields only.
+-- Name, school, cohort, role, email, avatar_url remain admin-managed.
+CREATE POLICY "Members can update own profile"
+  ON profiles
+  FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);


### PR DESCRIPTION
## Summary

- Add `bio` and `profile_visibility` columns to `profiles` table via migration
- Rebuild `/members/[id]` with GitHub-style sidebar + main content layout
- Inline edit mode for nickname, bio, LinkedIn, GitHub, and Student/Graduate status
- Per-field visibility toggle — hidden fields show 🔒 indicator on own profile only
- Navbar avatar now links to own `/members/:id` (desktop and mobile)

## Changes

**DB**
- `supabase/migrations/20260608000000_profiles_add_bio_visibility.sql` — adds `bio TEXT` and `profile_visibility JSONB` columns; adds RLS policy for members to update own row
- `docs/schema/tables/profiles.sql` — synced with actual DB columns

**Services**
- `src/services/membersService.js` — include `bio`, `profile_visibility` in queries; add `updateMyProfile()`

**UI**
- `src/app/members/[id]/page.js` — full rewrite: GitHub-style layout (sidebar + content), read view, inline edit mode
- `src/components/common/Navbar.js` — avatar click → `/members/:id`

## Test plan

- [ ] Log in → click navbar avatar → confirm navigates to own `/members/:id`
- [ ] Click [Edit Profile] → update nickname, bio, LinkedIn, GitHub → Save → confirm changes persist
- [ ] Toggle a field to Hidden → log out → log in as another account → confirm hidden field not visible
- [ ] On own profile → hidden field shows with 🔒 indicator
- [ ] Change Status to Graduate → Save → badge updates to Graduate
- [ ] Non-owner visiting profile → no [Edit Profile] button shown