### PR TITLE
[feat] Hero image editing for Admins/Executives with Cloudinary upload (#137)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'lh3.googleusercontent.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+      },
     ],
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,13 @@
         "@testing-library/user-event": "^13.5.0",
         "@uiw/react-codemirror": "^4.25.10",
         "@uiw/react-md-editor": "^4.1.1",
+        "cloudinary": "^2.10.0",
         "lucide-react": "^1.14.0",
         "next": "^16.2.3",
         "nodemailer": "^8.0.7",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-easy-crop": "^5.5.7",
         "react-markdown": "^10.1.0",
         "web-vitals": "^2.1.4"
       },
@@ -1702,6 +1704,18 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cloudinary": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.10.0.tgz",
+      "integrity": "sha512-sY09kYg7wprkndAOjZBAYqFZqwL+SxnEGcAvksOvFA+5upnFn949UjkEkHKNSwkBtW/xRDd0p6NgbSXZcxkI3w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.23"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -2521,6 +2535,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -3570,6 +3590,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -3918,6 +3944,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+      "integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "@testing-library/user-event": "^13.5.0",
     "@uiw/react-codemirror": "^4.25.10",
     "@uiw/react-md-editor": "^4.1.1",
+    "cloudinary": "^2.10.0",
     "lucide-react": "^1.14.0",
     "next": "^16.2.3",
     "nodemailer": "^8.0.7",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-easy-crop": "^5.5.7",
     "react-markdown": "^10.1.0",
     "web-vitals": "^2.1.4"
   },

