### PR TITLE
chore: update Seneca Discord invite link

### DIFF
--- a/src/config/socialLinks.js
+++ b/src/config/socialLinks.js
@@ -22,7 +22,7 @@ export const socialLinks = {
   ],
   // Member only — hover dropdown per school
   discord: [
-    { school: 'Seneca', url: 'https://discord.gg/SxXDZagWuH' },
+    { school: 'Seneca', url: 'https://discord.gg/QXuybeNpuN' },
     { school: 'York', url: 'https://discord.gg/york-placeholder' },
     // { school: 'TMU', url: 'https://discord.gg/tmu-placeholder' },
   ],


### PR DESCRIPTION
## Summary
- Update the Seneca Discord invite URL in `src/config/socialLinks.js` to the current invite link.

## Test plan
- [ ] As a member, open the navbar Discord dropdown and confirm the Seneca link opens `https://discord.gg/QXuybeNpuN`
- [ ] Confirm York still shows the placeholder link