### PR TITLE
fix: preserve import title, sort problems by newest, improve PDF export

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -84,7 +84,7 @@ async def convert_docx_to_pdf(file: UploadFile = File(...)):
                     "--norestore",
                     f"-env:UserInstallation=file://{user_install}",
                     "--convert-to",
-                    "pdf",
+                    "pdf:writer_pdf_Export:{\"EmbedStandardFonts\":{\"type\":\"boolean\",\"value\":\"true\"},\"UseTaggedPDF\":{\"type\":\"boolean\",\"value\":\"false\"}}",
                     "--outdir",
                     str(tmp_path),
                     str(input_path),

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -553,6 +553,7 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
               <div>
                 <p className="font-medium text-text-primary">Document mode</p>
                 <p>Word / Google Docs export (.docx) converts to PDF automatically. PDF uploads as-is. View-only after publish.</p>
+                <p className="text-text-hint text-xs mt-1">For pixel-perfect layout, export PDF from Word and upload the PDF. Server conversion may differ slightly from Word.</p>
               </div>
             </div>
             {form.documentName && (

--- a/src/lib/docxToPdfServer.js
+++ b/src/lib/docxToPdfServer.js
@@ -36,6 +36,9 @@ async function canUseLocalLibreOffice() {
   }
 }
 
+const PDF_EXPORT_FILTER =
+  'pdf:writer_pdf_Export:{"EmbedStandardFonts":{"type":"boolean","value":"true"},"UseTaggedPDF":{"type":"boolean","value":"false"}}'
+
 async function convertWithLocalLibreOffice(buffer) {
   const dir = await mkdtemp(path.join(tmpdir(), 'docx-pdf-'))
   try {
@@ -50,7 +53,7 @@ async function convertWithLocalLibreOffice(buffer) {
         '--nologo',
         '--nofirststartwizard',
         '--convert-to',
-        'pdf',
+        PDF_EXPORT_FILTER,
         '--outdir',
         dir,
         input,

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -49,8 +49,8 @@ export async function fetchProblems(schoolFilter) {
   let query = supabase
     .from('problems')
     .select(SELECT_FIELDS)
-    .order('week', { ascending: false, nullsFirst: false })
     .order('created_at', { ascending: false })
+    .order('week', { ascending: false, nullsFirst: false })
 
   if (schoolFilter && schoolFilter !== 'All Schools') {
     query = query.eq('school', schoolFilter)

--- a/src/utils/markdownImport.js
+++ b/src/utils/markdownImport.js
@@ -161,9 +161,7 @@ export function buildPendingImageMap(files) {
 
 export function guessTitleFromFilename(filename) {
   const base = filename.replace(/\.[^.]+$/, '').trim()
-  const withoutNumericPrefix = base.replace(/^\d+[-_.\s]+/, '')
-  const cleaned = (withoutNumericPrefix || base).replace(/[-_]+/g, ' ').trim()
-  return cleaned || 'Untitled'
+  return base.replace(/_/g, ' ').trim() || 'Untitled'
 }
 
 export function guessTitleFromImport(mdFile, mdText) {


### PR DESCRIPTION
## Summary
- Keep full filename as problem title on import (e.g. `8-Otherllo.docx` stays `8-Otherllo`, not `Otherllo`).
- Sort problems by `created_at` descending so the latest upload opens first on `/problems`.
- Embed standard fonts in LibreOffice PDF export (Heroku + local) and add a UI note that Word-exported PDFs preserve layout best.

## Test plan
- [ ] Upload `8-Otherllo.docx` and confirm title field shows `8-Otherllo`
- [ ] Publish a new problem and confirm it appears first when opening Problems
- [ ] Compare DOCX auto-conversion vs Word-exported PDF upload on a complex document