### PR TITLE
feat: admin member management with approvals and profile edits

### DIFF
--- a/docs/schema/tables/profiles.sql
+++ b/docs/schema/tables/profiles.sql
@@ -26,6 +26,8 @@ CREATE TABLE profiles (
   avatar_url      TEXT,
   bio             TEXT,
   profile_visibility JSONB NOT NULL DEFAULT '{"bio": true, "linkedin": true, "github": true}',
+  application_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (application_status IN ('pending', 'approved', 'rejected')),
   created_at      TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
   updated_at      TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );

--- a/src/app/admin/_components/MemberEditPanel.js
+++ b/src/app/admin/_components/MemberEditPanel.js
@@ -1,0 +1,165 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { SCHOOLS, ROLES } from '@/utils/constants'
+import { generateCohortOptions } from '@/utils/cohortOptions'
+import { formatPhone } from '@/utils/phone'
+import { memberToForm } from '@/services/adminService'
+
+const ROLE_OPTIONS = [
+  { value: ROLES.MEMBER, label: 'Member' },
+  { value: ROLES.EXECUTIVE, label: 'Executive' },
+  { value: ROLES.ADMIN, label: 'Admin' },
+]
+
+const STATUS_OPTIONS = [
+  { value: 'student', label: 'Student' },
+  { value: 'graduate', label: 'Graduate' },
+]
+
+const inputClass = 'w-full px-3 py-2 rounded-md border border-border text-sm font-inter bg-bg-input text-text-primary outline-none focus:border-border-strong transition-colors'
+
+function Field({ label, children }) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-text-secondary mb-1.5">{label}</label>
+      {children}
+    </div>
+  )
+}
+
+export default function MemberEditPanel({ member, saving, error, onSave, onCancel }) {
+  const [form, setForm] = useState(() => memberToForm(member))
+  const cohortOptions = generateCohortOptions()
+
+  useEffect(() => {
+    setForm(memberToForm(member))
+  }, [member])
+
+  function updateField(key, value) {
+    setForm(prev => ({ ...prev, [key]: value }))
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    onSave(form)
+  }
+
+  const displayName = [member.firstName, member.lastName].filter(Boolean).join(' ') || member.email
+
+  return (
+    <div className="border border-border rounded-lg bg-bg-surface flex flex-col max-h-[calc(100vh-12rem)] min-h-[320px]">
+      <div className="px-4 py-3 border-b border-border shrink-0">
+        <h2 className="font-montserrat font-semibold text-lg text-text-primary">Edit member</h2>
+        <p className="text-sm text-text-secondary mt-0.5 truncate">{displayName}</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
+        <div className="p-4 space-y-4 overflow-y-auto flex-1">
+          <Field label="First name">
+            <input
+              type="text"
+              value={form.first_name}
+              onChange={e => updateField('first_name', e.target.value)}
+              className={inputClass}
+              required
+            />
+          </Field>
+
+          <Field label="Last name">
+            <input
+              type="text"
+              value={form.last_name}
+              onChange={e => updateField('last_name', e.target.value)}
+              className={inputClass}
+              required
+            />
+          </Field>
+
+          <Field label="School">
+            <select
+              value={form.school}
+              onChange={e => updateField('school', e.target.value)}
+              className={inputClass}
+              required
+            >
+              <option value="">Select school</option>
+              {SCHOOLS.map(school => (
+                <option key={school} value={school}>{school}</option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Cohort">
+            <select
+              value={form.cohort}
+              onChange={e => updateField('cohort', e.target.value)}
+              className={inputClass}
+              required
+            >
+              <option value="">Select cohort</option>
+              {cohortOptions.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Role">
+            <select
+              value={form.role}
+              onChange={e => updateField('role', e.target.value)}
+              className={inputClass}
+            >
+              {ROLE_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Status">
+            <select
+              value={form.status}
+              onChange={e => updateField('status', e.target.value)}
+              className={inputClass}
+            >
+              {STATUS_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Phone">
+            <input
+              type="tel"
+              value={form.phone}
+              onChange={e => updateField('phone', formatPhone(e.target.value))}
+              placeholder="(416) 555-0100"
+              className={inputClass}
+            />
+          </Field>
+
+          {error && (
+            <p className="text-sm text-error font-inter">{error}</p>
+          )}
+        </div>
+
+        <div className="px-4 py-3 border-t border-border flex gap-3 justify-end shrink-0">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 border border-border-strong rounded-md text-sm font-inter text-text-secondary hover:bg-bg-layer1 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-5 py-2 bg-accent text-white rounded-md text-sm font-medium font-inter hover:bg-accent-hover disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/app/admin/_components/MemberTable.js
+++ b/src/app/admin/_components/MemberTable.js
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState } from 'react'
+import UserAvatar from '@/components/common/UserAvatar'
+import { cohortLabel } from '@/utils/cohort'
+import { isPendingApplicant } from '@/services/adminService'
+
+function formatStatus(status) {
+  if (!status || status === 'student') return 'Student'
+  return 'Graduate'
+}
+
+function formatRole(role) {
+  if (role === 'executive') return 'Executive'
+  if (role === 'admin') return 'Admin'
+  if (role === 'pending') return 'Pending'
+  return 'Member'
+}
+
+function formatDate(str) {
+  if (!str) return '—'
+  return new Date(str).toLocaleDateString('en-CA', { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+export default function MemberTable({
+  members,
+  selectedId,
+  isAdmin,
+  actionLoadingId,
+  onSelect,
+  onApprove,
+  onReject,
+}) {
+  const [rejectTarget, setRejectTarget] = useState(null)
+  const pendingCount = members.filter(isPendingApplicant).length
+
+  return (
+    <>
+      <div className="border border-border rounded-lg bg-bg-surface overflow-hidden flex flex-col max-h-[calc(100vh-12rem)] min-h-[320px]">
+        <div className="px-4 py-3 border-b border-border bg-bg-layer1 flex items-center justify-between shrink-0">
+          <p className="text-sm font-inter text-text-secondary">
+            {members.length} members
+            {pendingCount > 0 && (
+              <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-warning/10 text-warning border border-warning/20">
+                {pendingCount} pending
+              </span>
+            )}
+          </p>
+          {isAdmin && (
+            <p className="text-xs text-text-hint font-inter hidden sm:block">Click a row to edit</p>
+          )}
+        </div>
+
+        <div className="overflow-auto flex-1">
+          <table className="w-full border-collapse text-sm font-inter">
+            <thead className="sticky top-0 z-10 bg-bg-layer1">
+              <tr className="border-b border-border text-left text-xs text-text-hint">
+                <th className="py-2.5 px-3 font-medium w-36">Member</th>
+                <th className="py-2.5 px-3 font-medium">Email</th>
+                <th className="py-2.5 px-3 font-medium hidden md:table-cell">School</th>
+                <th className="py-2.5 px-3 font-medium hidden lg:table-cell">Cohort</th>
+                <th className="py-2.5 px-3 font-medium w-24">Role</th>
+                <th className="py-2.5 px-3 font-medium hidden sm:table-cell w-24">Status</th>
+                <th className="py-2.5 px-3 font-medium hidden xl:table-cell w-28">Applied</th>
+                <th className="py-2.5 px-3 font-medium w-40 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="py-16 text-center text-text-hint">
+                    No members found.
+                  </td>
+                </tr>
+              ) : members.map(member => {
+                const pending = isPendingApplicant(member)
+                const isSelected = selectedId === member.id
+                const isLoading = actionLoadingId === member.id
+
+                return (
+                  <tr
+                    key={member.id}
+                    onClick={() => isAdmin && !pending && onSelect(member)}
+                    className={`border-b border-border transition-colors ${
+                      pending ? 'bg-warning/5' : ''
+                    } ${
+                      isAdmin && !pending ? 'cursor-pointer hover:bg-bg-layer1' : ''
+                    } ${isSelected ? 'bg-link-bg/40' : ''}`}
+                  >
+                    <td className="py-2.5 px-3">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <UserAvatar
+                          avatarUrl={member.avatarUrl}
+                          firstName={member.firstName}
+                          role={member.role}
+                        />
+                        <span className="text-text-primary truncate">
+                          {[member.firstName, member.lastName].filter(Boolean).join(' ') || '—'}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="py-2.5 px-3 text-text-secondary truncate max-w-[180px]">{member.email ?? '—'}</td>
+                    <td className="py-2.5 px-3 text-text-secondary hidden md:table-cell">{member.school ?? '—'}</td>
+                    <td className="py-2.5 px-3 text-text-secondary hidden lg:table-cell">
+                      {member.cohort ? cohortLabel(member.cohort) : '—'}
+                    </td>
+                    <td className="py-2.5 px-3 text-text-primary">{formatRole(member.role)}</td>
+                    <td className="py-2.5 px-3 text-text-secondary hidden sm:table-cell">{formatStatus(member.status)}</td>
+                    <td className="py-2.5 px-3 text-text-hint hidden xl:table-cell">{formatDate(member.createdAt)}</td>
+                    <td className="py-2.5 px-3">
+                      {pending ? (
+                        <div className="flex items-center justify-end gap-2" onClick={e => e.stopPropagation()}>
+                          <button
+                            type="button"
+                            disabled={isLoading}
+                            onClick={() => onApprove(member.id)}
+                            className="px-3 py-1.5 rounded-md text-xs font-medium bg-success text-white hover:opacity-90 disabled:opacity-50 transition-opacity"
+                          >
+                            {isLoading ? '…' : 'Approve'}
+                          </button>
+                          <button
+                            type="button"
+                            disabled={isLoading}
+                            onClick={() => setRejectTarget(member)}
+                            className="px-3 py-1.5 rounded-md text-xs font-medium border border-border-strong text-text-secondary hover:bg-bg-layer1 disabled:opacity-50 transition-colors"
+                          >
+                            Reject
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="text-right text-xs text-text-hint">—</div>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {rejectTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="bg-bg-surface rounded-lg p-6 max-w-sm w-full shadow-lg border border-border">
+            <p className="font-inter text-base text-text-primary mb-2">Reject this application?</p>
+            <p className="text-sm text-text-secondary mb-6">
+              {[rejectTarget.firstName, rejectTarget.lastName].filter(Boolean).join(' ')} will be removed from the pending queue. Their account stays in the database.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                type="button"
+                onClick={() => setRejectTarget(null)}
+                className="px-4 py-2 border border-border-strong rounded-md text-sm font-inter text-text-secondary hover:bg-bg-layer1 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={actionLoadingId === rejectTarget.id}
+                onClick={async () => {
+                  await onReject(rejectTarget.id)
+                  setRejectTarget(null)
+                }}
+                className="px-4 py-2 bg-accent text-white rounded-md text-sm font-medium font-inter hover:bg-accent-hover disabled:opacity-50 transition-colors"
+              >
+                {actionLoadingId === rejectTarget.id ? 'Rejecting…' : 'Reject'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -1,19 +1,178 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
 import RoleGuard from '@/components/auth/RoleGuard'
+import { useAuth } from '@/hooks/useAuth'
+import { ROLES } from '@/utils/constants'
+import { formatRequestError } from '@/utils/requestErrors'
+import {
+  approveMember,
+  fetchAdminMembers,
+  isPendingApplicant,
+  rejectMember,
+  updateAdminMember,
+} from '@/services/adminService'
+import MemberTable from './_components/MemberTable'
+import MemberEditPanel from './_components/MemberEditPanel'
+
+function sortMembers(members) {
+  return [...members].sort((a, b) => {
+    const aPending = isPendingApplicant(a)
+    const bPending = isPendingApplicant(b)
+    if (aPending !== bPending) return aPending ? -1 : 1
+    return (a.firstName ?? '').localeCompare(b.firstName ?? '')
+  })
+}
 
 export default function AdminPage() {
+  const { profile, accessToken, loading: authLoading } = useAuth()
+  const isAdmin = profile?.role === ROLES.ADMIN
+
+  const [members, setMembers] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
+  const [selectedMember, setSelectedMember] = useState(null)
+  const [actionLoadingId, setActionLoadingId] = useState(null)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState('')
+
+  const loadMembers = useCallback(async () => {
+    if (!accessToken) return
+    setLoadError('')
+    try {
+      const data = await fetchAdminMembers(accessToken)
+      setMembers(sortMembers(data))
+    } catch (err) {
+      setLoadError(formatRequestError(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [accessToken])
+
+  useEffect(() => {
+    if (authLoading) return
+    if (!accessToken) {
+      setLoading(false)
+      setLoadError('Your session expired. Please refresh the page and log in again.')
+      return
+    }
+    setLoading(true)
+    loadMembers()
+  }, [accessToken, authLoading, loadMembers])
+
+  useEffect(() => {
+    setSelectedMember(current => {
+      if (!current) return null
+      const fresh = members.find(m => m.id === current.id)
+      if (!fresh || isPendingApplicant(fresh)) return null
+      return fresh
+    })
+  }, [members])
+
+  async function handleApprove(userId) {
+    if (!accessToken) return
+    setActionLoadingId(userId)
+    try {
+      const updated = await approveMember(accessToken, userId)
+      setMembers(prev => sortMembers(prev.map(m => (m.id === userId ? updated : m))))
+      if (selectedMember?.id === userId) setSelectedMember(null)
+    } catch (err) {
+      setLoadError(formatRequestError(err))
+    } finally {
+      setActionLoadingId(null)
+    }
+  }
+
+  async function handleReject(userId) {
+    if (!accessToken) return
+    setActionLoadingId(userId)
+    try {
+      await rejectMember(accessToken, userId)
+      setMembers(prev => sortMembers(prev.filter(m => m.id !== userId)))
+      if (selectedMember?.id === userId) setSelectedMember(null)
+    } catch (err) {
+      setLoadError(formatRequestError(err))
+    } finally {
+      setActionLoadingId(null)
+    }
+  }
+
+  async function handleSave(form) {
+    if (!selectedMember || !accessToken) return
+    setSaving(true)
+    setSaveError('')
+    try {
+      const updated = await updateAdminMember(accessToken, selectedMember.id, form)
+      setMembers(prev => sortMembers(prev.map(m => (m.id === updated.id ? updated : m))))
+      setSelectedMember(null)
+      setSaveError('')
+    } catch (err) {
+      setSaveError(formatRequestError(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const pendingCount = members.filter(isPendingApplicant).length
+
   return (
     <RoleGuard>
       <main className="min-h-screen bg-bg-base">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-10 md:pt-16 pb-8 md:pb-12">
-          <h1 className="font-montserrat font-bold text-4xl md:text-5xl mb-3 text-text-primary">Admin</h1>
-          <p className="text-text-secondary">User approvals · Role management · Problem CRUD · QR sessions</p>
-        </div>
-        <section className="max-w-6xl mx-auto px-4 sm:px-6 pb-16">
-          <div className="border border-border rounded-lg p-10 flex flex-col items-center justify-center text-center gap-3">
-            <p className="font-montserrat font-semibold text-text-primary">Coming soon</p>
-            <p className="text-sm text-text-secondary">Admin dashboard is in development.</p>
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-8 md:pt-12 pb-8">
+          <div className="mb-6">
+            <h1 className="font-montserrat font-bold text-3xl md:text-4xl text-text-primary">Admin</h1>
+            <p className="text-sm text-text-secondary mt-1 font-inter">
+              {isAdmin ? 'Member approvals and profile management' : 'Member approvals'}
+            </p>
           </div>
-        </section>
+
+          {loadError && (
+            <div className="mb-4 px-4 py-3 rounded-lg border border-error/30 bg-error/5 text-sm text-error font-inter">
+              {loadError}
+            </div>
+          )}
+
+          {loading || authLoading ? (
+            <div className="flex justify-center items-center py-32">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-text-primary" />
+            </div>
+          ) : (
+            <div className={`grid gap-4 ${isAdmin && selectedMember ? 'lg:grid-cols-5' : 'grid-cols-1'}`}>
+              <div className={isAdmin && selectedMember ? 'lg:col-span-3' : ''}>
+                <MemberTable
+                  members={members}
+                  selectedId={selectedMember?.id}
+                  isAdmin={isAdmin}
+                  actionLoadingId={actionLoadingId}
+                  onSelect={setSelectedMember}
+                  onApprove={handleApprove}
+                  onReject={handleReject}
+                />
+              </div>
+
+              {isAdmin && selectedMember && (
+                <div className="lg:col-span-2">
+                  <MemberEditPanel
+                    member={selectedMember}
+                    saving={saving}
+                    error={saveError}
+                    onSave={handleSave}
+                    onCancel={() => {
+                      setSelectedMember(null)
+                      setSaveError('')
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {!loading && pendingCount === 0 && !isAdmin && (
+            <p className="mt-4 text-sm text-text-hint font-inter text-center">
+              No pending approvals right now.
+            </p>
+          )}
+        </div>
       </main>
     </RoleGuard>
   )

--- a/src/app/api/admin/members/[id]/route.js
+++ b/src/app/api/admin/members/[id]/route.js
@@ -1,0 +1,92 @@
+import { verifyAdminCaller } from '@/lib/adminApi'
+import { SCHOOLS, ROLES } from '@/utils/constants'
+import { isValidPhone } from '@/utils/phone'
+
+const EDITABLE_ROLES = [ROLES.MEMBER, ROLES.EXECUTIVE, ROLES.ADMIN]
+const EDITABLE_STATUSES = ['student', 'graduate']
+
+const ALLOWED_FIELDS = new Set([
+  'first_name',
+  'last_name',
+  'school',
+  'cohort',
+  'role',
+  'status',
+  'phone',
+])
+
+function normalizeStatus(status) {
+  if (status === 'graduated') return 'graduate'
+  return status
+}
+
+export async function PATCH(request, { params }) {
+  const auth = await verifyAdminCaller(request, { adminOnly: true })
+  if (auth.error) return auth.error
+
+  const { id } = await params
+  if (!id) {
+    return Response.json({ error: 'Member id is required' }, { status: 400 })
+  }
+
+  const body = await request.json()
+  const updates = {}
+
+  for (const [key, value] of Object.entries(body)) {
+    if (!ALLOWED_FIELDS.has(key)) continue
+    updates[key] = value
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return Response.json({ error: 'No valid fields to update' }, { status: 400 })
+  }
+
+  if (updates.first_name !== undefined && !String(updates.first_name).trim()) {
+    return Response.json({ error: 'First name is required' }, { status: 400 })
+  }
+
+  if (updates.last_name !== undefined && !String(updates.last_name).trim()) {
+    return Response.json({ error: 'Last name is required' }, { status: 400 })
+  }
+
+  if (updates.school !== undefined && !SCHOOLS.includes(updates.school)) {
+    return Response.json({ error: 'Invalid school' }, { status: 400 })
+  }
+
+  if (updates.role !== undefined && !EDITABLE_ROLES.includes(updates.role)) {
+    return Response.json({ error: 'Invalid role' }, { status: 400 })
+  }
+
+  if (updates.status !== undefined) {
+    updates.status = normalizeStatus(updates.status)
+    if (!EDITABLE_STATUSES.includes(updates.status)) {
+      return Response.json({ error: 'Invalid status' }, { status: 400 })
+    }
+  }
+
+  if (updates.phone !== undefined && updates.phone && !isValidPhone(updates.phone)) {
+    return Response.json({ error: 'Phone must match (XXX) XXX-XXXX' }, { status: 400 })
+  }
+
+  if (updates.first_name) updates.first_name = String(updates.first_name).trim()
+  if (updates.last_name) updates.last_name = String(updates.last_name).trim()
+
+  if (updates.role && updates.role !== ROLES.PENDING) {
+    updates.application_status = 'approved'
+  }
+
+  const { serviceClient } = auth
+
+  const { data, error } = await serviceClient
+    .from('profiles')
+    .update(updates)
+    .eq('id', id)
+    .select('id, first_name, last_name, email, avatar_url, school, cohort, phone, status, role, application_status, created_at')
+    .single()
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 })
+  }
+
+  return Response.json({ profile: data })
+}

--- a/src/app/api/admin/members/route.js
+++ b/src/app/api/admin/members/route.js
@@ -1,0 +1,27 @@
+import { verifyAdminCaller } from '@/lib/adminApi'
+
+export async function GET(request) {
+  const auth = await verifyAdminCaller(request)
+  if (auth.error) return auth.error
+
+  const { serviceClient } = auth
+
+  const { data, error } = await serviceClient
+    .from('profiles')
+    .select('id, first_name, last_name, email, avatar_url, school, cohort, phone, status, role, application_status, created_at')
+    .neq('application_status', 'rejected')
+    .order('first_name', { ascending: true })
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 })
+  }
+
+  const sorted = [...(data ?? [])].sort((a, b) => {
+    const aPending = a.role === 'pending' && a.application_status === 'pending'
+    const bPending = b.role === 'pending' && b.application_status === 'pending'
+    if (aPending !== bPending) return aPending ? -1 : 1
+    return (a.first_name ?? '').localeCompare(b.first_name ?? '')
+  })
+
+  return Response.json({ members: sorted })
+}

--- a/src/app/api/admin/reject/route.js
+++ b/src/app/api/admin/reject/route.js
@@ -22,7 +22,7 @@ export async function POST(request) {
   }
 
   if (target.application_status === 'rejected') {
-    return Response.json({ error: 'Cannot approve a rejected application' }, { status: 400 })
+    return Response.json({ error: 'Application is already rejected' }, { status: 400 })
   }
 
   if (target.role !== 'pending' || target.application_status !== 'pending') {
@@ -31,7 +31,7 @@ export async function POST(request) {
 
   const { data, error } = await serviceClient
     .from('profiles')
-    .update({ role: 'member', application_status: 'approved' })
+    .update({ application_status: 'rejected' })
     .eq('id', userId)
     .select('id, first_name, last_name, email, avatar_url, school, cohort, phone, status, role, application_status, created_at')
     .single()

--- a/src/components/common/JoinModal.js
+++ b/src/components/common/JoinModal.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useJoinModal } from '@/contexts/JoinModalContext'
 import { useAuth } from '@/hooks/useAuth'
 import { createProfile } from '@/services/authService'
+import { formatRequestError } from '@/utils/requestErrors'
 import Button from '@/components/ui/Button'
 import { cohortLabel } from '@/utils/cohort'
 import { SCHOOLS } from '@/utils/constants'
@@ -151,6 +152,7 @@ export default function JoinModal() {
   async function handleSubmit() {
     if (submitting || !validate() || !user) return
     setSubmitting(true)
+    setErrors({})
 
     try {
       await createProfile({
@@ -171,11 +173,12 @@ export default function JoinModal() {
       })
 
       sessionStorage.removeItem('join_modal_dismissed')
-      await refreshProfile()
+      refreshProfile().catch(() => {})
       closeModal()
       router.push('/pending')
     } catch (err) {
-      setErrors({ submit: err.message })
+      setErrors({ submit: formatRequestError(err) })
+    } finally {
       setSubmitting(false)
     }
   }

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation'
 import { socialLinks } from '@/config/socialLinks'
 import { useAuth } from '@/hooks/useAuth'
 import { signInWithGoogle } from '@/services/authService'
+import { canAccessAdminRoutes } from '@/utils/constants'
 import { IconLinkedIn, IconGitHub } from '@/components/ui/SocialIcons'
 
 const publicLinks = [
@@ -135,7 +136,7 @@ export default function Navbar() {
 
   const role = profile?.role ?? null
   const isMember = role === 'member' || role === 'executive' || role === 'admin'
-  const isAdmin = role === 'admin'
+  const canAccessAdmin = canAccessAdminRoutes(role)
   const profileHref = role === 'pending' ? '/pending' : `/members/${user?.id}`
 
   const allLinks = isMember ? [...publicLinks, ...memberOnlyLinks] : publicLinks
@@ -209,7 +210,7 @@ export default function Navbar() {
               {loggingIn ? 'Redirecting…' : 'Log In'}
             </button>
           )}
-          {isAdmin && (
+          {canAccessAdmin && (
             <Link href="/admin" title="Admin"
               className="ml-1 p-1.5 text-text-secondary hover:text-text-primary transition-colors">⚙</Link>
           )}
@@ -276,7 +277,7 @@ export default function Navbar() {
           {user && (
             <>
               <div className="my-2 h-px bg-border" />
-              {isAdmin && (
+              {canAccessAdmin && (
                 <Link href="/admin" onClick={() => setMobileOpen(false)}
                   className="block px-2 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-layer1 rounded-md transition-colors">
                   Admin

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -9,6 +9,7 @@ export const AuthContext = createContext(null)
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
   const [profile, setProfile] = useState(null)
+  const [accessToken, setAccessToken] = useState(null)
   const [loading, setLoading] = useState(true)
 
   // getSession, fetchProfile, supabase are stable module-level references;
@@ -24,6 +25,7 @@ export function AuthProvider({ children }) {
       try {
         const session = await getSession()
         setUser(session?.user ?? null)
+        setAccessToken(session?.access_token ?? null)
         if (session?.user) {
           const p = await fetchProfile(session.user.id)
           setProfile(p)
@@ -52,10 +54,12 @@ export function AuthProvider({ children }) {
         try {
           const session = await getSession()
           setUser(session?.user ?? null)
+          setAccessToken(session?.access_token ?? null)
           if (!session?.user) setProfile(null)
         } catch {
           setUser(null)
           setProfile(null)
+          setAccessToken(null)
         }
       })()
     }
@@ -68,6 +72,7 @@ export function AuthProvider({ children }) {
         // buttons disappear briefly).
         if (!initialized) return
         setUser(session?.user ?? null)
+        setAccessToken(session?.access_token ?? null)
         if (session?.user) {
           try {
             const p = await fetchProfile(session.user.id)
@@ -105,12 +110,13 @@ export function AuthProvider({ children }) {
     }
     setUser(null)
     setProfile(null)
+    setAccessToken(null)
     sessionStorage.removeItem('join_modal_dismissed')
     window.location.href = '/'
   }
 
   return (
-    <AuthContext.Provider value={{ user, profile, loading, signOut, refreshProfile }}>
+    <AuthContext.Provider value={{ user, profile, accessToken, loading, signOut, refreshProfile }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/lib/adminApi.js
+++ b/src/lib/adminApi.js
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js'
+
+export function getServiceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  )
+}
+
+export async function verifyAdminCaller(request, { adminOnly = false } = {}) {
+  const authHeader = request.headers.get('authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    return { error: Response.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const token = authHeader.slice(7)
+  const serviceClient = getServiceClient()
+
+  const { data: { user }, error: authError } = await serviceClient.auth.getUser(token)
+  if (authError || !user) {
+    return { error: Response.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const { data: callerProfile, error: profileError } = await serviceClient
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (profileError || !callerProfile) {
+    return { error: Response.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const allowed = adminOnly
+    ? callerProfile.role === 'admin'
+    : ['admin', 'executive'].includes(callerProfile.role)
+
+  if (!allowed) {
+    return { error: Response.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+
+  return { serviceClient, user, callerProfile }
+}

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -1,0 +1,88 @@
+import { fetchWithTimeout } from '@/utils/fetchWithTimeout'
+
+async function adminFetch(accessToken, path, options = {}) {
+  if (!accessToken) {
+    throw new Error('No active session. Please refresh the page and log in again.')
+  }
+
+  const res = await fetchWithTimeout(path, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+      ...options.headers,
+    },
+  })
+
+  let json
+  try {
+    json = await res.json()
+  } catch {
+    throw new Error('Server returned an invalid response. Try again or refresh the page.')
+  }
+
+  if (!res.ok) throw new Error(json.error ?? 'Request failed.')
+  return json
+}
+
+function mapMember(row) {
+  return {
+    id: row.id,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    email: row.email,
+    avatarUrl: row.avatar_url,
+    school: row.school,
+    cohort: row.cohort,
+    phone: row.phone,
+    status: row.status,
+    role: row.role,
+    applicationStatus: row.application_status,
+    createdAt: row.created_at,
+  }
+}
+
+export function isPendingApplicant(member) {
+  return member.role === 'pending' && member.applicationStatus === 'pending'
+}
+
+export async function fetchAdminMembers(accessToken) {
+  const { members } = await adminFetch(accessToken, '/api/admin/members')
+  return members.map(mapMember)
+}
+
+export async function approveMember(accessToken, userId) {
+  const { profile } = await adminFetch(accessToken, '/api/admin/approve', {
+    method: 'POST',
+    body: JSON.stringify({ userId }),
+  })
+  return mapMember(profile)
+}
+
+export async function rejectMember(accessToken, userId) {
+  await adminFetch(accessToken, '/api/admin/reject', {
+    method: 'POST',
+    body: JSON.stringify({ userId }),
+  })
+}
+
+export async function updateAdminMember(accessToken, userId, fields) {
+  const { profile } = await adminFetch(accessToken, `/api/admin/members/${userId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(fields),
+  })
+  return mapMember(profile)
+}
+
+export function memberToForm(member) {
+  const status = member.status === 'graduated' ? 'graduate' : (member.status ?? 'student')
+  return {
+    first_name: member.firstName ?? '',
+    last_name: member.lastName ?? '',
+    school: member.school ?? '',
+    cohort: member.cohort ?? '',
+    role: member.role ?? 'member',
+    status,
+    phone: member.phone ?? '',
+  }
+}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,4 +1,6 @@
 import { supabase } from '@/lib/supabase'
+import { fetchWithTimeout } from '@/utils/fetchWithTimeout'
+import { withTimeout } from '@/utils/withTimeout'
 
 export async function signInWithGoogle(redirectTo) {
   // Flag that an OAuth redirect is about to happen so the pageshow handler
@@ -33,7 +35,7 @@ export async function fetchProfile(userId) {
 }
 
 export async function createProfile({ id, first_name, last_name, nickname, email, avatarUrl, school, cohort, phone, status, company, occupation, linkedin, github }) {
-  const { data, error } = await supabase
+  const request = supabase
     .from('profiles')
     .update({
       first_name,
@@ -54,6 +56,8 @@ export async function createProfile({ id, first_name, last_name, nickname, email
     .select()
     .single()
 
+  const { data, error } = await withTimeout(request)
+
   if (error) throw error
   return data
 }
@@ -70,15 +74,14 @@ export async function updateProfile(userId, fields) {
   return data
 }
 
-export async function adminApproval(userID) {
-  const session = await getSession()
-  if (!session) throw new Error('Unauthorized: No active session found.')
+export async function adminApproval(userID, accessToken) {
+  if (!accessToken) throw new Error('No active session. Please refresh the page and log in again.')
 
-  const res = await fetch('/api/admin/approve', {
+  const res = await fetchWithTimeout('/api/admin/approve', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${session.access_token}`,
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ userId: userID }),
   })

--- a/src/utils/cohortOptions.js
+++ b/src/utils/cohortOptions.js
@@ -1,0 +1,40 @@
+import { cohortLabel } from '@/utils/cohort'
+
+const FIRST_COHORT = { season: 'Fall', year: 2024 }
+const SKIPPED_TERMS = new Set(['Summer 2025'])
+const SEASON_ORDER = ['Winter', 'Summer', 'Fall']
+
+function getCurrentTerm() {
+  const month = new Date().getMonth() + 1
+  const year = new Date().getFullYear()
+  if (month <= 4) return { season: 'Winter', year }
+  if (month <= 8) return { season: 'Summer', year }
+  return { season: 'Fall', year }
+}
+
+export function generateCohortOptions() {
+  const current = getCurrentTerm()
+  const cohorts = []
+  let { season, year } = FIRST_COHORT
+
+  while (true) {
+    const term = `${season} ${year}`
+    const isCurrent = season === current.season && year === current.year
+
+    if (!SKIPPED_TERMS.has(term)) {
+      const num = cohorts.length + 1
+      cohorts.push({
+        value: String(num),
+        label: `${cohortLabel(num)} (Joined ${term}${isCurrent ? ' ← now' : ''})`,
+      })
+    }
+
+    if (isCurrent) break
+
+    const idx = SEASON_ORDER.indexOf(season)
+    if (idx === 2) { season = 'Winter'; year += 1 }
+    else season = SEASON_ORDER[idx + 1]
+  }
+
+  return cohorts.reverse()
+}

--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -1,0 +1,20 @@
+const DEFAULT_TIMEOUT_MS = 15000
+
+export async function fetchWithTimeout(url, options = {}, ms = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), ms)
+
+  try {
+    return await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    })
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error('Request timed out. Check your connection and try again.')
+    }
+    throw error
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/src/utils/phone.js
+++ b/src/utils/phone.js
@@ -1,0 +1,10 @@
+export function formatPhone(raw) {
+  const digits = raw.replace(/\D/g, '').slice(0, 10)
+  if (digits.length < 4) return digits
+  if (digits.length < 7) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`
+}
+
+export function isValidPhone(phone) {
+  return /^\(\d{3}\) \d{3}-\d{4}$/.test(phone)
+}

--- a/src/utils/requestErrors.js
+++ b/src/utils/requestErrors.js
@@ -1,0 +1,25 @@
+export function formatRequestError(error) {
+  const message = error?.message ?? 'Something went wrong. Please try again.'
+
+  if (message.includes('timed out') || message.includes('timeout')) {
+    return `${message} If this keeps happening, refresh the page and log in again.`
+  }
+
+  if (message.includes('No active session') || message.includes('Unauthorized')) {
+    return 'Your session expired. Please refresh the page and log in again.'
+  }
+
+  if (message.includes('Failed to fetch') || message.includes('NetworkError')) {
+    return 'Network error. Check your internet connection and try again.'
+  }
+
+  if (message.includes('application_status') || message.includes('column')) {
+    return 'Database is out of date. Ask a developer to run the latest Supabase migration.'
+  }
+
+  if (message.includes('SUPABASE_SERVICE_ROLE_KEY') || message.includes('service role')) {
+    return 'Server configuration error. Ask a developer to set SUPABASE_SERVICE_ROLE_KEY in .env.local.'
+  }
+
+  return message
+}

--- a/src/utils/withTimeout.js
+++ b/src/utils/withTimeout.js
@@ -1,0 +1,24 @@
+const DEFAULT_TIMEOUT_MS = 15000
+
+export function withTimeout(
+  promise,
+  ms = DEFAULT_TIMEOUT_MS,
+  message = 'Request timed out. Check your connection and try again.'
+) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(message))
+    }, ms)
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+}

--- a/supabase/migrations/20260623120000_add_application_status.sql
+++ b/supabase/migrations/20260623120000_add_application_status.sql
@@ -1,0 +1,16 @@
+-- Application review state is separate from member role.
+-- pending + application_status=pending: awaiting approval
+-- pending + application_status=rejected: rejected applicant (no member access)
+-- member+ roles: application_status=approved
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS application_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (application_status IN ('pending', 'approved', 'rejected'));
+
+UPDATE public.profiles
+SET application_status = 'approved'
+WHERE role IN ('member', 'executive', 'admin');
+
+UPDATE public.profiles
+SET application_status = 'pending'
+WHERE role = 'pending' AND application_status IS DISTINCT FROM 'rejected';


### PR DESCRIPTION
## Summary
- Replace the Admin page stub with a member table: pending applicants at the top, one-click Approve/Reject, and an admin-only edit panel for operational profile fields and role changes.
- Add `application_status` on `profiles` (pending / approved / rejected) plus server API routes secured with the Supabase service role.
- Harden save flows with 15s request timeouts, cached `accessToken` for admin API calls, and clearer user-facing error messages in JoinModal and Admin.

## Test plan
- [ ] Run `supabase db push` (or apply `20260623120000_add_application_status.sql`) before testing Admin APIs
- [ ] Log in as executive: open `/admin`, approve and reject a pending applicant
- [ ] Log in as admin: edit a member (name, school, cohort, role, status, phone), save, confirm panel closes and table updates
- [ ] Submit JoinModal as a new user: confirm no infinite spinner; errors show if request fails
- [ ] Confirm executive sees Admin link in navbar (desktop and mobile)

