### PR TITLE
Fix loading LibreOffice shared libraries on Heroku for DOCX to PDF

### DIFF
--- a/backend/.profile.d/libreoffice.sh
+++ b/backend/.profile.d/libreoffice.sh
@@ -1,0 +1,10 @@
+# Ensure Heroku apt LibreOffice can resolve shared libraries (libreglo.so, etc.)
+APT_ROOT="${APT_ROOT:-/app/.apt}"
+
+export PATH="${APT_ROOT}/usr/bin:${APT_ROOT}/usr/lib/libreoffice/program:${PATH}"
+export LD_LIBRARY_PATH="${APT_ROOT}/usr/lib/libreoffice/program:${APT_ROOT}/usr/lib/x86_64-linux-gnu:${APT_ROOT}/lib/x86_64-linux-gnu:${APT_ROOT}/usr/lib:${APT_ROOT}/lib:${LD_LIBRARY_PATH}"
+export SAL_USE_VCLPLUGIN="${SAL_USE_VCLPLUGIN:-svp}"
+
+if [ -z "${HOME}" ] || [ "${HOME}" = "/" ]; then
+  export HOME=/tmp
+fi

--- a/backend/Aptfile
+++ b/backend/Aptfile
@@ -1,3 +1,7 @@
 libreoffice-writer
 libreoffice-common
+libreoffice-core
+ure
+ure-java
+libxml2
 fonts-liberation

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -8,6 +10,54 @@ from fastapi.responses import Response
 router = APIRouter(prefix="/documents", tags=["documents"])
 
 MAX_BYTES = 50 * 1024 * 1024
+
+# Heroku apt buildpack installs packages under /app/.apt
+APT_ROOT = Path(os.environ.get("APT_ROOT", "/app/.apt"))
+
+
+def resolve_soffice() -> str:
+    candidates = [
+        os.environ.get("LIBREOFFICE_PATH"),
+        str(APT_ROOT / "usr/bin/soffice"),
+        str(APT_ROOT / "usr/lib/libreoffice/program/soffice"),
+        "/usr/bin/soffice",
+        "soffice",
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if Path(candidate).is_file() or shutil.which(candidate):
+            return candidate
+    return "soffice"
+
+
+def libreoffice_env() -> dict:
+    """Build env so Heroku apt LibreOffice can find libreglo.so and friends."""
+    env = os.environ.copy()
+    lib_paths = [
+        str(APT_ROOT / "usr/lib/libreoffice/program"),
+        str(APT_ROOT / "usr/lib/x86_64-linux-gnu"),
+        str(APT_ROOT / "lib/x86_64-linux-gnu"),
+        str(APT_ROOT / "usr/lib"),
+        str(APT_ROOT / "lib"),
+        "/usr/lib/libreoffice/program",
+        "/usr/lib/x86_64-linux-gnu",
+        "/usr/lib",
+    ]
+    existing = [p for p in env.get("LD_LIBRARY_PATH", "").split(":") if p]
+    env["LD_LIBRARY_PATH"] = ":".join([*lib_paths, *existing])
+
+    path_prefix = [
+        str(APT_ROOT / "usr/bin"),
+        str(APT_ROOT / "usr/lib/libreoffice/program"),
+    ]
+    env["PATH"] = ":".join([*path_prefix, env.get("PATH", "")])
+
+    # LibreOffice needs a writable home and headless VCL plugin on servers.
+    env["HOME"] = env.get("HOME") if env.get("HOME") and env["HOME"] != "/" else "/tmp"
+    env.setdefault("SAL_USE_VCLPLUGIN", "svp")
+    env.setdefault("PYTHONPATH", "")
+    return env
 
 
 @router.post("/convert/docx-to-pdf")
@@ -25,14 +75,21 @@ async def convert_docx_to_pdf(file: UploadFile = File(...)):
         tmp_path = Path(tmp)
         input_path = tmp_path / "input.docx"
         input_path.write_bytes(raw)
+        user_install = tmp_path / "lo-profile"
+        user_install.mkdir()
+
+        soffice = resolve_soffice()
+        env = libreoffice_env()
 
         try:
             subprocess.run(
                 [
-                    "soffice",
+                    soffice,
                     "--headless",
                     "--nologo",
                     "--nofirststartwizard",
+                    "--norestore",
+                    f"-env:UserInstallation=file://{user_install}",
                     "--convert-to",
                     "pdf",
                     "--outdir",
@@ -42,6 +99,7 @@ async def convert_docx_to_pdf(file: UploadFile = File(...)):
                 check=True,
                 capture_output=True,
                 timeout=120,
+                env=env,
             )
         except FileNotFoundError as exc:
             raise HTTPException(
@@ -50,10 +108,14 @@ async def convert_docx_to_pdf(file: UploadFile = File(...)):
             ) from exc
         except subprocess.CalledProcessError as exc:
             stderr = (exc.stderr or b"").decode("utf-8", errors="ignore")
-            raise HTTPException(
-                status_code=500,
-                detail=f"DOCX to PDF conversion failed. {stderr[:200]}".strip(),
-            ) from exc
+            if "libreglo.so" in stderr or "shared libraries" in stderr:
+                detail = (
+                    "DOCX to PDF conversion failed: LibreOffice libraries are missing on the server. "
+                    "Redeploy the backend with the apt buildpack and updated Aptfile."
+                )
+            else:
+                detail = "DOCX to PDF conversion failed. Try uploading a PDF instead."
+            raise HTTPException(status_code=500, detail=detail) from exc
         except subprocess.TimeoutExpired as exc:
             raise HTTPException(status_code=504, detail="Conversion timed out.") from exc
 


### PR DESCRIPTION
This pull request improves the reliability of DOCX to PDF conversion using LibreOffice on Heroku, especially when deployed with the Heroku apt buildpack. The changes ensure that LibreOffice binaries and libraries are correctly found and loaded, provide more informative error messages, and add missing dependencies.

**Heroku LibreOffice integration improvements:**

* Added a new shell script (`backend/.profile.d/libreoffice.sh`) to set up `PATH`, `LD_LIBRARY_PATH`, and other environment variables so that LibreOffice can locate its binaries and shared libraries when installed via the Heroku apt buildpack.
* Added utility functions (`resolve_soffice` and `libreoffice_env`) in `backend/routers/documents.py` to dynamically locate the `soffice` binary and construct the correct environment for subprocess calls.
* Updated the DOCX to PDF conversion route to use the resolved `soffice` path, the custom environment, and a user profile directory to avoid permission issues. [[1]](diffhunk://#diff-74bd80c76db7ce52c1652c6688bf11e42a3b2d03e42c0681e1de17aeee4e1123R78-R92) [[2]](diffhunk://#diff-74bd80c76db7ce52c1652c6688bf11e42a3b2d03e42c0681e1de17aeee4e1123R102)

**Dependency and error handling enhancements:**

* Added missing LibreOffice-related packages (`libreoffice-core`, `ure`, `ure-java`, `libxml2`) to `backend/Aptfile` to ensure all required libraries are present.
* Improved error handling during conversion to provide clearer messages if shared libraries are missing, guiding users to redeploy with the correct dependencies.