### PR TITLE
feat: download original docx or pdf from problem documents

### DIFF
--- a/src/app/api/problems/[id]/route.js
+++ b/src/app/api/problems/[id]/route.js
@@ -1,0 +1,55 @@
+import { verifyAdminCaller } from '@/lib/adminApi'
+import { PROBLEM_BUCKET, CONTENT_TYPE } from '@/services/problemsService'
+
+export const runtime = 'nodejs'
+
+async function removeStorageObject(serviceClient, path) {
+  if (!path) return
+  const { error } = await serviceClient.storage.from(PROBLEM_BUCKET).remove([path])
+  if (error) {
+    const message = error.message?.toLowerCase() ?? ''
+    if (message.includes('not found') || message.includes('does not exist')) return
+    throw error
+  }
+}
+
+export async function DELETE(request, { params }) {
+  const auth = await verifyAdminCaller(request)
+  if (auth.error) return auth.error
+
+  const { id } = await params
+  if (!id) {
+    return Response.json({ error: 'Problem id is required.' }, { status: 400 })
+  }
+
+  const { serviceClient } = auth
+
+  const { data: problem, error: fetchError } = await serviceClient
+    .from('problems')
+    .select('file_url, content_type, source_file_url')
+    .eq('id', id)
+    .single()
+
+  if (fetchError) {
+    return Response.json({ error: fetchError.message ?? 'Problem not found.' }, { status: 404 })
+  }
+
+  if (problem?.content_type === CONTENT_TYPE.DOCUMENT) {
+    try {
+      await removeStorageObject(serviceClient, problem.file_url)
+      await removeStorageObject(serviceClient, problem.source_file_url)
+    } catch (err) {
+      return Response.json(
+        { error: err?.message ?? 'Failed to remove problem document from storage.' },
+        { status: 500 },
+      )
+    }
+  }
+
+  const { error: deleteError } = await serviceClient.from('problems').delete().eq('id', id)
+  if (deleteError) {
+    return Response.json({ error: deleteError.message ?? 'Failed to delete problem.' }, { status: 500 })
+  }
+
+  return Response.json({ ok: true })
+}

--- a/src/app/api/problems/documents/route.js
+++ b/src/app/api/problems/documents/route.js
@@ -129,3 +129,20 @@ export async function GET(request) {
 
   return Response.json({ signedUrl: data.signedUrl })
 }
+
+export async function DELETE(request) {
+  const auth = await verifyAdminCaller(request)
+  if (auth.error) return auth.error
+
+  const path = request.nextUrl.searchParams.get('path')
+  if (!path) {
+    return Response.json({ error: 'path is required.' }, { status: 400 })
+  }
+
+  const { error } = await auth.serviceClient.storage.from(PROBLEM_BUCKET).remove([path])
+  if (error) {
+    return Response.json({ error: error.message ?? 'Failed to delete file.' }, { status: 500 })
+  }
+
+  return Response.json({ ok: true })
+}

