### PR TITLE
feat: Problems CRUD with markdown and document upload (#31)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,12 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key        # Backend only — never expose to frontend
 
-# FastAPI (Railway)
-NEXT_PUBLIC_API_URL=https://your-railway-app.up.railway.app
+# FastAPI (Heroku) — also used for DOCX → PDF conversion when LibreOffice is not local
+NEXT_PUBLIC_API_URL=https://your-heroku-app.herokuapp.com
+# Optional server-only override for Next.js API routes
+BACKEND_API_URL=https://your-heroku-app.herokuapp.com
+# Local dev: LibreOffice via brew install --cask libreoffice (auto-detected on macOS)
+# LIBREOFFICE_PATH=/Applications/LibreOffice.app/Contents/MacOS/soffice
 
 # Contact Form (Footer) — Gmail SMTP
 # Use a Gmail App Password, not your account password

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The **codeXperts Club** official website — a members-only platform for a codin
 | Feature | Description |
 |---------|-------------|
 | **Google OAuth + RBAC** | 4-tier role system (Public → Member → Executive → Admin) with Supabase RLS enforcement |
-| **Coding Problems** | Weekly problems posted by execs, solved in a Monaco Editor (VSCode-style), executed via Piston API |
+| **Coding Problems** | Weekly problems on `/problems` (markdown editor or Word/PDF document mode); exec/admin CRUD; members read-only |
 | **QR Attendance** | Admin generates a session token → members scan to check in → auto-expires |
 | **Schedule Page** | Google Calendar API integration — synced events with subscribe/download for members |
 | **Member Directory** | Filterable profile cards with cohort, school, role badges, and per-field visibility controls |
@@ -441,7 +441,8 @@ codexperts-web/
 │   │   ├── about/           # /about
 │   │   ├── schedule/        # /schedule
 │   │   ├── api/             # Next.js API routes
-│   │   │   └── calendar/    # GET /api/calendar — iCal fetch + parse (no API key)
+│   │   │   ├── calendar/    # GET /api/calendar — iCal fetch + parse (no API key)
+│   │   │   └── problems/    # Document upload, DOCX→PDF preview/convert
 │   │   ├── announcements/   # /announcements
 │   │   ├── events/          # /events
 │   │   ├── join/            # /join — redirects to / (join flow is Navbar modal)
@@ -451,6 +452,7 @@ codexperts-web/
 │   │   └── admin/           # /admin (admin only)
 │   ├── components/
 │   │   ├── common/          # Navbar, Footer
+│   │   ├── layout/          # PageContainer (About-style max width)
 │   │   ├── auth/            # ProtectedRoute, RoleGuard
 │   │   └── ui/              # Button, Card, Modal
 │   ├── config/
@@ -469,9 +471,11 @@ codexperts-web/
 │   └── schema/              # Database schema definitions
 ├── backend/
 │   ├── main.py              # FastAPI entry point
+│   ├── Procfile             # Heroku web process
+│   ├── Aptfile              # LibreOffice for DOCX→PDF on Heroku
 │   ├── requirements.txt
 │   ├── .env.example
-│   └── routers/
+│   └── routers/             # documents (DOCX→PDF), future execute/attendance
 ├── scripts/
 │   └── sprint-report.js     # CLI tool — GitHub Issue contribution report per member
 ├── package.json

--- a/backend/Aptfile
+++ b/backend/Aptfile
@@ -1,0 +1,3 @@
+libreoffice-writer
+libreoffice-common
+fonts-liberation

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn main:app --host 0.0.0.0 --port $PORT

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,8 +5,8 @@ from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(title="codeXperts API")
 
-# Comma-separated list of explicit origins. Production domain and any extra
-# Vercel preview aliases should be set here in the Railway environment.
+# Comma-separated list of explicit origins. Production domain and Vercel preview
+# aliases should be set in the Heroku config vars.
 origins = [
     o.strip()
     for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
@@ -33,6 +33,10 @@ app.add_middleware(
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+from routers import documents
+
+app.include_router(documents.router)
 
 # Routers added in later sprints:
 # from routers import execute, attendance

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.30.6
 httpx==0.27.0
 pytest==8.3.2
 python-dotenv
+python-multipart==0.0.9

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -1,0 +1,71 @@
+import subprocess
+import tempfile
+from pathlib import Path
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import Response
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+MAX_BYTES = 50 * 1024 * 1024
+
+
+@router.post("/convert/docx-to-pdf")
+async def convert_docx_to_pdf(file: UploadFile = File(...)):
+    if not file.filename or not file.filename.lower().endswith(".docx"):
+        raise HTTPException(status_code=400, detail="Only .docx files are supported.")
+
+    raw = await file.read()
+    if len(raw) > MAX_BYTES:
+        raise HTTPException(status_code=400, detail="File exceeds the 50 MB limit.")
+    if not raw:
+        raise HTTPException(status_code=400, detail="Empty file.")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        input_path = tmp_path / "input.docx"
+        input_path.write_bytes(raw)
+
+        try:
+            subprocess.run(
+                [
+                    "soffice",
+                    "--headless",
+                    "--nologo",
+                    "--nofirststartwizard",
+                    "--convert-to",
+                    "pdf",
+                    "--outdir",
+                    str(tmp_path),
+                    str(input_path),
+                ],
+                check=True,
+                capture_output=True,
+                timeout=120,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(
+                status_code=503,
+                detail="Document converter is not available on the server.",
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or b"").decode("utf-8", errors="ignore")
+            raise HTTPException(
+                status_code=500,
+                detail=f"DOCX to PDF conversion failed. {stderr[:200]}".strip(),
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise HTTPException(status_code=504, detail="Conversion timed out.") from exc
+
+        pdf_path = tmp_path / "input.pdf"
+        if not pdf_path.exists():
+            raise HTTPException(status_code=500, detail="Conversion produced no PDF output.")
+
+        pdf_bytes = pdf_path.read_bytes()
+        output_name = Path(file.filename).with_suffix(".pdf").name
+
+        return Response(
+            content=pdf_bytes,
+            media_type="application/pdf",
+            headers={"Content-Disposition": f'inline; filename="{output_name}"'},
+        )

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@uiw/react-codemirror": "^4.25.10",
         "@uiw/react-md-editor": "^4.1.1",
         "cloudinary": "^2.10.0",
+        "docx-preview": "^0.3.7",
+        "jszip": "^3.10.1",
         "lucide-react": "^1.14.0",
         "next": "^16.2.3",
         "nodemailer": "^8.0.7",
@@ -24,6 +26,7 @@
         "react-dom": "^19.2.4",
         "react-easy-crop": "^5.5.7",
         "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -1751,6 +1754,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -1887,6 +1896,15 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/docx-preview": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/docx-preview/-/docx-preview-0.3.7.tgz",
+      "integrity": "sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jszip": ">=3.0.0"
+      }
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -2368,6 +2386,12 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2376,6 +2400,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -2501,6 +2531,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -2516,6 +2552,27 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -3628,6 +3685,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -3894,6 +3957,12 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -4001,6 +4070,21 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -4358,6 +4442,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4376,6 +4466,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -4439,6 +4535,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/stringify-entities": {
@@ -4844,7 +4949,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@uiw/react-codemirror": "^4.25.10",
     "@uiw/react-md-editor": "^4.1.1",
     "cloudinary": "^2.10.0",
+    "docx-preview": "^0.3.7",
+    "jszip": "^3.10.1",
     "lucide-react": "^1.14.0",
     "next": "^16.2.3",
     "nodemailer": "^8.0.7",
@@ -19,6 +21,7 @@
     "react-dom": "^19.2.4",
     "react-easy-crop": "^5.5.7",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {

--- a/src/app/announcements/_editor.js
+++ b/src/app/announcements/_editor.js
@@ -14,12 +14,34 @@ const customTheme = EditorView.theme({
   '.cm-editor': { borderRadius: '0 0 6px 6px' },
 })
 
-export default function MarkdownCodeEditor({ value, onChange, height = '360px' }) {
+export default function MarkdownCodeEditor({ value, onChange, height = '360px', onFilesDrop }) {
+  const extensions = [markdown(), customTheme]
+
+  if (onFilesDrop) {
+    extensions.push(EditorView.domEventHandlers({
+      dragover(event) {
+        if (event.dataTransfer?.types?.includes('Files')) {
+          event.preventDefault()
+          return true
+        }
+        return false
+      },
+      drop(event) {
+        const files = Array.from(event.dataTransfer?.files ?? [])
+        if (files.length === 0) return false
+        event.preventDefault()
+        event.stopPropagation()
+        onFilesDrop(files)
+        return true
+      },
+    }))
+  }
+
   return (
     <CodeMirror
       value={value}
       height={height}
-      extensions={[markdown(), customTheme]}
+      extensions={extensions}
       onChange={onChange}
       basicSetup={{
         lineNumbers: true,

--- a/src/app/api/problems/documents/preview/route.js
+++ b/src/app/api/problems/documents/preview/route.js
@@ -1,0 +1,37 @@
+import { verifyAdminCaller } from '@/lib/adminApi'
+import { convertDocxToPdf } from '@/lib/docxToPdfServer'
+
+export const runtime = 'nodejs'
+
+export async function POST(request) {
+  const auth = await verifyAdminCaller(request)
+  if (auth.error) return auth.error
+
+  const formData = await request.formData()
+  const file = formData.get('file')
+
+  if (!file || typeof file.name !== 'string' || !file.name.toLowerCase().endsWith('.docx')) {
+    return Response.json({ error: 'A .docx file is required.' }, { status: 400 })
+  }
+
+  try {
+    const pdfBuffer = await convertDocxToPdf(Buffer.from(await file.arrayBuffer()), file.name)
+    const pdfName = file.name.replace(/\.docx$/i, '.pdf')
+
+    return new Response(pdfBuffer, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `inline; filename="${pdfName}"`,
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch (err) {
+    return Response.json(
+      {
+        error: err?.message
+          ?? 'Could not convert DOCX to PDF. Install LibreOffice locally, configure BACKEND_API_URL, or upload a PDF instead.',
+      },
+      { status: 422 },
+    )
+  }
+}

--- a/src/app/api/problems/documents/route.js
+++ b/src/app/api/problems/documents/route.js
@@ -1,0 +1,107 @@
+import { randomUUID } from 'crypto'
+import { verifyAdminCaller, verifyMemberPlusCaller } from '@/lib/adminApi'
+import { convertDocxToPdf } from '@/lib/docxToPdfServer'
+import {
+  PROBLEM_BUCKET,
+  MAX_DOCUMENT_BYTES,
+  detectProblemFileType,
+  FILE_FORMAT,
+} from '@/services/problemsService'
+
+export const runtime = 'nodejs'
+
+export async function POST(request) {
+  const auth = await verifyAdminCaller(request)
+  if (auth.error) return auth.error
+
+  const formData = await request.formData()
+  const file = formData.get('file')
+  const problemId = formData.get('problemId')
+
+  if (!file || typeof problemId !== 'string' || !problemId.trim()) {
+    return Response.json({ error: 'File and problemId are required.' }, { status: 400 })
+  }
+
+  if (file.size > MAX_DOCUMENT_BYTES) {
+    return Response.json({ error: 'File exceeds the 50 MB limit.' }, { status: 400 })
+  }
+
+  let fileType = detectProblemFileType(file)
+  if (fileType !== FILE_FORMAT.DOCX && fileType !== FILE_FORMAT.PDF) {
+    return Response.json({ error: 'Only .docx and .pdf files are supported.' }, { status: 400 })
+  }
+
+  let bytes = Buffer.from(await file.arrayBuffer())
+
+  if (fileType === FILE_FORMAT.DOCX) {
+    try {
+      bytes = await convertDocxToPdf(bytes, file.name)
+      fileType = FILE_FORMAT.PDF
+    } catch (err) {
+      return Response.json(
+        {
+          error: err?.message
+            ?? 'Could not convert DOCX to PDF. Upload a PDF instead, or configure document conversion.',
+        },
+        { status: 422 },
+      )
+    }
+  }
+
+  const path = `${problemId}/${randomUUID()}.${fileType}`
+
+  const { error } = await auth.serviceClient.storage
+    .from(PROBLEM_BUCKET)
+    .upload(path, bytes, {
+      contentType: fileType === FILE_FORMAT.PDF ? 'application/pdf' : undefined,
+      upsert: false,
+    })
+
+  if (error) {
+    return Response.json({ error: error.message ?? 'Upload failed.' }, { status: 500 })
+  }
+
+  return Response.json({ path, fileFormat: fileType })
+}
+
+export async function GET(request) {
+  const auth = await verifyMemberPlusCaller(request)
+  if (auth.error) return auth.error
+
+  const path = request.nextUrl.searchParams.get('path')
+  if (!path) {
+    return Response.json({ error: 'path is required.' }, { status: 400 })
+  }
+
+  if (request.nextUrl.searchParams.get('download') === '1') {
+    const { data, error } = await auth.serviceClient.storage
+      .from(PROBLEM_BUCKET)
+      .download(path)
+
+    if (error) {
+      return Response.json({ error: error.message ?? 'Failed to download file.' }, { status: 500 })
+    }
+
+    const ext = path.split('.').pop()?.toLowerCase()
+    const contentType = ext === 'pdf'
+      ? 'application/pdf'
+      : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+
+    return new Response(data, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'private, max-age=3600',
+      },
+    })
+  }
+
+  const { data, error } = await auth.serviceClient.storage
+    .from(PROBLEM_BUCKET)
+    .createSignedUrl(path, 3600)
+
+  if (error) {
+    return Response.json({ error: error.message ?? 'Failed to create signed URL.' }, { status: 500 })
+  }
+
+  return Response.json({ signedUrl: data.signedUrl })
+}

--- a/src/app/api/upload/route.js
+++ b/src/app/api/upload/route.js
@@ -7,13 +7,14 @@ cloudinary.config({
   api_secret: process.env.CLOUDINARY_API_SECRET,
 })
 
-const ALLOWED_FOLDERS = ['hero', 'profiles', 'announcements', 'events']
+const ALLOWED_FOLDERS = ['hero', 'profiles', 'announcements', 'events', 'problems']
 
 const FOLDER_ROLES = {
   hero: ['executive', 'admin'],
   profiles: ['member', 'executive', 'admin'],
   announcements: ['executive', 'admin'],
   events: ['executive', 'admin'],
+  problems: ['executive', 'admin'],
 }
 
 function getServiceClient() {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,3 +5,30 @@
 body {
   font-family: var(--font-inter), sans-serif;
 }
+
+/* DOCX viewer — preserve native page width; scroll horizontally when needed */
+.docx-preview-problem .docx-wrapper {
+  background: #fff;
+  padding: 0;
+}
+
+.docx-preview-problem .docx-wrapper > section.docx {
+  width: auto !important;
+  min-width: min(100%, 40rem);
+  margin: 0 auto 1rem;
+  box-sizing: border-box;
+  background: #fff;
+}
+
+.docx-preview-problem section.docx {
+  color: #000;
+}
+
+.docx-preview-problem table {
+  border-collapse: collapse;
+}
+
+.docx-preview-problem img {
+  max-width: 100%;
+  height: auto;
+}

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -1,0 +1,687 @@
+'use client'
+
+import { useState, useRef, useCallback, useEffect } from 'react'
+import dynamic from 'next/dynamic'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Upload } from 'lucide-react'
+import { uploadImage } from '@/services/cloudinaryService'
+import { resolveMarkdownWithAssets, pickMarkdownFile, countUnresolvedImageRefs, prepareMarkdownForDisplay, buildPendingImageMap, guessTitleFromImport, guessTitleFromFilename, applyLocalImagesForPreview } from '@/utils/markdownImport'
+import { extractFilesFromZip, isZipFile } from '@/utils/zipImport'
+import {
+  CONTENT_TYPE,
+  FILE_FORMAT,
+  detectProblemFileType,
+  downloadProblemDocument,
+  getDocumentSignedUrl,
+  previewDocxAsPdf,
+} from '@/services/problemsService'
+
+const MarkdownCodeEditor = dynamic(() => import('../announcements/_editor'), { ssr: false })
+
+export const SCHOOL_OPTIONS = ['Seneca College', 'York University']
+
+export const mdComponents = {
+  h1: ({ children }) => <h1 className="font-montserrat font-bold text-2xl text-text-primary mt-6 mb-3">{children}</h1>,
+  h2: ({ children }) => <h2 className="font-montserrat font-semibold text-xl text-text-primary mt-5 mb-2">{children}</h2>,
+  h3: ({ children }) => <h3 className="font-montserrat font-medium text-lg text-text-primary mt-4 mb-2">{children}</h3>,
+  p: ({ children }) => <p className="text-text-primary font-inter text-base leading-[1.7] mb-4">{children}</p>,
+  ul: ({ children }) => <ul className="list-disc pl-6 mb-4 text-text-primary font-inter">{children}</ul>,
+  ol: ({ children }) => <ol className="list-decimal pl-6 mb-4 text-text-primary font-inter">{children}</ol>,
+  li: ({ children }) => <li className="mb-1">{children}</li>,
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  a: ({ href, children }) => <a href={href} className="text-link hover:underline" target="_blank" rel="noopener noreferrer">{children}</a>,
+  img: ({ src, alt }) => {
+    if (!src || (!/^https?:/i.test(src) && !src.startsWith('data:') && !src.startsWith('blob:'))) return null
+    return <img src={src} alt={alt ?? ''} className="max-w-full rounded-md my-4" />
+  },
+  table: ({ children }) => (
+    <div className="overflow-x-auto my-4">
+      <table className="border-collapse border border-border w-full text-sm font-inter">{children}</table>
+    </div>
+  ),
+  thead: ({ children }) => <thead className="bg-bg-surface">{children}</thead>,
+  th: ({ children }) => (
+    <th className="border border-border px-3 py-2 text-left font-medium text-text-primary">{children}</th>
+  ),
+  td: ({ children }) => (
+    <td className="border border-border px-3 py-2 align-top text-text-primary">{children}</td>
+  ),
+  blockquote: ({ children }) => <blockquote className="border-l-4 border-border pl-4 italic text-text-secondary my-4">{children}</blockquote>,
+  code: ({ children, className }) => {
+    const isBlock = Boolean(className?.includes('language-'))
+    return isBlock
+      ? <code className="block bg-bg-elevated rounded p-4 font-mono text-sm overflow-x-auto my-4">{children}</code>
+      : <code className="bg-bg-elevated rounded px-1 py-0.5 font-mono text-sm">{children}</code>
+  },
+  hr: () => <hr className="border-border my-6" />,
+}
+
+export function emptyProblemForm() {
+  return {
+    title: '',
+    week: '',
+    dueDate: '',
+    school: SCHOOL_OPTIONS[0],
+    contentType: CONTENT_TYPE.MARKDOWN,
+    fileFormat: null,
+    description: '',
+    pendingFile: null,
+    fileUrl: null,
+    documentName: null,
+    pendingImageFiles: [],
+  }
+}
+
+export function problemToForm(problem) {
+  return {
+    title: problem.title ?? '',
+    week: problem.week != null ? String(problem.week) : '',
+    dueDate: problem.due_date ? String(problem.due_date).slice(0, 10) : '',
+    school: problem.school ?? SCHOOL_OPTIONS[0],
+    contentType: problem.content_type ?? CONTENT_TYPE.MARKDOWN,
+    fileFormat: problem.file_format,
+    description: problem.description ?? '',
+    pendingFile: null,
+    fileUrl: problem.file_url,
+    documentName: problem.file_url ? problem.file_url.split('/').pop() : null,
+    pendingImageFiles: [],
+  }
+}
+
+function EditorTabs({ activeTab, onTabChange, disabled }) {
+  return (
+    <div className="flex border-b border-border bg-bg-surface px-3 pt-2 rounded-t-md gap-1">
+      {['Write', 'Preview'].map(tab => (
+        <button
+          key={tab}
+          type="button"
+          disabled={disabled}
+          onClick={() => onTabChange(tab)}
+          className={`px-4 py-1.5 text-sm font-inter rounded-t-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+            activeTab === tab
+              ? 'bg-bg-base border border-b-0 border-border text-text-primary font-medium -mb-px pb-2'
+              : 'text-text-secondary hover:text-text-primary'
+          }`}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function readFileAsText(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '')
+    reader.onerror = () => reject(new Error('Failed to read file.'))
+    reader.readAsText(file)
+  })
+}
+
+async function renderDocxToElement(buffer, container) {
+  container.innerHTML = ''
+  const { renderAsync } = await import('docx-preview')
+  await renderAsync(buffer, container, container, {
+    className: 'docx-preview-problem',
+    inWrapper: true,
+    ignoreWidth: false,
+    ignoreHeight: false,
+    ignoreFonts: false,
+    useBase64URL: true,
+    breakPages: false,
+    experimental: true,
+  })
+}
+
+function MarkdownBody({ children, pendingImageMap }) {
+  const prepared = prepareMarkdownForDisplay(children)
+  const preview = applyLocalImagesForPreview(prepared, pendingImageMap)
+  return (
+    <Markdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+      {preview}
+    </Markdown>
+  )
+}
+
+export function DocumentViewer({ storagePath, fileFormat, accessToken, className = '' }) {
+  const containerRef = useRef(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [pdfUrl, setPdfUrl] = useState('')
+  const [docxBuffer, setDocxBuffer] = useState(null)
+
+  useEffect(() => {
+    if (!storagePath || !fileFormat || !accessToken) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      setError('')
+      setPdfUrl('')
+      setDocxBuffer(null)
+      try {
+        if (fileFormat === FILE_FORMAT.PDF) {
+          const url = await getDocumentSignedUrl(storagePath, accessToken)
+          if (!cancelled) setPdfUrl(url)
+        } else if (fileFormat === FILE_FORMAT.DOCX) {
+          const blob = await downloadProblemDocument(storagePath, accessToken)
+          if (!cancelled) setDocxBuffer(await blob.arrayBuffer())
+        }
+      } catch {
+        if (!cancelled) setError('Failed to load document.')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => { cancelled = true }
+  }, [storagePath, fileFormat, accessToken])
+
+  useEffect(() => {
+    if (!docxBuffer || !containerRef.current) return
+
+    let cancelled = false
+    renderDocxToElement(docxBuffer, containerRef.current).catch(() => {
+      if (!cancelled) setError('Failed to render document.')
+    })
+
+    return () => { cancelled = true }
+  }, [docxBuffer])
+
+  if (loading) {
+    return (
+      <div className={`flex items-center justify-center py-16 ${className}`}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return <p className={`text-text-secondary font-inter text-sm ${className}`}>{error}</p>
+  }
+
+  if (fileFormat === FILE_FORMAT.PDF && pdfUrl) {
+    return (
+      <iframe
+        title="Problem document"
+        src={pdfUrl}
+        className={`w-full min-h-[70vh] border border-border rounded-md bg-bg-base ${className}`}
+      />
+    )
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={`overflow-x-auto border border-border rounded-md bg-bg-base p-2 sm:p-4 min-h-[50vh] ${className}`}
+    />
+  )
+}
+
+function PendingDocumentPreview({ file, fileFormat, accessToken }) {
+  const [pdfUrl, setPdfUrl] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    let objectUrl = ''
+
+    async function load() {
+      setLoading(true)
+      setError('')
+      setPdfUrl('')
+      try {
+        if (fileFormat === FILE_FORMAT.PDF) {
+          objectUrl = URL.createObjectURL(file)
+          if (!cancelled) setPdfUrl(objectUrl)
+        } else if (fileFormat === FILE_FORMAT.DOCX) {
+          const pdfBlob = await previewDocxAsPdf(file, accessToken)
+          objectUrl = URL.createObjectURL(pdfBlob)
+          if (!cancelled) setPdfUrl(objectUrl)
+        }
+      } catch (err) {
+        if (!cancelled) setError(err?.message ?? 'Failed to preview document.')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [file, fileFormat, accessToken])
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 gap-3">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent" />
+        {fileFormat === FILE_FORMAT.DOCX && (
+          <p className="text-sm font-inter text-text-secondary">Converting Word to PDF for preview…</p>
+        )}
+      </div>
+    )
+  }
+
+  if (error) {
+    return <p className="text-sm font-inter text-accent">{error}</p>
+  }
+
+  if (pdfUrl) {
+    return (
+      <iframe
+        title="Document preview"
+        src={pdfUrl}
+        className="w-full min-h-[50vh] border border-border rounded-md bg-bg-base"
+      />
+    )
+  }
+
+  return null
+}
+
+export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, editMode = false, accessToken }) {
+  const [tab, setTab] = useState('Write')
+  const [dragOver, setDragOver] = useState(false)
+  const [fileError, setFileError] = useState('')
+  const [editorKey, setEditorKey] = useState(0)
+  const fileInputRef = useRef(null)
+
+  const isDocument = form.contentType === CONTENT_TYPE.DOCUMENT
+
+  const applyMdBundle = useCallback(async (files, titleSourceFile) => {
+    const mdFile = pickMarkdownFile(files)
+    if (!mdFile) return
+    setFileError('')
+    try {
+      let text = await readFileAsText(mdFile)
+      const pendingImageMap = buildPendingImageMap(files)
+      const hasImages = pendingImageMap.size > 0
+      const uploader = accessToken
+        ? async (img) => {
+            const { url } = await uploadImage(img, 'problems')
+            return url
+          }
+        : null
+
+      if (hasImages && !accessToken) {
+        setFileError('Sign in again to upload images with this markdown file.')
+        return
+      }
+
+      text = await resolveMarkdownWithAssets(text, files, uploader)
+
+      const missingImages = countUnresolvedImageRefs(text)
+      if (missingImages > 0 && !hasImages) {
+        setFileError(
+          `${missingImages} image(s) missing. Import or drop image files separately (filenames must match the markdown).`,
+        )
+      } else if (missingImages > 0) {
+        setFileError(
+          `Imported with ${missingImages} unresolved image(s). Check filenames match paths in the markdown.`,
+        )
+      }
+
+      const titleFile = titleSourceFile ?? mdFile
+      onChange(prev => ({
+        ...prev,
+        contentType: CONTENT_TYPE.MARKDOWN,
+        fileFormat: null,
+        description: text,
+        pendingFile: null,
+        fileUrl: null,
+        documentName: null,
+        pendingImageFiles: [...pendingImageMap.values()],
+        title: prev.title.trim() || guessTitleFromImport(mdFile, text) || guessTitleFromFilename(titleFile.name),
+      }))
+      setEditorKey(k => k + 1)
+      setTab('Write')
+    } catch {
+      setFileError('Failed to read the markdown file.')
+    }
+  }, [onChange, accessToken])
+
+  const attachMarkdownImages = useCallback(async (imageFiles) => {
+    if (!imageFiles.length) return
+    if (!accessToken) {
+      setFileError('Sign in again to upload images.')
+      return
+    }
+
+    setFileError('')
+    try {
+      const existing = form.pendingImageFiles ?? []
+      const merged = [...existing]
+      for (const file of imageFiles) {
+        const name = file.name.toLowerCase()
+        const idx = merged.findIndex(f => f.name.toLowerCase() === name)
+        if (idx >= 0) merged[idx] = file
+        else merged.push(file)
+      }
+
+      const uploader = async (img) => {
+        const { url } = await uploadImage(img, 'problems')
+        return url
+      }
+      const text = await resolveMarkdownWithAssets(form.description, merged, uploader)
+      const missingImages = countUnresolvedImageRefs(text)
+      if (missingImages > 0) {
+        setFileError(
+          `${missingImages} image(s) still missing. Filenames must match paths in the markdown.`,
+        )
+      }
+
+      onChange(prev => ({
+        ...prev,
+        contentType: CONTENT_TYPE.MARKDOWN,
+        description: text,
+        pendingImageFiles: merged,
+      }))
+    } catch {
+      setFileError('Failed to attach images.')
+    }
+  }, [accessToken, form.description, form.pendingImageFiles, onChange])
+
+  const applyFile = useCallback(async (file) => {
+    if (!file) return
+    setFileError('')
+
+    if (/\.(png|jpe?g|gif|webp|svg)$/i.test(file.name)) {
+      await attachMarkdownImages([file])
+      return
+    }
+
+    if (isZipFile(file)) {
+      try {
+        const extracted = await extractFilesFromZip(file)
+        if (pickMarkdownFile(extracted)) {
+          await applyMdBundle(extracted, file)
+          return
+        }
+        setFileError('Zip file must include a .md file.')
+      } catch (err) {
+        setFileError(err?.message || 'Failed to read the zip file.')
+      }
+      return
+    }
+
+    const type = detectProblemFileType(file)
+    if (!type) {
+      setFileError('Unsupported file type. Use .md, .docx, .pdf, or an image file.')
+      return
+    }
+
+    if (type === 'md') {
+      await applyMdBundle([file])
+      return
+    }
+
+    onChange(prev => ({
+      ...prev,
+      contentType: CONTENT_TYPE.DOCUMENT,
+      fileFormat: type,
+      description: '',
+      pendingFile: file,
+      documentName: file.name,
+      pendingImageFiles: [],
+      title: prev.title.trim() || guessTitleFromFilename(file.name),
+    }))
+  }, [onChange, applyMdBundle, attachMarkdownImages])
+
+  const applyDroppedFiles = useCallback(async (files) => {
+    if (files.length === 0) return
+
+    const images = files.filter(f => /\.(png|jpe?g|gif|webp|svg)$/i.test(f.name))
+    const nonImages = files.filter(f => !/\.(png|jpe?g|gif|webp|svg)$/i.test(f.name))
+
+    if (pickMarkdownFile(nonImages)) {
+      await applyMdBundle(files)
+      return
+    }
+
+    const zipFile = nonImages.find(isZipFile)
+    if (zipFile) {
+      await applyFile(zipFile)
+      return
+    }
+
+    if (images.length > 0 && nonImages.length === 0) {
+      await attachMarkdownImages(images)
+      return
+    }
+
+    if (nonImages[0]) await applyFile(nonImages[0])
+  }, [applyFile, applyMdBundle, attachMarkdownImages])
+
+  const handleDrop = useCallback(async (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setDragOver(false)
+    const files = Array.from(e.dataTransfer?.files ?? [])
+    if (files.length === 0) return
+    await applyDroppedFiles(files)
+  }, [applyDroppedFiles])
+
+  const handleDragOver = useCallback((e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+    setDragOver(true)
+  }, [])
+
+  const onFilePick = useCallback(async (e) => {
+    const file = e.target.files?.[0]
+    if (file) await applyFile(file)
+    e.target.value = ''
+  }, [applyFile])
+
+  const canPublish = form.title.trim() && (
+    isDocument
+      ? (form.pendingFile || (editMode && form.fileUrl))
+      : true
+  )
+  const pendingImageMap = new Map(
+    (form.pendingImageFiles ?? []).map((file) => [file.name.toLowerCase(), file]),
+  )
+
+  return (
+    <div className="flex flex-col gap-4">
+      <input
+        type="text"
+        placeholder="Title (required)"
+        value={form.title}
+        onChange={e => onChange(prev => ({ ...prev, title: e.target.value }))}
+        className={`w-full border rounded-md px-3 py-2 text-sm font-inter text-text-primary bg-bg-base focus:outline-none focus:border-border-strong ${
+          form.title.trim() ? 'border-border' : 'border-accent'
+        }`}
+      />
+      {!form.title.trim() && (
+        <p className="text-sm font-inter text-accent -mt-2">Add a title to enable Publish.</p>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <input
+          type="number"
+          min="1"
+          placeholder="Week #"
+          value={form.week}
+          onChange={e => onChange(prev => ({ ...prev, week: e.target.value }))}
+          className="border border-border rounded-md px-3 py-2 text-sm font-inter text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+        />
+        <input
+          type="date"
+          value={form.dueDate}
+          onChange={e => onChange(prev => ({ ...prev, dueDate: e.target.value }))}
+          className="border border-border rounded-md px-3 py-2 text-sm font-inter text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+        />
+        <select
+          value={form.school}
+          onChange={e => onChange(prev => ({ ...prev, school: e.target.value }))}
+          className="border border-border rounded-md px-3 py-2 text-sm font-inter text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+        >
+          {SCHOOL_OPTIONS.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </div>
+
+      <div
+        onDragOver={handleDragOver}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+        onDragEnter={handleDragOver}
+        className={`border rounded-md overflow-hidden transition-colors ${
+          dragOver ? 'border-accent bg-accent-bg' : 'border-border'
+        }`}
+      >
+        {isDocument ? (
+          <div
+            className="bg-bg-base p-6 min-h-[360px] flex flex-col gap-4"
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+          >
+            <div className="flex items-start gap-3 text-text-secondary font-inter text-sm">
+              <Upload size={18} className="shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium text-text-primary">Document mode</p>
+                <p>Word / Google Docs export (.docx) converts to PDF automatically. PDF uploads as-is. View-only after publish.</p>
+              </div>
+            </div>
+            {form.documentName && (
+              <p className="text-sm font-inter text-text-primary">
+                File: <span className="font-medium">{form.documentName}</span>
+                {form.fileFormat === FILE_FORMAT.DOCX && (
+                  <span className="text-text-hint ml-2">→ saved as PDF</span>
+                )}
+                {form.fileFormat === FILE_FORMAT.PDF && (
+                  <span className="text-text-hint ml-2 uppercase">pdf</span>
+                )}
+              </p>
+            )}
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="px-4 py-2 border border-border-strong rounded-md text-sm font-inter text-text-secondary hover:bg-bg-surface transition-colors"
+              >
+                {form.pendingFile || form.fileUrl ? 'Replace file' : 'Choose file'}
+              </button>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="px-4 py-2 text-sm font-inter text-text-hint hover:text-text-secondary"
+              >
+                or drop a file here
+              </button>
+            </div>
+            {form.pendingFile ? (
+              <PendingDocumentPreview
+                file={form.pendingFile}
+                fileFormat={form.fileFormat}
+                accessToken={accessToken}
+              />
+            ) : editMode && form.fileUrl && (
+              <DocumentViewer
+                storagePath={form.fileUrl}
+                fileFormat={form.fileFormat}
+                accessToken={accessToken}
+              />
+            )}
+          </div>
+        ) : (
+          <>
+            <EditorTabs activeTab={tab} onTabChange={setTab} disabled={false} />
+            {tab === 'Write' ? (
+              <div className="bg-bg-base relative">
+                <MarkdownCodeEditor
+                  key={editorKey}
+                  value={form.description}
+                  onChange={val => onChange(prev => ({ ...prev, description: val ?? '' }))}
+                  onFilesDrop={applyDroppedFiles}
+                />
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="absolute bottom-3 right-3 z-10 text-xs font-inter text-text-hint hover:text-text-secondary border border-border rounded px-2 py-1 bg-bg-base"
+                >
+                  Import file
+                </button>
+              </div>
+            ) : (
+              <div className="min-h-[360px] bg-bg-base px-6 py-4">
+                {form.description.trim() ? (
+                  <MarkdownBody pendingImageMap={pendingImageMap}>{form.description}</MarkdownBody>
+                ) : (
+                  <p className="text-text-hint font-inter text-sm italic">Nothing to preview.</p>
+                )}
+              </div>
+            )}
+            <p className="text-xs text-text-hint font-inter px-4 py-2 border-t border-border bg-bg-surface">
+              Type, paste, or import one file (.md / .docx / .pdf / image). Word becomes PDF. For markdown photos, import images separately.
+            </p>
+          </>
+        )}
+      </div>
+
+      {fileError && (
+        <p className="text-sm font-inter text-accent">{fileError}</p>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".md,.markdown,.docx,.pdf,.png,.jpg,.jpeg,.gif,.webp,.svg,.zip,text/markdown,text/plain,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,image/*,application/zip"
+        className="hidden"
+        onChange={onFilePick}
+      />
+
+      <div className="flex gap-3 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 border border-border-strong rounded-md text-sm font-inter text-text-secondary hover:bg-bg-surface transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={!canPublish || submitting}
+          className="px-5 py-2 bg-accent text-white rounded-md text-sm font-medium font-inter hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? (editMode ? 'Saving...' : 'Publishing...') : (editMode ? 'Save' : 'Publish')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function ProblemBody({ problem, accessToken }) {
+  if (problem.content_type === CONTENT_TYPE.DOCUMENT && problem.file_url) {
+    return (
+      <DocumentViewer
+        storagePath={problem.file_url}
+        fileFormat={problem.file_format}
+        accessToken={accessToken}
+        className="mb-8"
+      />
+    )
+  }
+
+  return (
+    <div className="font-inter text-base text-text-primary leading-[1.7] prose max-w-none mb-8
+      prose-headings:font-montserrat prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
+      prose-code:font-mono prose-code:text-sm prose-code:bg-bg-elevated prose-code:px-1 prose-code:py-0.5 prose-code:rounded
+      prose-pre:bg-bg-elevated prose-pre:p-4 prose-pre:rounded-lg prose-pre:font-mono prose-pre:text-sm">
+      <MarkdownBody>{problem.description || '_No content._'}</MarkdownBody>
+    </div>
+  )
+}

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -3,14 +3,30 @@
 import { useState, useEffect, useCallback, useRef, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import {
-  ChevronLeft, ChevronRight, List, Trash2, Plus, Download, PenLine, Check, Minus,
+  ChevronLeft, ChevronRight, List, Trash2, Plus, Download, PenLine, Check, Minus, Pencil,
 } from 'lucide-react'
-import ReactMarkdown from 'react-markdown'
 import RoleGuard from '@/components/auth/RoleGuard'
 import { useAuth } from '@/hooks/useAuth'
-import { fetchProblems, deleteProblem } from '@/services/problemsService'
+import {
+  fetchProblems,
+  deleteProblem,
+  createProblem,
+  updateProblem,
+  uploadProblemDocument,
+  removeProblemDocument,
+  CONTENT_TYPE,
+} from '@/services/problemsService'
 import { fetchUserSubmissions } from '@/services/submissionsService'
 import { ROLES } from '@/utils/constants'
+import {
+  ProblemForm,
+  ProblemBody,
+  emptyProblemForm,
+  problemToForm,
+} from './_shared'
+import PageContainer from '@/components/layout/PageContainer'
+import { uploadImage } from '@/services/cloudinaryService'
+import { uploadLocalImagesInMarkdown, buildPendingImageMap, countRelativeImageUrls } from '@/utils/markdownImport'
 
 const SCHOOLS = ['All Schools', 'Seneca College', 'York University']
 
@@ -32,169 +48,208 @@ function downloadMd(problem) {
   URL.revokeObjectURL(url)
 }
 
-function PostView({ problems, currentIdx, navigateTo, setView, profile, onDelete, schoolFilter, setSchoolFilter }) {
+function PostView({
+  problems, currentIdx, navigateTo, setView, profile, onDelete, onEdit, onNew,
+  schoolFilter, setSchoolFilter, showForm, form, onFormChange, onPublish, onCancelForm, submitting, editMode, accessToken,
+}) {
   const router = useRouter()
   const problem = problems[currentIdx]
   const isAdmin = profile?.role === ROLES.ADMIN || profile?.role === ROLES.EXECUTIVE
   const isOldest = currentIdx === problems.length - 1
   const isNewest = currentIdx === 0
-
-  if (!problem) {
-    return (
-      <div className="flex-1 flex items-center justify-center py-24">
-        <p className="text-text-secondary font-inter">No problems found.</p>
-      </div>
-    )
-  }
+  const isMarkdown = problem?.content_type !== CONTENT_TYPE.DOCUMENT
 
   return (
     <>
-      {/* Page header */}
       <div className="bg-bg-surface py-8 border-b border-border">
-        <div className="max-w-[800px] mx-auto px-6 flex items-center justify-between">
+        <PageContainer className="flex items-center justify-between">
           <div className="flex items-center gap-4">
             <h1 className="font-montserrat font-bold text-4xl text-text-primary">Problems</h1>
             <SchoolFilter value={schoolFilter} onChange={setSchoolFilter} />
           </div>
           {isAdmin && (
             <button
-              disabled
-              title="Coming soon"
-              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter bg-accent text-white transition-colors opacity-40 cursor-not-allowed"
+              onClick={onNew}
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter bg-accent hover:bg-accent-hover text-white transition-colors"
             >
               <Plus size={14} />
               New
             </button>
           )}
-        </div>
+        </PageContainer>
       </div>
 
-      {/* Problem content */}
-      <div className="flex-1 bg-bg-base py-12">
-        <div className="max-w-[800px] mx-auto px-6">
-          <h2 className="font-montserrat font-semibold text-2xl text-text-primary mb-3">
-            {problem.title}
-          </h2>
-
-          {/* Meta row */}
-          <div className="flex flex-wrap items-center gap-2 text-text-secondary font-inter text-sm mb-4">
-            {problem.week != null && (
-              <span>Week {problem.week}</span>
-            )}
-            {problem.due_date && (
-              <span className="before:content-['📅'] before:mr-1">
-                Due: {formatDue(problem.due_date)}
-              </span>
-            )}
-            {problem.school && (
-              <span className="text-text-hint">· {problem.school}</span>
-            )}
-          </div>
-
-          <hr className="border-border mb-6" />
-
-          {/* Markdown body */}
-          <div className="font-inter text-base text-text-primary leading-[1.7] prose max-w-none mb-8
-            prose-headings:font-montserrat prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
-            prose-code:font-mono prose-code:text-sm prose-code:bg-bg-elevated prose-code:px-1 prose-code:py-0.5 prose-code:rounded
-            prose-pre:bg-bg-elevated prose-pre:p-4 prose-pre:rounded-lg prose-pre:font-mono prose-pre:text-sm">
-            <ReactMarkdown>{problem.description || '_No content._'}</ReactMarkdown>
-          </div>
-
-          {/* Solution button */}
-          <button
-            onClick={() => router.push(`/solutions?problem=${problem.id}`)}
-            className="w-full py-3 rounded-md bg-accent hover:bg-accent-hover text-white font-inter font-medium text-sm flex items-center justify-center gap-2 transition-colors"
-          >
-            <PenLine size={14} />
-            Go to My Solution →
-          </button>
+      {showForm ? (
+        <div className="flex-1 bg-bg-base py-12">
+          <PageContainer>
+            <ProblemForm
+              form={form}
+              onChange={onFormChange}
+              onSubmit={onPublish}
+              onCancel={onCancelForm}
+              submitting={submitting}
+              editMode={editMode}
+              accessToken={accessToken}
+            />
+          </PageContainer>
         </div>
-      </div>
+      ) : problem ? (
+        <>
+          <div className="flex-1 bg-bg-base py-12">
+            <PageContainer>
+              <h2 className="font-montserrat font-semibold text-2xl text-text-primary mb-3">
+                {problem.title}
+              </h2>
 
-      {/* Navigation row */}
-      <div className="border-t border-border py-8 bg-bg-base">
-        <div className="max-w-[800px] mx-auto px-6 flex items-center justify-between">
-          <button
-            onClick={() => navigateTo(currentIdx + 1)}
-            disabled={isOldest}
-            className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
-          >
-            <ChevronLeft size={14} />
-            Previous
-          </button>
+              <div className="flex flex-wrap items-center gap-2 text-text-secondary font-inter text-sm mb-4">
+                {problem.week != null && <span>Week {problem.week}</span>}
+                {problem.due_date && (
+                  <span className="before:content-['📅'] before:mr-1">
+                    Due: {formatDue(problem.due_date)}
+                  </span>
+                )}
+                {problem.school && <span className="text-text-hint">· {problem.school}</span>}
+                {!isMarkdown && problem.file_format && (
+                  <span className="text-text-hint uppercase">· {problem.file_format}</span>
+                )}
+              </div>
 
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => setView('list')}
-              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary transition-colors"
-            >
-              <List size={14} />
-              List
-            </button>
-            <button
-              onClick={() => downloadMd(problem)}
-              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary transition-colors"
-              title="Download .md"
-            >
-              <Download size={14} />
-              .md
-            </button>
-          </div>
+              <hr className="border-border mb-6" />
 
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => navigateTo(currentIdx - 1)}
-              disabled={isNewest}
-              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
-            >
-              Next
-              <ChevronRight size={14} />
-            </button>
-            {isAdmin && (
+              <ProblemBody problem={problem} accessToken={accessToken} />
+
               <button
-                onClick={() => onDelete(problem.id)}
-                className="flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium font-inter transition-colors text-accent hover:text-accent-hover"
+                onClick={() => router.push(`/solutions?problem=${problem.id}`)}
+                className="w-full py-3 rounded-md bg-accent hover:bg-accent-hover text-white font-inter font-medium text-sm flex items-center justify-center gap-2 transition-colors"
               >
-                <Trash2 size={14} />
-                Delete
+                <PenLine size={14} />
+                Go to My Solution →
               </button>
+            </PageContainer>
+          </div>
+
+          <div className="border-t border-border py-8 bg-bg-base">
+            <PageContainer className="flex items-center justify-between">
+              <button
+                onClick={() => navigateTo(currentIdx + 1)}
+                disabled={isOldest}
+                className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
+              >
+                <ChevronLeft size={14} />
+                Previous
+              </button>
+
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => setView('list')}
+                  className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary transition-colors"
+                >
+                  <List size={14} />
+                  List
+                </button>
+                {isMarkdown && (
+                  <button
+                    onClick={() => downloadMd(problem)}
+                    className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary transition-colors"
+                    title="Download .md"
+                  >
+                    <Download size={14} />
+                    .md
+                  </button>
+                )}
+              </div>
+
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => navigateTo(currentIdx - 1)}
+                  disabled={isNewest}
+                  className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border transition-colors disabled:opacity-40 disabled:cursor-not-allowed border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary disabled:hover:border-border-strong disabled:hover:text-text-secondary"
+                >
+                  Next
+                  <ChevronRight size={14} />
+                </button>
+                {isAdmin && (
+                  <>
+                    <button
+                      onClick={() => onEdit(problem)}
+                      title="Edit"
+                      className="flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium font-inter transition-colors text-text-secondary hover:text-text-primary"
+                    >
+                      <Pencil size={14} />
+                    </button>
+                    <button
+                      onClick={() => onDelete(problem.id)}
+                      className="flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium font-inter transition-colors text-accent hover:text-accent-hover"
+                    >
+                      <Trash2 size={14} />
+                      Delete
+                    </button>
+                  </>
+                )}
+              </div>
+            </PageContainer>
+          </div>
+        </>
+      ) : (
+        <div className="flex-1 bg-bg-base flex items-center justify-center py-24">
+          <div className="text-center">
+            <p className="text-text-secondary font-inter mb-2">No problems found.</p>
+            {isAdmin && (
+              <p className="text-sm text-text-hint font-inter">
+                Click <span className="font-medium text-text-secondary">New</span> to publish the first problem.
+              </p>
             )}
           </div>
         </div>
-      </div>
+      )}
     </>
   )
 }
 
-function ListView({ problems, navigateTo, setView, profile, schoolFilter, setSchoolFilter, userSubmissions }) {
+function ListView({
+  problems, navigateTo, setView, profile, schoolFilter, setSchoolFilter, userSubmissions,
+  onNew, showForm, form, onFormChange, onPublish, onCancelForm, submitting, editMode, accessToken,
+}) {
   const isAdmin = profile?.role === ROLES.ADMIN || profile?.role === ROLES.EXECUTIVE
 
   return (
     <>
-      {/* Page header */}
       <div className="bg-bg-surface py-8 border-b border-border">
-        <div className="max-w-[900px] mx-auto px-6 flex items-center justify-between">
+        <PageContainer className="flex items-center justify-between">
           <div className="flex items-center gap-4">
             <h1 className="font-montserrat font-bold text-4xl text-text-primary">Problems</h1>
             <SchoolFilter value={schoolFilter} onChange={setSchoolFilter} />
           </div>
           {isAdmin && (
             <button
-              disabled
-              title="Coming soon"
-              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter bg-accent text-white transition-colors opacity-40 cursor-not-allowed"
+              onClick={onNew}
+              className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter bg-accent hover:bg-accent-hover text-white transition-colors"
             >
               <Plus size={14} />
               New
             </button>
           )}
-        </div>
+        </PageContainer>
       </div>
 
-      {/* Table */}
+      {showForm && (
+        <div className="bg-bg-base py-12 border-b border-border">
+          <PageContainer>
+            <ProblemForm
+              form={form}
+              onChange={onFormChange}
+              onSubmit={onPublish}
+              onCancel={onCancelForm}
+              submitting={submitting}
+              editMode={editMode}
+              accessToken={accessToken}
+            />
+          </PageContainer>
+        </div>
+      )}
+
       <div className="flex-1 bg-bg-base py-12">
-        <div className="max-w-[900px] mx-auto px-6">
+        <PageContainer>
           {problems.length === 0 ? (
             <p className="text-text-secondary font-inter text-center py-16">No problems found.</p>
           ) : (
@@ -237,7 +292,7 @@ function ListView({ problems, navigateTo, setView, profile, schoolFilter, setSch
               </tbody>
             </table>
           )}
-        </div>
+        </PageContainer>
       </div>
     </>
   )
@@ -256,7 +311,7 @@ function SchoolFilter({ value, onChange }) {
 }
 
 function ProblemsContent() {
-  const { profile } = useAuth()
+  const { profile, user, accessToken } = useAuth()
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -268,7 +323,12 @@ function ProblemsContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
-  // Restore index from URL on first load only
+  const [showForm, setShowForm] = useState(false)
+  const [editMode, setEditMode] = useState(false)
+  const [editingId, setEditingId] = useState(null)
+  const [form, setForm] = useState(emptyProblemForm())
+  const [submitting, setSubmitting] = useState(false)
+
   const restoredFromUrl = useRef(false)
   useEffect(() => {
     if (problems.length === 0 || restoredFromUrl.current) return
@@ -298,7 +358,7 @@ function ProblemsContent() {
       const solved = await fetchUserSubmissions(profile.id)
       setUserSubmissions(solved)
     } catch {
-      // Submissions are non-critical; fail silently
+      // Non-critical
     }
   }, [profile?.id])
 
@@ -312,10 +372,188 @@ function ProblemsContent() {
     if (p) router.push(`/problems?id=${p.id}`, { scroll: false })
   }
 
+  function openNew() {
+    setEditMode(false)
+    setEditingId(null)
+    setForm(emptyProblemForm())
+    setShowForm(true)
+    setView('post')
+  }
+
+  function openEdit(problem) {
+    setEditMode(true)
+    setEditingId(problem.id)
+    setForm(problemToForm(problem))
+    setShowForm(true)
+  }
+
+  function cancelForm() {
+    setShowForm(false)
+    setEditMode(false)
+    setEditingId(null)
+    setForm(emptyProblemForm())
+  }
+
+  function parseWeek(value) {
+    if (!value?.trim()) return null
+    const n = parseInt(value, 10)
+    return Number.isNaN(n) ? null : n
+  }
+
+  async function persistDocument(problemId, pendingFile, existingPath) {
+    const { path, fileFormat } = await uploadProblemDocument(pendingFile, problemId, accessToken)
+    if (existingPath) await removeProblemDocument(existingPath)
+    return { path, fileFormat }
+  }
+
+  async function finalizeMarkdownDescription(description, pendingImageFiles) {
+    let body = description
+    if (pendingImageFiles?.length) {
+      const pendingImageMap = buildPendingImageMap(pendingImageFiles)
+      body = await uploadLocalImagesInMarkdown(body, pendingImageMap, async (file) => {
+        const { url } = await uploadImage(file, 'problems')
+        return url
+      })
+    }
+    if (countRelativeImageUrls(body) > 0) {
+      throw new Error('Some images are still missing. Import the markdown folder again or upload PDF/DOCX.')
+    }
+    return body
+  }
+
+  async function handleCreate() {
+    if (!form.title.trim()) return
+    if (!accessToken) {
+      alert('Session expired. Please refresh and log in again.')
+      return
+    }
+    setSubmitting(true)
+    let createdId = null
+    try {
+      const week = parseWeek(form.week)
+      const dueDate = form.dueDate || null
+      const school = form.school || null
+
+      if (form.contentType === CONTENT_TYPE.DOCUMENT) {
+        if (!form.pendingFile) {
+          alert('Please upload a .docx or .pdf file.')
+          return
+        }
+        const row = await createProblem({
+          title: form.title.trim(),
+          week,
+          dueDate,
+          school,
+          contentType: CONTENT_TYPE.DOCUMENT,
+          createdBy: user?.id,
+        })
+        createdId = row.id
+        const { path, fileFormat } = await persistDocument(row.id, form.pendingFile, null)
+        await updateProblem(row.id, {
+          fileUrl: path,
+          fileFormat,
+          contentType: CONTENT_TYPE.DOCUMENT,
+        })
+        cancelForm()
+        await loadProblems()
+        router.push(`/problems?id=${row.id}`)
+        return
+      }
+
+      const description = await finalizeMarkdownDescription(form.description, form.pendingImageFiles)
+
+      await createProblem({
+        title: form.title.trim(),
+        description,
+        week,
+        dueDate,
+        school,
+        contentType: CONTENT_TYPE.MARKDOWN,
+        createdBy: user?.id,
+      })
+      cancelForm()
+      await loadProblems()
+      setCurrentIdx(0)
+    } catch (err) {
+      if (createdId) {
+        try { await deleteProblem(createdId) } catch { /* rollback best-effort */ }
+      }
+      alert(err.message ?? 'Failed to publish. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleUpdate(id) {
+    if (!form.title.trim()) return
+    if (!accessToken) {
+      alert('Session expired. Please refresh and log in again.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const existing = problems.find(p => p.id === id)
+      const week = parseWeek(form.week)
+      const dueDate = form.dueDate || null
+      const school = form.school || null
+
+      if (form.contentType === CONTENT_TYPE.DOCUMENT) {
+        let fileUrl = form.fileUrl
+        let fileFormat = form.fileFormat
+        if (form.pendingFile) {
+          const uploaded = await persistDocument(id, form.pendingFile, existing?.file_url)
+          fileUrl = uploaded.path
+          fileFormat = uploaded.fileFormat
+        }
+        await updateProblem(id, {
+          title: form.title.trim(),
+          week,
+          dueDate,
+          school,
+          contentType: CONTENT_TYPE.DOCUMENT,
+          fileUrl,
+          fileFormat,
+          description: '',
+        })
+      } else {
+        if (existing?.content_type === CONTENT_TYPE.DOCUMENT && existing.file_url) {
+          await removeProblemDocument(existing.file_url)
+        }
+        const description = await finalizeMarkdownDescription(form.description, form.pendingImageFiles)
+        await updateProblem(id, {
+          title: form.title.trim(),
+          description,
+          week,
+          dueDate,
+          school,
+          contentType: CONTENT_TYPE.MARKDOWN,
+          fileFormat: null,
+          fileUrl: null,
+        })
+      }
+
+      cancelForm()
+      await loadProblems()
+    } catch (err) {
+      alert(err.message ?? 'Failed to save. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function handlePublish() {
+    if (editMode && editingId) {
+      handleUpdate(editingId)
+    } else {
+      handleCreate()
+    }
+  }
+
   async function handleDelete(id) {
     if (!confirm('Delete this problem? This cannot be undone.')) return
     try {
       await deleteProblem(id)
+      cancelForm()
       await loadProblems()
       setCurrentIdx(0)
     } catch {
@@ -339,7 +577,26 @@ function ProblemsContent() {
     )
   }
 
-  const sharedProps = { problems, profile, schoolFilter, setSchoolFilter, userSubmissions }
+  const formProps = {
+    showForm,
+    form,
+    onFormChange: setForm,
+    onPublish: handlePublish,
+    onCancelForm: cancelForm,
+    submitting,
+    editMode,
+    accessToken,
+  }
+
+  const sharedProps = {
+    problems,
+    profile,
+    schoolFilter,
+    setSchoolFilter,
+    userSubmissions,
+    onNew: openNew,
+    ...formProps,
+  }
 
   return view === 'post' ? (
     <PostView
@@ -348,6 +605,7 @@ function ProblemsContent() {
       navigateTo={navigateTo}
       setView={setView}
       onDelete={handleDelete}
+      onEdit={openEdit}
     />
   ) : (
     <ListView

--- a/src/components/layout/PageContainer.js
+++ b/src/components/layout/PageContainer.js
@@ -1,0 +1,11 @@
+/**
+ * Standard page content width — matches About (`max-w-6xl` + responsive horizontal padding).
+ * Margins shrink via px-4 / sm:px-6 before the max-width constrains content.
+ */
+export default function PageContainer({ children, className = '' }) {
+  return (
+    <div className={`max-w-6xl mx-auto px-4 sm:px-6 ${className}`}>
+      {children}
+    </div>
+  )
+}

--- a/src/lib/adminApi.js
+++ b/src/lib/adminApi.js
@@ -41,3 +41,34 @@ export async function verifyAdminCaller(request, { adminOnly = false } = {}) {
 
   return { serviceClient, user, callerProfile }
 }
+
+export async function verifyMemberPlusCaller(request) {
+  const authHeader = request.headers.get('authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    return { error: Response.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const token = authHeader.slice(7)
+  const serviceClient = getServiceClient()
+
+  const { data: { user }, error: authError } = await serviceClient.auth.getUser(token)
+  if (authError || !user) {
+    return { error: Response.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const { data: callerProfile, error: profileError } = await serviceClient
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (profileError || !callerProfile) {
+    return { error: Response.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  if (!['member', 'executive', 'admin'].includes(callerProfile.role)) {
+    return { error: Response.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+
+  return { serviceClient, user, callerProfile }
+}

--- a/src/lib/docxToPdfServer.js
+++ b/src/lib/docxToPdfServer.js
@@ -1,0 +1,129 @@
+import { execFile } from 'child_process'
+import { access, mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { constants } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+const MAX_BYTES = 50 * 1024 * 1024
+
+function backendUrl() {
+  return process.env.BACKEND_API_URL || process.env.NEXT_PUBLIC_API_URL || ''
+}
+
+export function resolveSofficePath() {
+  if (process.env.LIBREOFFICE_PATH) return process.env.LIBREOFFICE_PATH
+  if (process.platform === 'darwin') {
+    return '/Applications/LibreOffice.app/Contents/MacOS/soffice'
+  }
+  return 'soffice'
+}
+
+function assertPdfBuffer(buffer) {
+  if (!buffer?.length || buffer.subarray(0, 4).toString() !== '%PDF') {
+    throw new Error('Conversion did not produce a valid PDF file.')
+  }
+}
+
+async function canUseLocalLibreOffice() {
+  try {
+    await access(resolveSofficePath(), constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function convertWithLocalLibreOffice(buffer) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'docx-pdf-'))
+  try {
+    const input = path.join(dir, 'input.docx')
+    const output = path.join(dir, 'input.pdf')
+    await writeFile(input, buffer)
+    const soffice = resolveSofficePath()
+    await execFileAsync(
+      soffice,
+      [
+        '--headless',
+        '--nologo',
+        '--nofirststartwizard',
+        '--convert-to',
+        'pdf',
+        '--outdir',
+        dir,
+        input,
+      ],
+      { timeout: 120000 },
+    )
+    const pdf = await readFile(output)
+    assertPdfBuffer(pdf)
+    return pdf
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+function parseBackendError(text) {
+  if (!text) return 'DOCX to PDF conversion failed on the server.'
+  if (text.includes('Application Error') || text.trimStart().startsWith('<!DOCTYPE')) {
+    return 'DOCX conversion server is unavailable. Use local LibreOffice or upload a PDF.'
+  }
+  try {
+    const body = JSON.parse(text)
+    return body.detail ?? body.error ?? 'DOCX to PDF conversion failed on the server.'
+  } catch {
+    return text.replace(/\s+/g, ' ').trim().slice(0, 200)
+  }
+}
+
+async function convertWithBackend(buffer, filename) {
+  const baseUrl = backendUrl().replace(/\/$/, '')
+  if (!baseUrl) {
+    throw new Error('DOCX conversion backend is not configured. Upload a PDF or install LibreOffice locally.')
+  }
+
+  const formData = new FormData()
+  formData.append('file', new Blob([buffer]), filename)
+
+  const res = await fetch(`${baseUrl}/documents/convert/docx-to-pdf`, {
+    method: 'POST',
+    body: formData,
+  })
+
+  const bytes = Buffer.from(await res.arrayBuffer())
+  if (!res.ok) {
+    throw new Error(parseBackendError(bytes.toString('utf-8')))
+  }
+
+  assertPdfBuffer(bytes)
+  return bytes
+}
+
+export async function convertDocxToPdf(buffer, filename = 'document.docx') {
+  if (!buffer || buffer.byteLength === 0) {
+    throw new Error('Empty DOCX file.')
+  }
+  if (buffer.byteLength > MAX_BYTES) {
+    throw new Error('File exceeds the 50 MB limit.')
+  }
+
+  if (await canUseLocalLibreOffice()) {
+    let lastError = null
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        return await convertWithLocalLibreOffice(buffer)
+      } catch (err) {
+        lastError = err
+      }
+    }
+    throw new Error(
+      lastError?.message
+        ? `Local DOCX conversion failed: ${lastError.message}`
+        : 'Local DOCX conversion failed.',
+    )
+  }
+
+  return convertWithBackend(buffer, filename)
+}

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -1,9 +1,54 @@
 import { supabase } from '@/lib/supabase'
 
+export const PROBLEM_BUCKET = 'problem-documents'
+export const MAX_DOCUMENT_BYTES = 50 * 1024 * 1024
+
+export const CONTENT_TYPE = {
+  MARKDOWN: 'markdown',
+  DOCUMENT: 'document',
+}
+
+export const FILE_FORMAT = {
+  DOCX: 'docx',
+  PDF: 'pdf',
+}
+
+const SELECT_FIELDS = '*'
+
+function mapProblem(row) {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description ?? '',
+    week: row.week,
+    due_date: row.due_date,
+    school: row.school,
+    content_type: row.content_type ?? CONTENT_TYPE.MARKDOWN,
+    file_format: row.file_format,
+    file_url: row.file_url,
+    created_at: row.created_at,
+    created_by: row.created_by,
+  }
+}
+
+export function detectProblemFileType(file) {
+  const name = file.name.toLowerCase()
+  if (name.endsWith('.md') || name.endsWith('.markdown')) return 'md'
+  if (name.endsWith('.docx')) return FILE_FORMAT.DOCX
+  if (name.endsWith('.pdf')) return FILE_FORMAT.PDF
+
+  const mime = file.type
+  if (mime === 'text/markdown' || mime === 'text/plain' || mime === 'text/x-markdown') return 'md'
+  if (mime === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') return FILE_FORMAT.DOCX
+  if (mime === 'application/pdf') return FILE_FORMAT.PDF
+
+  return null
+}
+
 export async function fetchProblems(schoolFilter) {
   let query = supabase
     .from('problems')
-    .select('*')
+    .select(SELECT_FIELDS)
     .order('week', { ascending: false, nullsFirst: false })
     .order('created_at', { ascending: false })
 
@@ -13,10 +58,153 @@ export async function fetchProblems(schoolFilter) {
 
   const { data, error } = await query
   if (error) throw error
-  return data ?? []
+  return (data ?? []).map(mapProblem)
+}
+
+export async function createProblem({
+  title,
+  description = '',
+  week,
+  dueDate,
+  school,
+  contentType = CONTENT_TYPE.MARKDOWN,
+  fileFormat = null,
+  fileUrl = null,
+  createdBy,
+}) {
+  const { data, error } = await supabase
+    .from('problems')
+    .insert({
+      title,
+      description,
+      week: week ?? null,
+      due_date: dueDate || null,
+      school: school || null,
+      content_type: contentType,
+      file_format: fileFormat,
+      file_url: fileUrl,
+      created_by: createdBy ?? null,
+    })
+    .select(SELECT_FIELDS)
+    .single()
+
+  if (error) throw error
+  return mapProblem(data)
+}
+
+export async function updateProblem(id, fields) {
+  const payload = {}
+  if (fields.title !== undefined) payload.title = fields.title
+  if (fields.description !== undefined) payload.description = fields.description
+  if (fields.week !== undefined) payload.week = fields.week
+  if (fields.dueDate !== undefined) payload.due_date = fields.dueDate || null
+  if (fields.school !== undefined) payload.school = fields.school || null
+  if (fields.contentType !== undefined) payload.content_type = fields.contentType
+  if (fields.fileFormat !== undefined) payload.file_format = fields.fileFormat
+  if (fields.fileUrl !== undefined) payload.file_url = fields.fileUrl
+
+  const { data, error } = await supabase
+    .from('problems')
+    .update(payload)
+    .eq('id', id)
+    .select(SELECT_FIELDS)
+    .single()
+
+  if (error) throw error
+  return mapProblem(data)
+}
+
+export async function uploadProblemDocument(file, problemId, accessToken) {
+  if (!accessToken) throw new Error('Not authenticated.')
+
+  if (file.size > MAX_DOCUMENT_BYTES) {
+    throw new Error('File exceeds the 50 MB limit.')
+  }
+
+  const fileType = detectProblemFileType(file)
+  if (fileType !== FILE_FORMAT.DOCX && fileType !== FILE_FORMAT.PDF) {
+    throw new Error('Only .docx and .pdf files are supported for document upload.')
+  }
+
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('problemId', String(problemId))
+
+  const res = await fetch('/api/problems/documents', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    body: formData,
+  })
+
+  const body = await res.json()
+  if (!res.ok) throw new Error(body.error ?? 'Upload failed.')
+  return { path: body.path, fileFormat: body.fileFormat }
+}
+
+export async function previewDocxAsPdf(file, accessToken) {
+  if (!accessToken) throw new Error('Not authenticated.')
+
+  const formData = new FormData()
+  formData.append('file', file)
+
+  const res = await fetch('/api/problems/documents/preview', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    body: formData,
+  })
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? 'Failed to preview document.')
+  }
+
+  return res.blob()
+}
+
+export async function getDocumentSignedUrl(storagePath, accessToken) {
+  if (!accessToken) throw new Error('Not authenticated.')
+
+  const res = await fetch(
+    `/api/problems/documents?path=${encodeURIComponent(storagePath)}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  )
+
+  const body = await res.json()
+  if (!res.ok) throw new Error(body.error ?? 'Failed to load document.')
+  return body.signedUrl
+}
+
+export async function downloadProblemDocument(storagePath, accessToken) {
+  const res = await fetch(
+    `/api/problems/documents?path=${encodeURIComponent(storagePath)}&download=1`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  )
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? 'Failed to download document.')
+  }
+  return res.blob()
+}
+
+export async function removeProblemDocument(storagePath) {
+  if (!storagePath) return
+  const { error } = await supabase.storage.from(PROBLEM_BUCKET).remove([storagePath])
+  if (error) throw error
 }
 
 export async function deleteProblem(id) {
+  const { data: problem, error: fetchError } = await supabase
+    .from('problems')
+    .select('file_url, content_type')
+    .eq('id', id)
+    .single()
+
+  if (fetchError) throw fetchError
+
+  if (problem?.content_type === CONTENT_TYPE.DOCUMENT && problem.file_url) {
+    await removeProblemDocument(problem.file_url)
+  }
+
   const { error } = await supabase.from('problems').delete().eq('id', id)
   if (error) throw error
 }

--- a/src/utils/markdownImport.js
+++ b/src/utils/markdownImport.js
@@ -1,0 +1,316 @@
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg)$/i
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function buildImageFileMap(files) {
+  const map = new Map()
+  for (const file of files) {
+    if (!IMAGE_EXT.test(file.name)) continue
+    const lower = file.name.toLowerCase()
+    map.set(lower, file)
+    const stem = lower.replace(/\.[^.]+$/, '')
+    map.set(stem, file)
+    const base = lower.split('/').pop()
+    map.set(base, file)
+  }
+  return map
+}
+
+function dataUriToFile(dataUri, fallbackName = 'image.png') {
+  const match = dataUri.match(/^data:([^;]+);base64,(.+)$/i)
+  if (!match) return null
+  const mime = match[1]
+  const binary = atob(match[2])
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  const ext = mime.split('/')[1]?.replace('jpeg', 'jpg') ?? 'png'
+  const name = fallbackName.includes('.') ? fallbackName : `${fallbackName}.${ext}`
+  return new File([bytes], name, { type: mime })
+}
+
+function stripAngleBrackets(value) {
+  return value.trim().replace(/^<|>$/g, '')
+}
+
+export function normalizeMarkdownTables(md) {
+  const lines = []
+  for (const line of md.split('\n')) {
+    const pipeCount = (line.match(/\|/g) || []).length
+    if (!line.includes('|') || pipeCount < 4) {
+      lines.push(line)
+      continue
+    }
+
+    const expanded = line
+      .replace(/\|\s*\|/g, '|\n|')
+      .replace(/(\|)\s*(:?-{2,}:?)(\|)/g, '$1\n|$2$3')
+
+    for (const part of expanded.split('\n')) {
+      const trimmed = part.trim()
+      if (trimmed) lines.push(trimmed)
+    }
+  }
+  return lines.join('\n')
+}
+
+function htmlTableToMarkdown(tableHtml) {
+  if (typeof DOMParser === 'undefined') return tableHtml
+
+  const doc = new DOMParser().parseFromString(tableHtml, 'text/html')
+  const table = doc.querySelector('table')
+  if (!table) return tableHtml
+
+  const rows = [...table.querySelectorAll('tr')]
+  if (rows.length === 0) return tableHtml
+
+  const mdRows = rows.map((row) => {
+    const cells = [...row.querySelectorAll('th, td')]
+    return `| ${cells.map((cell) => cellToMarkdown(cell)).join(' | ')} |`
+  })
+
+  const colCount = Math.max(...rows.map((row) => row.querySelectorAll('th, td').length))
+  const separator = `| ${Array(colCount).fill('---').join(' | ')} |`
+  if (mdRows.length === 1) mdRows.splice(1, 0, separator)
+  else if (!/^\|\s*:?-{2,}/.test(mdRows[1] ?? '')) mdRows.splice(1, 0, separator)
+
+  return mdRows.join('\n')
+}
+
+function cellToMarkdown(cell) {
+  const images = [...cell.querySelectorAll('img')]
+  if (images.length > 0) {
+    return images
+      .map((img) => {
+        const src = img.getAttribute('src') ?? ''
+        const alt = img.getAttribute('alt') ?? ''
+        return `![${alt}](${src})`
+      })
+      .join(' ')
+  }
+
+  const text = cell.textContent.replace(/\|/g, '\\|').replace(/\n/g, ' ').trim()
+  return text
+}
+
+export function convertHtmlTablesToMarkdown(md) {
+  if (!/<table[\s>]/i.test(md)) return md
+  return md.replace(/<table[\s\S]*?<\/table>/gi, (tableHtml) => htmlTableToMarkdown(tableHtml))
+}
+
+function parseReferenceDefinitions(md) {
+  const defs = new Map()
+  const body = md.replace(/^\[([^\]]+)\]:\s*(.+)$/gm, (_, ref, target) => {
+    defs.set(ref.trim(), stripAngleBrackets(target))
+    return ''
+  })
+  return { body: body.trim(), defs }
+}
+
+export function inlineReferenceImages(md, defs) {
+  let result = md
+  for (const [ref, url] of defs) {
+    if (!url) continue
+    const refPattern = new RegExp(`!\\[([^\\]]*)\\]\\[${escapeRegExp(ref)}\\]`, 'g')
+    result = result.replace(refPattern, (_, alt) => `![${alt}](${url})`)
+  }
+  return result
+}
+
+export function countUnresolvedImageRefs(md) {
+  const inlineRefs = [...md.matchAll(/!\[[^\]]*\]\[([^\]]+)\]/g)]
+  const defs = new Map()
+  for (const [, ref, target] of md.matchAll(/^\[([^\]]+)\]:\s*(.+)$/gm)) {
+    defs.set(ref.trim(), stripAngleBrackets(target))
+  }
+
+  let missing = 0
+  for (const [, ref] of inlineRefs) {
+    const target = defs.get(ref.trim())
+    if (!target || (!target.startsWith('http') && !target.startsWith('data:'))) missing += 1
+  }
+  return missing + countRelativeImageUrls(md)
+}
+
+function isResolvedImageUrl(src) {
+  return /^(https?:|data:|blob:)/i.test(src.trim())
+}
+
+export function countRelativeImageUrls(md) {
+  const inline = [...md.matchAll(/!\[[^\]]*\]\(([^)]+)\)/g)]
+  let missing = 0
+  for (const [, src] of inline) {
+    if (!isResolvedImageUrl(src)) missing += 1
+  }
+  const htmlImages = [...md.matchAll(/<img[^>]+src="([^"]+)"/gi)]
+  for (const [, src] of htmlImages) {
+    if (!isResolvedImageUrl(src)) missing += 1
+  }
+  return missing
+}
+
+export function buildPendingImageMap(files) {
+  const map = new Map()
+  for (const file of files) {
+    if (!IMAGE_EXT.test(file.name)) continue
+    map.set(file.name.toLowerCase(), file)
+  }
+  return map
+}
+
+export function guessTitleFromFilename(filename) {
+  const base = filename.replace(/\.[^.]+$/, '').trim()
+  const withoutNumericPrefix = base.replace(/^\d+[-_.\s]+/, '')
+  const cleaned = (withoutNumericPrefix || base).replace(/[-_]+/g, ' ').trim()
+  return cleaned || 'Untitled'
+}
+
+export function guessTitleFromImport(mdFile, mdText) {
+  const heading = mdText.match(/^#\s+(.+)$/m)
+  if (heading?.[1]) return heading[1].trim().slice(0, 120)
+
+  const blockquoteLead = mdText.match(/^>\s*([A-Za-z][^\n(]{2,60})/m)
+  if (blockquoteLead?.[1]) return blockquoteLead[1].trim()
+
+  return guessTitleFromFilename(mdFile.name)
+}
+
+export function applyLocalImagesForPreview(md, pendingImageMap) {
+  if (!pendingImageMap?.size) return md
+  let result = md
+  for (const match of result.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g)) {
+    const src = match[2]
+    if (isResolvedImageUrl(src)) continue
+    const base = src.split('/').pop()?.toLowerCase()
+    const file = base ? pendingImageMap.get(base) : null
+    if (!file) continue
+    const blobUrl = URL.createObjectURL(file)
+    result = result.replace(
+      new RegExp(`!\\[([^\\]]*)\\]\\(${escapeRegExp(src)}\\)`, 'g'),
+      `![$1](${blobUrl})`,
+    )
+  }
+  return result.replace(/<img([^>]+)src="([^"]+)"/gi, (full, attrs, src) => {
+    if (isResolvedImageUrl(src)) return full
+    const base = src.split('/').pop()?.toLowerCase()
+    const file = base ? pendingImageMap.get(base) : null
+    if (!file) return full
+    return `<img${attrs}src="${URL.createObjectURL(file)}"`
+  })
+}
+
+export async function uploadLocalImagesInMarkdown(md, pendingImageMap, uploadImage) {
+  if (!uploadImage || !pendingImageMap?.size) return md
+  let processed = md
+  const uploaded = new Map()
+
+  for (const [, src] of [...processed.matchAll(/!\[[^\]]*\]\(([^)]+)\)/g)]) {
+    if (isResolvedImageUrl(src)) continue
+    const base = src.split('/').pop()?.toLowerCase()
+    const file = base ? pendingImageMap.get(base) : null
+    if (!file || uploaded.has(base)) continue
+    const url = await uploadImage(file)
+    uploaded.set(base, url)
+    processed = processed.replace(
+      new RegExp(`!\\[[^\\]]*\\]\\([^)]*${escapeRegExp(base)}\\)`, 'gi'),
+      `![](${url})`,
+    )
+    processed = processed.replace(
+      new RegExp(`src="[^"]*${escapeRegExp(base)}"`, 'gi'),
+      `src="${url}"`,
+    )
+  }
+
+  return processed
+}
+
+async function uploadDataUriIfNeeded(target, ref, uploadImage) {
+  if (!target.startsWith('data:')) return target
+  const file = dataUriToFile(target, ref)
+  if (!file) return target
+  return uploadImage(file)
+}
+
+async function uploadAndReplaceRef(processed, ref, target, imageMap, uploadImage) {
+  const trimmed = stripAngleBrackets(target)
+  if (!trimmed) return processed
+
+  if (trimmed.startsWith('http')) return processed
+
+  if (trimmed.startsWith('data:')) {
+    const url = await uploadDataUriIfNeeded(trimmed, ref, uploadImage)
+    return processed.replace(
+      new RegExp(`^\\[${escapeRegExp(ref)}\\]:\\s*.+$`, 'm'),
+      `[${ref}]: ${url}`,
+    )
+  }
+
+  const baseName = trimmed.split('/').pop().toLowerCase()
+  const stem = baseName.replace(/\.[^.]+$/, '')
+  const imgFile = imageMap.get(baseName) || imageMap.get(stem) || imageMap.get(trimmed.toLowerCase())
+  if (!imgFile) return processed
+
+  const url = await uploadImage(imgFile)
+  return processed.replace(
+    new RegExp(`^\\[${escapeRegExp(ref)}\\]:\\s*.+$`, 'm'),
+    `[${ref}]: ${url}`,
+  )
+}
+
+export async function resolveMarkdownWithAssets(mdText, files, uploadImage) {
+  let processed = convertHtmlTablesToMarkdown(mdText)
+  processed = normalizeMarkdownTables(processed)
+
+  if (!uploadImage) {
+    const { body, defs } = parseReferenceDefinitions(processed)
+    return inlineReferenceImages(body, defs)
+  }
+
+  const imageMap = buildImageFileMap(files)
+  const refDefs = [...processed.matchAll(/^\[([^\]]+)\]:\s*(.+)$/gm)]
+
+  for (const [, ref, target] of refDefs) {
+    processed = await uploadAndReplaceRef(processed, ref, target, imageMap, uploadImage)
+  }
+
+  for (const [name, file] of imageMap) {
+    if (!name.includes('.')) continue
+    const url = await uploadImage(file)
+    const base = name.split('/').pop()
+    processed = processed.replace(
+      new RegExp(`!\\[[^\\]]*\\]\\([^)]*${escapeRegExp(base)}\\)`, 'gi'),
+      `![](${url})`,
+    )
+    processed = processed.replace(
+      new RegExp(`src="[^"]*${escapeRegExp(base)}"`, 'gi'),
+      `src="${url}"`,
+    )
+  }
+
+  const { body, defs } = parseReferenceDefinitions(processed)
+  const updatedDefs = new Map(defs)
+  for (const [ref, target] of updatedDefs) {
+    if (target.startsWith('data:')) {
+      const url = await uploadDataUriIfNeeded(target, ref, uploadImage)
+      updatedDefs.set(ref, url)
+    }
+  }
+
+  return inlineReferenceImages(body, updatedDefs)
+}
+
+export function pickMarkdownFile(files) {
+  return files.find((file) => {
+    const name = file.name.toLowerCase()
+    return name.endsWith('.md') || name.endsWith('.markdown')
+  })
+}
+
+export function prepareMarkdownForDisplay(md) {
+  if (!md) return md
+  let text = convertHtmlTablesToMarkdown(md)
+  text = normalizeMarkdownTables(text)
+  const { body, defs } = parseReferenceDefinitions(text)
+  return inlineReferenceImages(body, defs)
+}

--- a/src/utils/zipImport.js
+++ b/src/utils/zipImport.js
@@ -1,0 +1,42 @@
+const MIME_BY_EXT = {
+  md: 'text/markdown',
+  markdown: 'text/markdown',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+}
+
+function mimeFromName(name) {
+  const ext = name.split('.').pop()?.toLowerCase()
+  return MIME_BY_EXT[ext] ?? 'application/octet-stream'
+}
+
+export function isZipFile(file) {
+  const name = file.name.toLowerCase()
+  const type = (file.type || '').toLowerCase()
+  return (
+    name.endsWith('.zip')
+    || type === 'application/zip'
+    || type === 'application/x-zip-compressed'
+    || type === 'multipart/x-zip'
+  )
+}
+
+export async function extractFilesFromZip(zipFile) {
+  const JSZip = (await import('jszip')).default
+  const zip = await JSZip.loadAsync(await zipFile.arrayBuffer())
+  const files = []
+
+  for (const entry of Object.values(zip.files)) {
+    if (entry.dir) continue
+    const basename = entry.name.split('/').pop()
+    if (!basename || basename.startsWith('.')) continue
+    const blob = await entry.async('blob')
+    files.push(new File([blob], basename, { type: mimeFromName(basename) }))
+  }
+
+  return files
+}

--- a/supabase/migrations/20260623140000_add_problem_content_types_and_storage.sql
+++ b/supabase/migrations/20260623140000_add_problem_content_types_and_storage.sql
@@ -1,0 +1,74 @@
+-- Problem content modes: markdown (editable text) or document (docx/pdf in Storage)
+
+ALTER TABLE public.problems
+  ALTER COLUMN file_url DROP NOT NULL;
+
+ALTER TABLE public.problems
+  ADD COLUMN IF NOT EXISTS content_type TEXT NOT NULL DEFAULT 'markdown'
+    CHECK (content_type IN ('markdown', 'document'));
+
+ALTER TABLE public.problems
+  ADD COLUMN IF NOT EXISTS file_format TEXT
+    CHECK (file_format IS NULL OR file_format IN ('docx', 'pdf'));
+
+-- file_url stores Storage object path when content_type = 'document'
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit)
+VALUES ('problem-documents', 'problem-documents', false, 52428800)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY problem_documents_select_member_plus
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'problem-documents'
+  AND EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('member'::public.member_role, 'executive'::public.member_role, 'admin'::public.member_role)
+  )
+);
+
+CREATE POLICY problem_documents_insert_exec_admin
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'problem-documents'
+  AND EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('executive'::public.member_role, 'admin'::public.member_role)
+  )
+);
+
+CREATE POLICY problem_documents_update_exec_admin
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'problem-documents'
+  AND EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('executive'::public.member_role, 'admin'::public.member_role)
+  )
+);
+
+CREATE POLICY problem_documents_delete_exec_admin
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'problem-documents'
+  AND EXISTS (
+    SELECT 1
+    FROM public.profiles AS p
+    WHERE p.id = auth.uid()
+      AND p.role IN ('executive'::public.member_role, 'admin'::public.member_role)
+  )
+);


### PR DESCRIPTION
## Summary
- Add Problems create/edit/delete on `/problems` for executive and admin; members remain read-only.
- Support markdown mode (type, paste, single-file import) and document mode (`.docx` → PDF, `.pdf` as-is) with view-only body after publish.
- Add Supabase migration for `content_type` / `file_format` / `problem-documents` storage, Next.js document APIs, and FastAPI DOCX→PDF endpoint (Heroku Aptfile + Procfile).

## Product behavior
| Input | Result |
|-------|--------|
| Type / paste | Markdown editor (editable) |
| `.md` | Markdown mode; images imported separately |
| Image file | Attaches to current markdown (filename must match) |
| `.docx` (Word / Google Docs export) | Converted to PDF, document mode |
| `.pdf` | Stored and shown as PDF |

- Single **Import file** control (one file at a time); drag-and-drop also supported.
- Title auto-fills from filename when empty.
- Problems layout uses About-style `PageContainer` (`max-w-6xl`, `px-4 sm:px-6`).

## Post-merge ops (not fully live until done)
1. **Heroku:** deploy `backend/` with apt buildpack + Python buildpack, LibreOffice via `Aptfile`.
2. **Vercel:** set `BACKEND_API_URL` / `NEXT_PUBLIC_API_URL` to the Heroku app URL.
3. Local DOCX→PDF works with brew LibreOffice; production conversion requires Heroku LibreOffice.

## Test plan
- [ ] Executive/admin: New → type markdown → Preview → Publish
- [ ] Import `.md`, then import image files whose names match markdown paths
- [ ] Import `.docx` → PDF preview → Publish → post view shows PDF
- [ ] Import `.pdf` → Publish
- [ ] Member: read-only (no New/Edit/Delete)
- [ ] Edit metadata / replace document / delete problem
- [ ] Confirm migration applied on target Supabase project

Closes #31
