### PR TITLE
fix: rename navbar Log In to Get Started

### DIFF
--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -207,7 +207,7 @@ export default function Navbar() {
           ) : (
             <button onClick={handleLogIn} disabled={loggingIn}
               className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed">
-              {loggingIn ? 'Redirecting…' : 'Log In'}
+              {loggingIn ? 'Redirecting…' : 'Get Started'}
             </button>
           )}
           {canAccessAdmin && (
@@ -223,7 +223,7 @@ export default function Navbar() {
           ) : (
             <button onClick={handleLogIn} disabled={loggingIn}
               className="px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60">
-              {loggingIn ? '…' : 'Log In'}
+              {loggingIn ? '…' : 'Get Started'}
             </button>
           ))}
           <button


### PR DESCRIPTION
## Summary
- Rename the unauthenticated navbar CTA from `Log In` to `Get Started` on desktop and mobile.
- Same Google OAuth handler; clarifies that new members can start from this button.

## Test plan
- [ ] Logged out: navbar shows **Get Started** (desktop + mobile)
- [ ] Click opens Google sign-in as before
- [ ] Logged in: still shows profile chip + Log out