### PR TITLE
Preserve import title, sort problems by newest, and improve PDF export

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -84,7 +84,7 @@ async def convert_docx_to_pdf(file: UploadFile = File(...)):
                     "--norestore",
                     f"-env:UserInstallation=file://{user_install}",
                     "--convert-to",
-                    "pdf",
+                    "pdf:writer_pdf_Export:{\"EmbedStandardFonts\":{\"type\":\"boolean\",\"value\":\"true\"},\"UseTaggedPDF\":{\"type\":\"boolean\",\"value\":\"false\"}}",
                     "--outdir",
                     str(tmp_path),
                     str(input_path),

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -553,6 +553,7 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
               <div>
                 <p className="font-medium text-text-primary">Document mode</p>
                 <p>Word / Google Docs export (.docx) converts to PDF automatically. PDF uploads as-is. View-only after publish.</p>
+                <p className="text-text-hint text-xs mt-1">For pixel-perfect layout, export PDF from Word and upload the PDF. Server conversion may differ slightly from Word.</p>
               </div>
             </div>
             {form.documentName && (

--- a/src/lib/docxToPdfServer.js
+++ b/src/lib/docxToPdfServer.js
@@ -36,6 +36,9 @@ async function canUseLocalLibreOffice() {
   }
 }
 
+const PDF_EXPORT_FILTER =
+  'pdf:writer_pdf_Export:{"EmbedStandardFonts":{"type":"boolean","value":"true"},"UseTaggedPDF":{"type":"boolean","value":"false"}}'
+
 async function convertWithLocalLibreOffice(buffer) {
   const dir = await mkdtemp(path.join(tmpdir(), 'docx-pdf-'))
   try {
@@ -50,7 +53,7 @@ async function convertWithLocalLibreOffice(buffer) {
         '--nologo',
         '--nofirststartwizard',
         '--convert-to',
-        'pdf',
+        PDF_EXPORT_FILTER,
         '--outdir',
         dir,
         input,

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -49,8 +49,8 @@ export async function fetchProblems(schoolFilter) {
   let query = supabase
     .from('problems')
     .select(SELECT_FIELDS)
-    .order('week', { ascending: false, nullsFirst: false })
     .order('created_at', { ascending: false })
+    .order('week', { ascending: false, nullsFirst: false })
 
   if (schoolFilter && schoolFilter !== 'All Schools') {
     query = query.eq('school', schoolFilter)

--- a/src/utils/markdownImport.js
+++ b/src/utils/markdownImport.js
@@ -161,9 +161,7 @@ export function buildPendingImageMap(files) {
 
 export function guessTitleFromFilename(filename) {
   const base = filename.replace(/\.[^.]+$/, '').trim()
-  const withoutNumericPrefix = base.replace(/^\d+[-_.\s]+/, '')
-  const cleaned = (withoutNumericPrefix || base).replace(/[-_]+/g, ' ').trim()
-  return cleaned || 'Untitled'
+  return base.replace(/_/g, ' ').trim() || 'Untitled'
 }
 
 export function guessTitleFromImport(mdFile, mdText) {


### PR DESCRIPTION
This pull request introduces improvements to the DOCX-to-PDF conversion pipeline to ensure more consistent PDF exports, updates user guidance on document uploads, and makes minor code and query adjustments. The most important changes are grouped below.

**DOCX-to-PDF Conversion Consistency:**

* Updated the LibreOffice PDF export command in both the backend (`documents.py`) and local server conversion (`docxToPdfServer.js`) to use a specific filter (`writer_pdf_Export`) with options to embed standard fonts and disable tagged PDF, ensuring more consistent output between server and local conversions. [[1]](diffhunk://#diff-74bd80c76db7ce52c1652c6688bf11e42a3b2d03e42c0681e1de17aeee4e1123L87-R87) [[2]](diffhunk://#diff-dddbec4785d21c84fc6d29543d2d283d9287e82005808cf5d3fa73101cd222f6R39-R41) [[3]](diffhunk://#diff-dddbec4785d21c84fc6d29543d2d283d9287e82005808cf5d3fa73101cd222f6L53-R56)

**User Guidance:**

* Added a UI hint advising users to export PDFs directly from Word for pixel-perfect layout, as server-side conversion may differ slightly.

**Code and Query Adjustments:**

* Fixed the ordering of the `problems` query to ensure problems are ordered by `created_at` and then by `week` in descending order.
* Simplified the `guessTitleFromFilename` utility to no longer remove numeric prefixes, only replacing underscores with spaces for cleaner titles.…rt (#183)