--- a/src/app/api/upload/route.js
+++ b/src/app/api/upload/route.js
@@ -1,0 +1,84 @@
+import { v2 as cloudinary } from 'cloudinary'
+import { createClient } from '@supabase/supabase-js'
+
+cloudinary.config({
+  cloud_name: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+})
+
+const ALLOWED_FOLDERS = ['hero', 'profiles', 'announcements', 'events']
+
+const FOLDER_ROLES = {
+  hero: ['executive', 'admin'],
+  profiles: ['member', 'executive', 'admin'],
+  announcements: ['executive', 'admin'],
+  events: ['executive', 'admin'],
+}
+
+function getServiceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  )
+}
+
+export async function POST(request) {
+  const authHeader = request.headers.get('authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const token = authHeader.slice(7)
+  const serviceClient = getServiceClient()
+
+  const { data: { user }, error: authError } = await serviceClient.auth.getUser(token)
+  if (authError || !user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const folder = request.nextUrl.searchParams.get('folder')
+  if (!folder || !ALLOWED_FOLDERS.includes(folder)) {
+    return Response.json({ error: 'Invalid folder' }, { status: 400 })
+  }
+
+  const { data: profile } = await serviceClient
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || !FOLDER_ROLES[folder].includes(profile.role)) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const formData = await request.formData()
+  const file = formData.get('file')
+  if (!file) {
+    return Response.json({ error: 'No file provided' }, { status: 400 })
+  }
+
+  try {
+    const bytes = await file.arrayBuffer()
+    const buffer = Buffer.from(bytes)
+
+    const result = await new Promise((resolve, reject) => {
+      cloudinary.uploader.upload_stream(
+        {
+          folder: `codexperts/${folder}`,
+          resource_type: 'image',
+          transformation: [{ quality: 'auto', fetch_format: 'auto' }],
+        },
+        (error, result) => {
+          if (error) reject(error)
+          else resolve(result)
+        }
+      ).end(buffer)
+    })
+
+    return Response.json({ url: result.secure_url, publicId: result.public_id })
+  } catch (error) {
+    console.error('Upload error:', error)
+    return Response.json({ error: 'Upload failed' }, { status: 500 })
+  }
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,23 +1,47 @@
+'use client'
+
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import Script from 'next/script'
 import Button from '@/components/ui/Button'
 import JoinUsButton from '@/components/ui/JoinUsButton'
+import HeroImageEditor from '@/components/home/HeroImageEditor'
+import { getOptimizedUrl } from '@/services/cloudinaryService'
+import { supabase } from '@/lib/supabase'
+
+const FALLBACK_HERO = '/hero.jpg'
 
 export default function HomePage() {
+  const [heroUrl, setHeroUrl] = useState(null)
+
+  useEffect(() => {
+    supabase
+      .from('site_settings')
+      .select('value')
+      .eq('key', 'hero_image_url')
+      .single()
+      .then(({ data }) => {
+        if (data?.value) setHeroUrl(data.value)
+      })
+  }, [])
+
+  const src = getOptimizedUrl(heroUrl) ?? FALLBACK_HERO
+
   return (
     <main className="min-h-screen bg-bg-base">
 
       {/* Hero — full width, no padding */}
-      <section>
+      <section className="relative">
         <Image
-          src="/hero.jpg"
+          src={src}
           alt="group photo of codeXperts"
           width={1920}
           height={1080}
           className="object-cover object-[0%_60%] w-full h-[50vh] md:h-[70vh]"
           priority
         />
+        <HeroImageEditor onUpdate={setHeroUrl} />
       </section>
 
       {/* Social Feed — full width bg-bg-base, inner container matches footer */}

--- a/src/components/home/HeroImageEditor.js
+++ b/src/components/home/HeroImageEditor.js
@@ -1,0 +1,141 @@
+'use client'
+
+import { useRef, useState, useCallback } from 'react'
+import Cropper from 'react-easy-crop'
+import { useAuth } from '@/hooks/useAuth'
+import { canAccessAdminRoutes } from '@/utils/constants'
+import { uploadImage } from '@/services/cloudinaryService'
+import { supabase } from '@/lib/supabase'
+import { IconEdit } from '@/components/ui/Icons'
+
+// Hero aspect ratio: matches w-full h-[70vh] on desktop
+const HERO_ASPECT = 16 / 7
+
+async function getCroppedBlob(imageSrc, pixelCrop) {
+  const res = await fetch(imageSrc)
+  const blob = await res.blob()
+  const bitmap = await createImageBitmap(blob)
+  const canvas = document.createElement('canvas')
+  canvas.width = pixelCrop.width
+  canvas.height = pixelCrop.height
+  canvas.getContext('2d').drawImage(
+    bitmap,
+    pixelCrop.x, pixelCrop.y, pixelCrop.width, pixelCrop.height,
+    0, 0, pixelCrop.width, pixelCrop.height
+  )
+  return new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', 0.95))
+}
+
+export default function HeroImageEditor({ onUpdate }) {
+  const { profile } = useAuth()
+  const inputRef = useRef(null)
+  const [imageSrc, setImageSrc] = useState(null)
+  const [crop, setCrop] = useState({ x: 0, y: 0 })
+  const [zoom, setZoom] = useState(1)
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState(null)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const onCropComplete = useCallback((_, pixels) => setCroppedAreaPixels(pixels), [])
+
+  if (!canAccessAdminRoutes(profile?.role)) return null
+
+  function handleFileChange(e) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => setImageSrc(reader.result)
+    reader.readAsDataURL(file)
+    e.target.value = ''
+  }
+
+  async function handleUpload() {
+    if (!croppedAreaPixels || !imageSrc) return
+    setError(null)
+    setUploading(true)
+    try {
+      const blob = await getCroppedBlob(imageSrc, croppedAreaPixels)
+      const file = new File([blob], 'hero.jpg', { type: 'image/jpeg' })
+      const { url } = await uploadImage(file, 'hero')
+
+      const { error: dbError } = await supabase
+        .from('site_settings')
+        .update({ value: url, updated_at: new Date().toISOString() })
+        .eq('key', 'hero_image_url')
+
+      if (dbError) throw dbError
+      onUpdate(url)
+      setImageSrc(null)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="absolute top-3 right-3 z-10 flex flex-col items-end gap-1">
+        <button
+          onClick={() => inputRef.current?.click()}
+          className="bg-black/60 hover:bg-black/80 text-white p-2 rounded-md transition-colors"
+          title="Edit Hero Image"
+        >
+          <IconEdit className="w-4 h-4" />
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+      </div>
+
+      {imageSrc && (
+        <div className="fixed inset-0 z-50 bg-black flex flex-col">
+          <div className="relative flex-1">
+            <Cropper
+              image={imageSrc}
+              crop={crop}
+              zoom={zoom}
+              aspect={HERO_ASPECT}
+              onCropChange={setCrop}
+              onZoomChange={setZoom}
+              onCropComplete={onCropComplete}
+            />
+          </div>
+
+          <div className="bg-black/90 px-6 py-4 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <span className="text-white/70 text-xs font-inter">Zoom</span>
+              <input
+                type="range"
+                min={1} max={3} step={0.05}
+                value={zoom}
+                onChange={e => setZoom(Number(e.target.value))}
+                className="w-32 accent-white"
+              />
+            </div>
+            {error && <span className="text-red-400 text-xs font-inter flex-1 text-center">{error}</span>}
+            <div className="flex gap-2">
+              <button
+                onClick={() => { setImageSrc(null); setError(null) }}
+                className="px-4 py-2 text-sm font-inter text-white border border-white/30 rounded-md hover:bg-white/10 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleUpload}
+                disabled={uploading}
+                className="px-4 py-2 text-sm font-inter bg-white text-black rounded-md hover:bg-white/90 transition-colors disabled:opacity-50"
+              >
+                {uploading ? 'Uploading…' : 'Upload'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/services/cloudinaryService.js
+++ b/src/services/cloudinaryService.js
@@ -1,0 +1,27 @@
+import { supabase } from '@/lib/supabase'
+
+export async function uploadImage(file, folder) {
+  const { data: { session } } = await supabase.auth.getSession()
+  if (!session) throw new Error('Not authenticated')
+
+  const formData = new FormData()
+  formData.append('file', file)
+
+  const res = await fetch(`/api/upload?folder=${folder}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${session.access_token}` },
+    body: formData,
+  })
+
+  if (!res.ok) {
+    const { error } = await res.json()
+    throw new Error(error ?? 'Upload failed')
+  }
+
+  return res.json()
+}
+
+export function getOptimizedUrl(url) {
+  if (!url || !url.includes('res.cloudinary.com')) return url
+  return url.replace('/upload/', '/upload/f_auto,q_auto/')
+}

--- a/supabase/migrations/20260609000000_add_site_settings.sql
+++ b/supabase/migrations/20260609000000_add_site_settings.sql
@@ -1,0 +1,37 @@
+CREATE TABLE public.site_settings (
+  key   TEXT PRIMARY KEY,
+  value TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO public.site_settings (key, value)
+VALUES ('hero_image_url', NULL);
+
+ALTER TABLE public.site_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY site_settings_select_public
+ON public.site_settings
+FOR SELECT
+TO anon, authenticated
+USING (TRUE);
+
+CREATE POLICY site_settings_update_exec_admin
+ON public.site_settings
+FOR UPDATE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('executive'::public.member_role, 'admin'::public.member_role)
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('executive'::public.member_role, 'admin'::public.member_role)
+  )
+);


### PR DESCRIPTION
## Summary

- Adds `site_settings` Supabase table to store dynamic site config (starting with `hero_image_url`)
- Adds a generic `/api/upload` endpoint for Cloudinary image uploads, reusable across hero, profiles, announcements, and events
- Admin/Executive users see an edit icon button on the hero section; clicking opens a full-screen crop/zoom modal powered by `react-easy-crop`
- Cropped image is uploaded to Cloudinary (`codexperts/hero/` folder) with automatic format and quality optimization (`f_auto`, `q_auto`)
- Homepage fetches the hero URL from DB on load, falling back to `/hero.jpg` if not set

## Test plan

- [ ] Log in as Admin or Executive — confirm edit icon appears on hero image (top-right)
- [ ] Log in as Member or log out — confirm edit icon is hidden
- [ ] Click icon, select an image, crop and zoom, click Upload — confirm new hero image appears immediately
- [ ] Reload the page — confirm the new hero image persists (loaded from DB)
- [ ] Check Cloudinary dashboard — confirm image uploaded under `codexperts/hero/`
- [ ] Confirm non-admin upload attempt returns 403