### PR TITLE
feat: allow pending users to edit own profile, remove My Profile nav link

### DIFF
--- a/src/app/pending/page.js
+++ b/src/app/pending/page.js
@@ -4,10 +4,12 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { useAuth } from '@/hooks/useAuth'
+import { useJoinModal } from '@/contexts/JoinModalContext'
 import { socialLinks } from '@/config/socialLinks'
 
 export default function PendingPage() {
   const { user, profile, loading, signOut } = useAuth()
+  const { openModal } = useJoinModal()
   const clubEntry = socialLinks.clubSignup.find(({ school }) => school === profile?.school)
   const clubUrl = clubEntry?.url ?? null
   const router = useRouter()
@@ -49,12 +51,12 @@ export default function PendingPage() {
         </div>
 
         <div className="mt-8 flex flex-col gap-3">
-          <Link
-            href={`/members/${user.id}`}
-            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-accent text-white hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 text-center"
+          <button
+            onClick={openModal}
+            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-accent text-white hover:bg-accent-hover active:scale-[0.98] transition-all duration-150"
           >
             Edit My Profile
-          </Link>
+          </button>
           <button
             onClick={signOut}
             className="w-full px-4 py-2.5 rounded-xl text-sm font-medium border border-border text-text-secondary hover:bg-bg-surface active:scale-[0.98] transition-all duration-150"

--- a/src/app/pending/page.js
+++ b/src/app/pending/page.js
@@ -49,15 +49,21 @@ export default function PendingPage() {
         </div>
 
         <div className="mt-8 flex flex-col gap-3">
+          <Link
+            href={`/members/${user.id}`}
+            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-accent text-white hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 text-center"
+          >
+            Edit My Profile
+          </Link>
           <button
             onClick={signOut}
-            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-accent text-white hover:bg-accent-hover active:scale-[0.98] transition-all duration-150"
+            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium border border-border text-text-secondary hover:bg-bg-surface active:scale-[0.98] transition-all duration-150"
           >
             Sign out
           </button>
           <Link
             href="/"
-            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium border border-border text-text-secondary hover:bg-bg-surface transition-colors"
+            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium border border-border text-text-secondary hover:bg-bg-surface transition-colors text-center"
           >
             Back to home
           </Link>

--- a/src/components/auth/RoleGuard.js
+++ b/src/components/auth/RoleGuard.js
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import Link from 'next/link'
 import { useAuth } from '@/hooks/useAuth'
 import { useRouter, usePathname } from 'next/navigation'
 import { ROLES, canAccessMemberRoutes, canAccessAdminRoutes } from '@/utils/constants'
@@ -63,7 +64,9 @@ const RoleGuard = ({ children }) => {
     return null
   }
 
-  if (profile?.role === ROLES.PENDING) {
+  const isOwnProfilePath = pathname === `/members/${user?.id}`
+
+  if (profile?.role === ROLES.PENDING && !isOwnProfilePath) {
     return (
       <main className="min-h-screen flex items-center justify-center">
         <div className="text-center max-w-lg px-4">
@@ -75,6 +78,12 @@ const RoleGuard = ({ children }) => {
             After you sign up, an admin reviews your request. Once approved, you
             can use member areas like Problems and Members.
           </p>
+          <Link
+            href={`/members/${user.id}`}
+            className="mt-6 inline-block px-5 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors"
+          >
+            Edit My Profile
+          </Link>
         </div>
       </main>
     )

--- a/src/components/auth/RoleGuard.js
+++ b/src/components/auth/RoleGuard.js
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect } from 'react'
-import Link from 'next/link'
 import { useAuth } from '@/hooks/useAuth'
 import { useRouter, usePathname } from 'next/navigation'
 import { ROLES, canAccessMemberRoutes, canAccessAdminRoutes } from '@/utils/constants'
@@ -36,6 +35,7 @@ const RoleGuard = ({ children }) => {
   const router = useRouter()
   const pathname = usePathname()
   const accessError = getAccessError(pathname, profile)
+  const isOwnProfilePath = pathname === `/members/${user?.id}`
 
   useEffect(() => {
     if (loading) return
@@ -45,12 +45,15 @@ const RoleGuard = ({ children }) => {
       return
     }
 
-    if (profile?.role === ROLES.PENDING) return
+    if (profile?.role === ROLES.PENDING) {
+      if (!isOwnProfilePath) router.replace('/pending')
+      return
+    }
 
     if (accessError) {
       router.replace('/')
     }
-  }, [loading, user, profile, accessError, router])
+  }, [loading, user, profile, accessError, router, isOwnProfilePath])
 
   if (loading) {
     return (
@@ -64,29 +67,8 @@ const RoleGuard = ({ children }) => {
     return null
   }
 
-  const isOwnProfilePath = pathname === `/members/${user?.id}`
-
   if (profile?.role === ROLES.PENDING && !isOwnProfilePath) {
-    return (
-      <main className="min-h-screen flex items-center justify-center">
-        <div className="text-center max-w-lg px-4">
-          <h1 className="font-montserrat font-bold text-5xl text-text-primary">Account pending</h1>
-          <p className="mt-3 text-text-hint text-lg">
-            Your account is waiting for admin approval.
-          </p>
-          <p className="mt-4 text-text-secondary text-base">
-            After you sign up, an admin reviews your request. Once approved, you
-            can use member areas like Problems and Members.
-          </p>
-          <Link
-            href={`/members/${user.id}`}
-            className="mt-6 inline-block px-5 py-2.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors"
-          >
-            Edit My Profile
-          </Link>
-        </div>
-      </main>
-    )
+    return null
   }
 
   if (accessError) {

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -97,10 +97,21 @@ export default function JoinModal() {
       const meta = user.user_metadata
       const fullName = meta?.full_name ?? meta?.name ?? ''
       const parts = fullName.trim().split(' ')
-      setFirstName(meta?.given_name ?? parts[0] ?? '')
-      setLastName(meta?.family_name ?? parts.slice(1).join(' ') ?? '')
+      setFirstName(profile?.first_name ?? meta?.given_name ?? parts[0] ?? '')
+      setLastName(profile?.last_name ?? meta?.family_name ?? parts.slice(1).join(' ') ?? '')
+      setNickname(profile?.nickname ?? '')
+      setSchool(profile?.school ?? '')
+      setCohort(profile?.cohort ?? '')
+      setPhone(profile?.phone ?? '')
+      setStatus(profile?.status ?? '')
+      setCompany(profile?.company ?? '')
+      setOccupation(profile?.occupation ?? '')
+      const li = profile?.linkedin ?? ''
+      setLinkedin(li.replace('https://www.linkedin.com/in/', '').replace(/\/$/, ''))
+      const gh = profile?.github ?? ''
+      setGithub(gh.replace('https://github.com/', '').replace(/\/$/, ''))
     }
-  }, [isOpen, user])
+  }, [isOpen, user, profile])
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -136,6 +136,7 @@ export default function Navbar() {
   const role = profile?.role ?? null
   const isMember = role === 'member' || role === 'executive' || role === 'admin'
   const isAdmin = role === 'admin'
+  const profileHref = role === 'pending' ? '/pending' : `/members/${user?.id}`
 
   const allLinks = isMember ? [...publicLinks, ...memberOnlyLinks] : publicLinks
 
@@ -196,7 +197,7 @@ export default function Navbar() {
           <div className="w-px h-5 bg-border mx-1" />
           {user ? (
             <div className="flex items-center gap-2">
-              <Link href={`/members/${user.id}`}><UserChip user={user} profile={profile} /></Link>
+              <Link href={profileHref}><UserChip user={user} profile={profile} /></Link>
               <button onClick={signOut}
                 className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
                 Log out
@@ -217,7 +218,7 @@ export default function Navbar() {
         {/* Mobile: avatar (if logged in) or Login button + hamburger */}
         <div className="ml-auto lg:hidden flex items-center gap-2">
           {!loading && (user ? (
-            <Link href={`/members/${user.id}`}><UserChip user={user} profile={profile} /></Link>
+            <Link href={profileHref}><UserChip user={user} profile={profile} /></Link>
           ) : (
             <button onClick={handleLogIn} disabled={loggingIn}
               className="px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60">

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -275,10 +275,6 @@ export default function Navbar() {
           {user && (
             <>
               <div className="my-2 h-px bg-border" />
-              <Link href={`/members/${user.id}`} onClick={() => setMobileOpen(false)}
-                className="block px-2 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-layer1 rounded-md transition-colors">
-                My Profile
-              </Link>
               {isAdmin && (
                 <Link href="/admin" onClick={() => setMobileOpen(false)}
                   className="block px-2 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-layer1 rounded-md transition-colors">


### PR DESCRIPTION
## Summary

- Pending users can now navigate to their own `/members/[id]` page to edit their profile instead of hitting a dead-end screen
- Added "Edit My Profile" CTA button on the Account pending screen
- Removed redundant "My Profile" link from the mobile hamburger menu for all users — the avatar chip already links there

## Changes

- `src/components/auth/RoleGuard.js` — added `isOwnProfilePath` check (`pathname === /members/${user.id}`) so pending users pass through to their own profile; all other member routes still show the pending screen; added "Edit My Profile" button
- `src/components/common/Navbar.js` — removed "My Profile" link from mobile hamburger

## Notes

- `isOwnProfilePath` uses `user.id` from `useAuth` (not the URL param) to prevent a pending user from accessing `/members/some-other-id`
- DB RLS SELECT policy (`profiles_select_all`: `TO authenticated USING (TRUE)`) already allows any authenticated user to read any profile row — no migration needed
- RLS UPDATE policy (`auth.uid() = id`) was already in place — pending users can save their own changes

## Test plan

- [ ] Log in as pending user → see "Edit My Profile" button on pending screen → click → land on profile page in edit mode
- [ ] Edit a field (e.g. nickname) and save → reload → confirm it persisted
- [ ] As pending user, navigate to `/members` directly → confirm "Account pending" screen appears
- [ ] As pending user, navigate to `/members/[another-user-id]` → confirm "Account pending" screen appears
- [ ] Open mobile hamburger as any role → confirm "My Profile" is gone
- [ ] Tap avatar chip in mobile header → confirm it still navigates to own profile