--- a/src/app/api/problems/documents/route.js
+++ b/src/app/api/problems/documents/route.js
@@ -10,6 +10,14 @@ import {
 
 export const runtime = 'nodejs'
 
+async function uploadBytes(serviceClient, path, bytes, contentType) {
+  const { error } = await serviceClient.storage
+    .from(PROBLEM_BUCKET)
+    .upload(path, bytes, { contentType, upsert: false })
+
+  if (error) throw error
+}
+
 export async function POST(request) {
   const auth = await verifyAdminCaller(request)
   if (auth.error) return auth.error
@@ -26,18 +34,44 @@ export async function POST(request) {
     return Response.json({ error: 'File exceeds the 50 MB limit.' }, { status: 400 })
   }
 
-  let fileType = detectProblemFileType(file)
-  if (fileType !== FILE_FORMAT.DOCX && fileType !== FILE_FORMAT.PDF) {
+  const sourceType = detectProblemFileType(file)
+  if (sourceType !== FILE_FORMAT.DOCX && sourceType !== FILE_FORMAT.PDF) {
     return Response.json({ error: 'Only .docx and .pdf files are supported.' }, { status: 400 })
   }
 
-  let bytes = Buffer.from(await file.arrayBuffer())
+  const bytes = Buffer.from(await file.arrayBuffer())
 
-  if (fileType === FILE_FORMAT.DOCX) {
-    try {
-      bytes = await convertDocxToPdf(bytes, file.name)
-      fileType = FILE_FORMAT.PDF
-    } catch (err) {
+  try {
+    if (sourceType === FILE_FORMAT.DOCX) {
+      const sourcePath = `${problemId}/${randomUUID()}.docx`
+      const pdfPath = `${problemId}/${randomUUID()}.pdf`
+      const pdfBytes = await convertDocxToPdf(bytes, file.name)
+
+      await uploadBytes(
+        auth.serviceClient,
+        sourcePath,
+        bytes,
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      )
+      await uploadBytes(auth.serviceClient, pdfPath, pdfBytes, 'application/pdf')
+
+      return Response.json({
+        path: pdfPath,
+        sourcePath,
+        fileFormat: FILE_FORMAT.DOCX,
+      })
+    }
+
+    const pdfPath = `${problemId}/${randomUUID()}.pdf`
+    await uploadBytes(auth.serviceClient, pdfPath, bytes, 'application/pdf')
+
+    return Response.json({
+      path: pdfPath,
+      sourcePath: null,
+      fileFormat: FILE_FORMAT.PDF,
+    })
+  } catch (err) {
+    if (sourceType === FILE_FORMAT.DOCX) {
       return Response.json(
         {
           error: err?.message
@@ -46,22 +80,8 @@ export async function POST(request) {
         { status: 422 },
       )
     }
+    return Response.json({ error: err?.message ?? 'Upload failed.' }, { status: 500 })
   }
-
-  const path = `${problemId}/${randomUUID()}.${fileType}`
-
-  const { error } = await auth.serviceClient.storage
-    .from(PROBLEM_BUCKET)
-    .upload(path, bytes, {
-      contentType: fileType === FILE_FORMAT.PDF ? 'application/pdf' : undefined,
-      upsert: false,
-    })
-
-  if (error) {
-    return Response.json({ error: error.message ?? 'Upload failed.' }, { status: 500 })
-  }
-
-  return Response.json({ path, fileFormat: fileType })
 }
 
 export async function GET(request) {
@@ -87,12 +107,16 @@ export async function GET(request) {
       ? 'application/pdf'
       : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 
-    return new Response(data, {
-      headers: {
-        'Content-Type': contentType,
-        'Cache-Control': 'private, max-age=3600',
-      },
-    })
+    const filename = request.nextUrl.searchParams.get('filename')
+    const headers = {
+      'Content-Type': contentType,
+      'Cache-Control': 'private, max-age=3600',
+    }
+    if (filename) {
+      headers['Content-Disposition'] = `attachment; filename="${filename.replace(/"/g, '')}"`
+    }
+
+    return new Response(data, { headers })
   }
 
   const { data, error } = await auth.serviceClient.storage

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -69,6 +69,7 @@ export function emptyProblemForm() {
     description: '',
     pendingFile: null,
     fileUrl: null,
+    sourceFileUrl: null,
     documentName: null,
     pendingImageFiles: [],
   }
@@ -85,6 +86,7 @@ export function problemToForm(problem) {
     description: problem.description ?? '',
     pendingFile: null,
     fileUrl: problem.file_url,
+    sourceFileUrl: problem.source_file_url ?? null,
     documentName: problem.file_url ? problem.file_url.split('/').pop() : null,
     pendingImageFiles: [],
   }
@@ -152,6 +154,7 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
   const [error, setError] = useState('')
   const [pdfUrl, setPdfUrl] = useState('')
   const [docxBuffer, setDocxBuffer] = useState(null)
+  const isPdfStorage = storagePath?.toLowerCase().endsWith('.pdf')
 
   useEffect(() => {
     if (!storagePath || !fileFormat || !accessToken) {
@@ -167,7 +170,7 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
       setPdfUrl('')
       setDocxBuffer(null)
       try {
-        if (fileFormat === FILE_FORMAT.PDF) {
+        if (isPdfStorage) {
           const url = await getDocumentSignedUrl(storagePath, accessToken)
           if (!cancelled) setPdfUrl(url)
         } else if (fileFormat === FILE_FORMAT.DOCX) {
@@ -183,7 +186,7 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
 
     load()
     return () => { cancelled = true }
-  }, [storagePath, fileFormat, accessToken])
+  }, [storagePath, fileFormat, accessToken, isPdfStorage])
 
   useEffect(() => {
     if (!docxBuffer || !containerRef.current) return
@@ -208,7 +211,7 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
     return <p className={`text-text-secondary font-inter text-sm ${className}`}>{error}</p>
   }
 
-  if (fileFormat === FILE_FORMAT.PDF && pdfUrl) {
+  if (isPdfStorage && pdfUrl) {
     return (
       <iframe
         title="Problem document"

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -15,6 +15,10 @@ import {
   uploadProblemDocument,
   removeProblemDocument,
   CONTENT_TYPE,
+  FILE_FORMAT,
+  buildProblemDocumentFilename,
+  getProblemDownloadStoragePath,
+  downloadProblemDocument,
 } from '@/services/problemsService'
 import { fetchUserSubmissions } from '@/services/submissionsService'
 import { ROLES } from '@/utils/constants'
@@ -48,9 +52,27 @@ function downloadMd(problem) {
   URL.revokeObjectURL(url)
 }
 
+async function downloadDocument(problem, accessToken) {
+  const storagePath = getProblemDownloadStoragePath(problem)
+  if (!storagePath || !accessToken) return
+
+  const blob = await downloadProblemDocument(
+    storagePath,
+    accessToken,
+    buildProblemDocumentFilename(problem),
+  )
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = buildProblemDocumentFilename(problem)
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
 function PostView({
   problems, currentIdx, navigateTo, setView, profile, onDelete, onEdit, onNew,
   schoolFilter, setSchoolFilter, showForm, form, onFormChange, onPublish, onCancelForm, submitting, editMode, accessToken,
+  onDownloadDocument,
 }) {
   const router = useRouter()
   const problem = problems[currentIdx]
@@ -147,7 +169,7 @@ function PostView({
                   <List size={14} />
                   List
                 </button>
-                {isMarkdown && (
+                {isMarkdown ? (
                   <button
                     onClick={() => downloadMd(problem)}
                     className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary transition-colors"
@@ -155,6 +177,15 @@ function PostView({
                   >
                     <Download size={14} />
                     .md
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => onDownloadDocument(problem)}
+                    className="flex items-center gap-1.5 px-5 py-2 rounded-md text-sm font-medium font-inter border border-border-strong text-text-secondary hover:border-text-primary hover:text-text-primary transition-colors"
+                    title={`Download .${problem.file_format === FILE_FORMAT.DOCX ? 'docx' : 'pdf'}`}
+                  >
+                    <Download size={14} />
+                    .{problem.file_format === FILE_FORMAT.DOCX ? 'docx' : 'pdf'}
                   </button>
                 )}
               </div>
@@ -400,10 +431,11 @@ function ProblemsContent() {
     return Number.isNaN(n) ? null : n
   }
 
-  async function persistDocument(problemId, pendingFile, existingPath) {
-    const { path, fileFormat } = await uploadProblemDocument(pendingFile, problemId, accessToken)
-    if (existingPath) await removeProblemDocument(existingPath)
-    return { path, fileFormat }
+  async function persistDocument(problemId, pendingFile, existing) {
+    const { path, sourcePath, fileFormat } = await uploadProblemDocument(pendingFile, problemId, accessToken)
+    if (existing?.file_url) await removeProblemDocument(existing.file_url)
+    if (existing?.source_file_url) await removeProblemDocument(existing.source_file_url)
+    return { path, sourcePath, fileFormat }
   }
 
   async function finalizeMarkdownDescription(description, pendingImageFiles) {
@@ -448,9 +480,10 @@ function ProblemsContent() {
           createdBy: user?.id,
         })
         createdId = row.id
-        const { path, fileFormat } = await persistDocument(row.id, form.pendingFile, null)
+        const { path, sourcePath, fileFormat } = await persistDocument(row.id, form.pendingFile, null)
         await updateProblem(row.id, {
           fileUrl: path,
+          sourceFileUrl: sourcePath,
           fileFormat,
           contentType: CONTENT_TYPE.DOCUMENT,
         })
@@ -499,10 +532,12 @@ function ProblemsContent() {
 
       if (form.contentType === CONTENT_TYPE.DOCUMENT) {
         let fileUrl = form.fileUrl
+        let sourceFileUrl = form.sourceFileUrl ?? null
         let fileFormat = form.fileFormat
         if (form.pendingFile) {
-          const uploaded = await persistDocument(id, form.pendingFile, existing?.file_url)
+          const uploaded = await persistDocument(id, form.pendingFile, existing)
           fileUrl = uploaded.path
+          sourceFileUrl = uploaded.sourcePath
           fileFormat = uploaded.fileFormat
         }
         await updateProblem(id, {
@@ -512,12 +547,14 @@ function ProblemsContent() {
           school,
           contentType: CONTENT_TYPE.DOCUMENT,
           fileUrl,
+          sourceFileUrl,
           fileFormat,
           description: '',
         })
       } else {
-        if (existing?.content_type === CONTENT_TYPE.DOCUMENT && existing.file_url) {
-          await removeProblemDocument(existing.file_url)
+        if (existing?.content_type === CONTENT_TYPE.DOCUMENT) {
+          if (existing.file_url) await removeProblemDocument(existing.file_url)
+          if (existing.source_file_url) await removeProblemDocument(existing.source_file_url)
         }
         const description = await finalizeMarkdownDescription(form.description, form.pendingImageFiles)
         await updateProblem(id, {
@@ -529,6 +566,7 @@ function ProblemsContent() {
           contentType: CONTENT_TYPE.MARKDOWN,
           fileFormat: null,
           fileUrl: null,
+          sourceFileUrl: null,
         })
       }
 
@@ -558,6 +596,18 @@ function ProblemsContent() {
       setCurrentIdx(0)
     } catch {
       alert('Failed to delete. Please try again.')
+    }
+  }
+
+  async function handleDownloadDocument(problem) {
+    if (!accessToken) {
+      alert('Session expired. Please refresh and log in again.')
+      return
+    }
+    try {
+      await downloadDocument(problem, accessToken)
+    } catch (err) {
+      alert(err.message ?? 'Failed to download document.')
     }
   }
 
@@ -606,6 +656,7 @@ function ProblemsContent() {
       setView={setView}
       onDelete={handleDelete}
       onEdit={openEdit}
+      onDownloadDocument={handleDownloadDocument}
     />
   ) : (
     <ListView

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -433,8 +433,8 @@ function ProblemsContent() {
 
   async function persistDocument(problemId, pendingFile, existing) {
     const { path, sourcePath, fileFormat } = await uploadProblemDocument(pendingFile, problemId, accessToken)
-    if (existing?.file_url) await removeProblemDocument(existing.file_url)
-    if (existing?.source_file_url) await removeProblemDocument(existing.source_file_url)
+    if (existing?.file_url) await removeProblemDocument(existing.file_url, accessToken)
+    if (existing?.source_file_url) await removeProblemDocument(existing.source_file_url, accessToken)
     return { path, sourcePath, fileFormat }
   }
 
@@ -509,7 +509,7 @@ function ProblemsContent() {
       setCurrentIdx(0)
     } catch (err) {
       if (createdId) {
-        try { await deleteProblem(createdId) } catch { /* rollback best-effort */ }
+        try { await deleteProblem(createdId, accessToken) } catch { /* rollback best-effort */ }
       }
       alert(err.message ?? 'Failed to publish. Please try again.')
     } finally {
@@ -553,8 +553,8 @@ function ProblemsContent() {
         })
       } else {
         if (existing?.content_type === CONTENT_TYPE.DOCUMENT) {
-          if (existing.file_url) await removeProblemDocument(existing.file_url)
-          if (existing.source_file_url) await removeProblemDocument(existing.source_file_url)
+          if (existing.file_url) await removeProblemDocument(existing.file_url, accessToken)
+          if (existing.source_file_url) await removeProblemDocument(existing.source_file_url, accessToken)
         }
         const description = await finalizeMarkdownDescription(form.description, form.pendingImageFiles)
         await updateProblem(id, {
@@ -589,13 +589,17 @@ function ProblemsContent() {
 
   async function handleDelete(id) {
     if (!confirm('Delete this problem? This cannot be undone.')) return
+    if (!accessToken) {
+      alert('Session expired. Please refresh and log in again.')
+      return
+    }
     try {
-      await deleteProblem(id)
+      await deleteProblem(id, accessToken)
       cancelForm()
       await loadProblems()
       setCurrentIdx(0)
-    } catch {
-      alert('Failed to delete. Please try again.')
+    } catch (err) {
+      alert(err.message ?? 'Failed to delete. Please try again.')
     }
   }
 

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -26,9 +26,25 @@ function mapProblem(row) {
     content_type: row.content_type ?? CONTENT_TYPE.MARKDOWN,
     file_format: row.file_format,
     file_url: row.file_url,
+    source_file_url: row.source_file_url ?? null,
     created_at: row.created_at,
     created_by: row.created_by,
   }
+}
+
+export function buildProblemDocumentFilename(problem) {
+  const slug = (problem.title || 'problem').trim().toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '') || 'problem'
+  const ext = problem.file_format === FILE_FORMAT.DOCX ? 'docx' : 'pdf'
+  return `${slug}.${ext}`
+}
+
+export function getProblemDownloadStoragePath(problem) {
+  if (problem.file_format === FILE_FORMAT.DOCX) {
+    return problem.source_file_url || problem.file_url
+  }
+  return problem.file_url
 }
 
 export function detectProblemFileType(file) {
@@ -70,6 +86,7 @@ export async function createProblem({
   contentType = CONTENT_TYPE.MARKDOWN,
   fileFormat = null,
   fileUrl = null,
+  sourceFileUrl = null,
   createdBy,
 }) {
   const { data, error } = await supabase
@@ -83,6 +100,7 @@ export async function createProblem({
       content_type: contentType,
       file_format: fileFormat,
       file_url: fileUrl,
+      source_file_url: sourceFileUrl,
       created_by: createdBy ?? null,
     })
     .select(SELECT_FIELDS)
@@ -102,6 +120,7 @@ export async function updateProblem(id, fields) {
   if (fields.contentType !== undefined) payload.content_type = fields.contentType
   if (fields.fileFormat !== undefined) payload.file_format = fields.fileFormat
   if (fields.fileUrl !== undefined) payload.file_url = fields.fileUrl
+  if (fields.sourceFileUrl !== undefined) payload.source_file_url = fields.sourceFileUrl
 
   const { data, error } = await supabase
     .from('problems')
@@ -138,7 +157,11 @@ export async function uploadProblemDocument(file, problemId, accessToken) {
 
   const body = await res.json()
   if (!res.ok) throw new Error(body.error ?? 'Upload failed.')
-  return { path: body.path, fileFormat: body.fileFormat }
+  return {
+    path: body.path,
+    sourcePath: body.sourcePath ?? null,
+    fileFormat: body.fileFormat,
+  }
 }
 
 export async function previewDocxAsPdf(file, accessToken) {
@@ -174,11 +197,16 @@ export async function getDocumentSignedUrl(storagePath, accessToken) {
   return body.signedUrl
 }
 
-export async function downloadProblemDocument(storagePath, accessToken) {
-  const res = await fetch(
-    `/api/problems/documents?path=${encodeURIComponent(storagePath)}&download=1`,
-    { headers: { Authorization: `Bearer ${accessToken}` } },
-  )
+export async function downloadProblemDocument(storagePath, accessToken, filename) {
+  const params = new URLSearchParams({
+    path: storagePath,
+    download: '1',
+  })
+  if (filename) params.set('filename', filename)
+
+  const res = await fetch(`/api/problems/documents?${params}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
     throw new Error(body.error ?? 'Failed to download document.')
@@ -195,14 +223,15 @@ export async function removeProblemDocument(storagePath) {
 export async function deleteProblem(id) {
   const { data: problem, error: fetchError } = await supabase
     .from('problems')
-    .select('file_url, content_type')
+    .select('file_url, source_file_url, content_type')
     .eq('id', id)
     .single()
 
   if (fetchError) throw fetchError
 
-  if (problem?.content_type === CONTENT_TYPE.DOCUMENT && problem.file_url) {
-    await removeProblemDocument(problem.file_url)
+  if (problem?.content_type === CONTENT_TYPE.DOCUMENT) {
+    if (problem.file_url) await removeProblemDocument(problem.file_url)
+    if (problem.source_file_url) await removeProblemDocument(problem.source_file_url)
   }
 
   const { error } = await supabase.from('problems').delete().eq('id', id)

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -214,26 +214,30 @@ export async function downloadProblemDocument(storagePath, accessToken, filename
   return res.blob()
 }
 
-export async function removeProblemDocument(storagePath) {
+export async function removeProblemDocument(storagePath, accessToken) {
   if (!storagePath) return
-  const { error } = await supabase.storage.from(PROBLEM_BUCKET).remove([storagePath])
-  if (error) throw error
+  if (!accessToken) throw new Error('Not authenticated.')
+
+  const res = await fetch(
+    `/api/problems/documents?path=${encodeURIComponent(storagePath)}`,
+    {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  )
+
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(body.error ?? 'Failed to remove document.')
 }
 
-export async function deleteProblem(id) {
-  const { data: problem, error: fetchError } = await supabase
-    .from('problems')
-    .select('file_url, source_file_url, content_type')
-    .eq('id', id)
-    .single()
+export async function deleteProblem(id, accessToken) {
+  if (!accessToken) throw new Error('Not authenticated.')
 
-  if (fetchError) throw fetchError
+  const res = await fetch(`/api/problems/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
 
-  if (problem?.content_type === CONTENT_TYPE.DOCUMENT) {
-    if (problem.file_url) await removeProblemDocument(problem.file_url)
-    if (problem.source_file_url) await removeProblemDocument(problem.source_file_url)
-  }
-
-  const { error } = await supabase.from('problems').delete().eq('id', id)
-  if (error) throw error
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(body.error ?? 'Failed to delete problem.')
 }

--- a/supabase/migrations/20260708140000_add_problem_source_file_url.sql
+++ b/supabase/migrations/20260708140000_add_problem_source_file_url.sql
@@ -1,0 +1,7 @@
+-- Store original .docx when uploads are converted to PDF for viewing
+
+ALTER TABLE public.problems
+  ADD COLUMN IF NOT EXISTS source_file_url TEXT;
+
+COMMENT ON COLUMN public.problems.source_file_url IS
+  'Storage path to original .docx when content_type=document and file_format=docx; null for PDF uploads';


### PR DESCRIPTION
## Summary
- Store original `.docx` in Supabase when uploads are converted to PDF for viewing (`source_file_url`).
- Add Download button on Problems post view: `.docx` for Word uploads, `.pdf` for PDF uploads.
- Clean up both storage objects on replace/delete.

## Migration
Run `supabase/migrations/20260708140000_add_problem_source_file_url.sql` on Supabase before deploy.

## Test plan
- [ ] Upload `.docx` → view PDF preview → download returns `.docx` original
- [ ] Upload `.pdf` → download returns `.pdf`
- [ ] Replace document on edit removes old PDF and DOCX copies
- [ ] Existing problems uploaded before this change still download stored PDF