### PR TITLE
feat: admin executive titles, pending revert, and member sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Public (Unauthenticated)
 | **Public** | Landing, public announcements, events |
 | **Member** | Dashboard, member directory, problem submissions |
 | **Executive** | Post problems, manage sessions, events CRUD |
-| **Admin** | User approval, role management, full access |
+| **Admin** | User approval, role management, executive position assignment for Our Team, full access |
 
 **Onboarding flow:** `Google Sign-In → pending → Admin approval → member`
 

--- a/src/app/admin/_components/MemberEditPanel.js
+++ b/src/app/admin/_components/MemberEditPanel.js
@@ -1,15 +1,21 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { SCHOOLS, ROLES } from '@/utils/constants'
+import { SCHOOLS, ROLES, EXECUTIVE_TITLES } from '@/utils/constants'
 import { generateCohortOptions } from '@/utils/cohortOptions'
 import { formatPhone } from '@/utils/phone'
 import { memberToForm } from '@/services/adminService'
 
 const ROLE_OPTIONS = [
+  { value: ROLES.PENDING, label: 'Pending' },
   { value: ROLES.MEMBER, label: 'Member' },
   { value: ROLES.EXECUTIVE, label: 'Executive' },
   { value: ROLES.ADMIN, label: 'Admin' },
+]
+
+const TITLE_OPTIONS = [
+  { value: '', label: 'None' },
+  ...EXECUTIVE_TITLES.map((title) => ({ value: title, label: title })),
 ]
 
 const STATUS_OPTIONS = [
@@ -46,11 +52,12 @@ export default function MemberEditPanel({ member, saving, error, onSave, onCance
   }
 
   const displayName = [member.firstName, member.lastName].filter(Boolean).join(' ') || member.email
+  const isPendingRole = form.role === ROLES.PENDING
 
   return (
-    <div className="border border-border rounded-lg bg-bg-surface flex flex-col max-h-[calc(100vh-12rem)] min-h-[320px]">
+    <div className="border border-border rounded-lg bg-bg-surface flex flex-col max-h-[min(90vh,40rem)] shadow-lg">
       <div className="px-4 py-3 border-b border-border shrink-0">
-        <h2 className="font-montserrat font-semibold text-lg text-text-primary">Edit member</h2>
+        <h2 id="edit-member-title" className="font-montserrat font-semibold text-lg text-text-primary">Edit member</h2>
         <p className="text-sm text-text-secondary mt-0.5 truncate">{displayName}</p>
       </div>
 
@@ -62,7 +69,7 @@ export default function MemberEditPanel({ member, saving, error, onSave, onCance
               value={form.first_name}
               onChange={e => updateField('first_name', e.target.value)}
               className={inputClass}
-              required
+              required={!isPendingRole}
             />
           </Field>
 
@@ -72,7 +79,7 @@ export default function MemberEditPanel({ member, saving, error, onSave, onCance
               value={form.last_name}
               onChange={e => updateField('last_name', e.target.value)}
               className={inputClass}
-              required
+              required={!isPendingRole}
             />
           </Field>
 
@@ -81,7 +88,7 @@ export default function MemberEditPanel({ member, saving, error, onSave, onCance
               value={form.school}
               onChange={e => updateField('school', e.target.value)}
               className={inputClass}
-              required
+              required={!isPendingRole}
             >
               <option value="">Select school</option>
               {SCHOOLS.map(school => (
@@ -95,7 +102,7 @@ export default function MemberEditPanel({ member, saving, error, onSave, onCance
               value={form.cohort}
               onChange={e => updateField('cohort', e.target.value)}
               className={inputClass}
-              required
+              required={!isPendingRole}
             >
               <option value="">Select cohort</option>
               {cohortOptions.map(opt => (
@@ -107,14 +114,46 @@ export default function MemberEditPanel({ member, saving, error, onSave, onCance
           <Field label="Role">
             <select
               value={form.role}
-              onChange={e => updateField('role', e.target.value)}
+              onChange={e => {
+                const role = e.target.value
+                setForm(prev => ({
+                  ...prev,
+                  role,
+                  executive_title:
+                    role === ROLES.EXECUTIVE || role === ROLES.ADMIN
+                      ? prev.executive_title
+                      : '',
+                }))
+              }}
               className={inputClass}
             >
               {ROLE_OPTIONS.map(opt => (
                 <option key={opt.value} value={opt.value}>{opt.label}</option>
               ))}
             </select>
+            {form.role === ROLES.PENDING && (
+              <p className="mt-1.5 text-xs text-text-hint">
+                Returns this person to the approval queue. Their Our Team position is cleared.
+              </p>
+            )}
           </Field>
+
+          {(form.role === ROLES.EXECUTIVE || form.role === ROLES.ADMIN) && (
+            <Field label="Our Team position">
+              <select
+                value={form.executive_title}
+                onChange={e => updateField('executive_title', e.target.value)}
+                className={inputClass}
+              >
+                {TITLE_OPTIONS.map(opt => (
+                  <option key={opt.value || 'none'} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              <p className="mt-1.5 text-xs text-text-hint">
+                Shown on About → Our Team for this member&apos;s school. One person per position per school.
+              </p>
+            </Field>
+          )}
 
           <Field label="Status">
             <select

--- a/src/app/admin/_components/MemberTable.js
+++ b/src/app/admin/_components/MemberTable.js
@@ -1,9 +1,15 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import UserAvatar from '@/components/common/UserAvatar'
 import { cohortLabel } from '@/utils/cohort'
 import { isPendingApplicant } from '@/services/adminService'
+import {
+  compareNumberLike,
+  compareText,
+  sortIndicator,
+  toggleSort,
+} from '@/utils/memberSort'
 
 function formatStatus(status) {
   if (!status || status === 'student') return 'Student'
@@ -22,6 +28,61 @@ function formatDate(str) {
   return new Date(str).toLocaleDateString('en-CA', { year: 'numeric', month: 'short', day: 'numeric' })
 }
 
+function memberName(member) {
+  return [member.firstName, member.lastName].filter(Boolean).join(' ')
+}
+
+function compareMembers(a, b, key, dir) {
+  let result = 0
+
+  switch (key) {
+    case 'name':
+      result = compareText(memberName(a), memberName(b))
+      break
+    case 'email':
+      result = compareText(a.email, b.email)
+      break
+    case 'school':
+      result = compareText(a.school, b.school)
+      break
+    case 'cohort':
+      result = compareNumberLike(a.cohort, b.cohort)
+      break
+    case 'role':
+      result = compareText(formatRole(a.role), formatRole(b.role))
+        || compareText(a.executiveTitle, b.executiveTitle)
+      break
+    case 'status':
+      result = compareText(formatStatus(a.status), formatStatus(b.status))
+      break
+    case 'createdAt':
+      result = new Date(a.createdAt || 0) - new Date(b.createdAt || 0)
+      break
+    default:
+      result = 0
+  }
+
+  if (result === 0 && key !== 'name') {
+    result = compareText(memberName(a), memberName(b))
+  }
+
+  return dir === 'asc' ? result : -result
+}
+
+function SortHeader({ label, sortKey, activeKey, activeDir, onSort, className = '' }) {
+  return (
+    <th className={`py-2.5 px-3 font-medium ${className}`}>
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className="text-left hover:text-text-primary transition-colors"
+      >
+        {label}{sortIndicator(activeKey, activeDir, sortKey)}
+      </button>
+    </th>
+  )
+}
+
 export default function MemberTable({
   members,
   selectedId,
@@ -32,7 +93,25 @@ export default function MemberTable({
   onReject,
 }) {
   const [rejectTarget, setRejectTarget] = useState(null)
+  const [sortKey, setSortKey] = useState('name')
+  const [sortDir, setSortDir] = useState('asc')
   const pendingCount = members.filter(isPendingApplicant).length
+
+  const sortedMembers = useMemo(() => {
+    return [...members].sort((a, b) => {
+      // Keep pending applicants pinned to the top regardless of column sort
+      const aPending = isPendingApplicant(a)
+      const bPending = isPendingApplicant(b)
+      if (aPending !== bPending) return aPending ? -1 : 1
+      return compareMembers(a, b, sortKey, sortDir)
+    })
+  }, [members, sortKey, sortDir])
+
+  function handleSort(key) {
+    const next = toggleSort(sortKey, sortDir, key)
+    setSortKey(next.key)
+    setSortDir(next.dir)
+  }
 
   return (
     <>
@@ -47,7 +126,7 @@ export default function MemberTable({
             )}
           </p>
           {isAdmin && (
-            <p className="text-xs text-text-hint font-inter hidden sm:block">Click a row to edit</p>
+            <p className="text-xs text-text-hint font-inter hidden sm:block">Click a name to edit · click headers to sort</p>
           )}
         </div>
 
@@ -55,24 +134,24 @@ export default function MemberTable({
           <table className="w-full border-collapse text-sm font-inter">
             <thead className="sticky top-0 z-10 bg-bg-layer1">
               <tr className="border-b border-border text-left text-xs text-text-hint">
-                <th className="py-2.5 px-3 font-medium w-36">Member</th>
-                <th className="py-2.5 px-3 font-medium">Email</th>
-                <th className="py-2.5 px-3 font-medium hidden md:table-cell">School</th>
-                <th className="py-2.5 px-3 font-medium hidden lg:table-cell">Cohort</th>
-                <th className="py-2.5 px-3 font-medium w-24">Role</th>
-                <th className="py-2.5 px-3 font-medium hidden sm:table-cell w-24">Status</th>
-                <th className="py-2.5 px-3 font-medium hidden xl:table-cell w-28">Applied</th>
+                <SortHeader label="Member" sortKey="name" activeKey={sortKey} activeDir={sortDir} onSort={handleSort} className="w-36" />
+                <SortHeader label="Email" sortKey="email" activeKey={sortKey} activeDir={sortDir} onSort={handleSort} />
+                <SortHeader label="School" sortKey="school" activeKey={sortKey} activeDir={sortDir} onSort={handleSort} className="hidden md:table-cell" />
+                <SortHeader label="Cohort" sortKey="cohort" activeKey={sortKey} activeDir={sortDir} onSort={handleSort} className="w-28" />
+                <SortHeader label="Role" sortKey="role" activeKey={sortKey} activeDir={sortDir} onSort={handleSort} className="w-24" />
+                <SortHeader label="Status" sortKey="status" activeKey={sortKey} activeDir={sortDir} onSort={handleSort} className="hidden sm:table-cell w-24" />
+                <SortHeader label="Applied" sortKey="createdAt" activeKey={sortKey} activeDir={sortDir} onSort={handleSort} className="hidden xl:table-cell w-28" />
                 <th className="py-2.5 px-3 font-medium w-40 text-right">Actions</th>
               </tr>
             </thead>
             <tbody>
-              {members.length === 0 ? (
+              {sortedMembers.length === 0 ? (
                 <tr>
                   <td colSpan={8} className="py-16 text-center text-text-hint">
                     No members found.
                   </td>
                 </tr>
-              ) : members.map(member => {
+              ) : sortedMembers.map(member => {
                 const pending = isPendingApplicant(member)
                 const isSelected = selectedId === member.id
                 const isLoading = actionLoadingId === member.id
@@ -80,11 +159,8 @@ export default function MemberTable({
                 return (
                   <tr
                     key={member.id}
-                    onClick={() => isAdmin && !pending && onSelect(member)}
                     className={`border-b border-border transition-colors ${
                       pending ? 'bg-warning/5' : ''
-                    } ${
-                      isAdmin && !pending ? 'cursor-pointer hover:bg-bg-layer1' : ''
                     } ${isSelected ? 'bg-link-bg/40' : ''}`}
                   >
                     <td className="py-2.5 px-3">
@@ -94,17 +170,32 @@ export default function MemberTable({
                           firstName={member.firstName}
                           role={member.role}
                         />
-                        <span className="text-text-primary truncate">
-                          {[member.firstName, member.lastName].filter(Boolean).join(' ') || '—'}
-                        </span>
+                        {isAdmin && !pending ? (
+                          <button
+                            type="button"
+                            onClick={() => onSelect(member)}
+                            className="text-text-primary truncate text-left hover:text-link hover:underline transition-colors"
+                          >
+                            {memberName(member) || '—'}
+                          </button>
+                        ) : (
+                          <span className="text-text-primary truncate">
+                            {memberName(member) || '—'}
+                          </span>
+                        )}
                       </div>
                     </td>
                     <td className="py-2.5 px-3 text-text-secondary truncate max-w-[180px]">{member.email ?? '—'}</td>
                     <td className="py-2.5 px-3 text-text-secondary hidden md:table-cell">{member.school ?? '—'}</td>
-                    <td className="py-2.5 px-3 text-text-secondary hidden lg:table-cell">
+                    <td className="py-2.5 px-3 text-text-secondary">
                       {member.cohort ? cohortLabel(member.cohort) : '—'}
                     </td>
-                    <td className="py-2.5 px-3 text-text-primary">{formatRole(member.role)}</td>
+                    <td className="py-2.5 px-3 text-text-primary">
+                      <span>{formatRole(member.role)}</span>
+                      {member.executiveTitle && (
+                        <span className="block text-xs text-text-hint mt-0.5">{member.executiveTitle}</span>
+                      )}
+                    </td>
                     <td className="py-2.5 px-3 text-text-secondary hidden sm:table-cell">{formatStatus(member.status)}</td>
                     <td className="py-2.5 px-3 text-text-hint hidden xl:table-cell">{formatDate(member.createdAt)}</td>
                     <td className="py-2.5 px-3">

--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -15,15 +15,6 @@ import {
 import MemberTable from './_components/MemberTable'
 import MemberEditPanel from './_components/MemberEditPanel'
 
-function sortMembers(members) {
-  return [...members].sort((a, b) => {
-    const aPending = isPendingApplicant(a)
-    const bPending = isPendingApplicant(b)
-    if (aPending !== bPending) return aPending ? -1 : 1
-    return (a.firstName ?? '').localeCompare(b.firstName ?? '')
-  })
-}
-
 export default function AdminPage() {
   const { profile, accessToken, loading: authLoading } = useAuth()
   const isAdmin = profile?.role === ROLES.ADMIN
@@ -41,7 +32,7 @@ export default function AdminPage() {
     setLoadError('')
     try {
       const data = await fetchAdminMembers(accessToken)
-      setMembers(sortMembers(data))
+      setMembers(data)
     } catch (err) {
       setLoadError(formatRequestError(err))
     } finally {
@@ -69,12 +60,33 @@ export default function AdminPage() {
     })
   }, [members])
 
+  const closeEditor = useCallback(() => {
+    setSelectedMember(null)
+    setSaveError('')
+  }, [])
+
+  useEffect(() => {
+    if (!selectedMember) return undefined
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    function onKeyDown(e) {
+      if (e.key === 'Escape') closeEditor()
+    }
+    window.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      document.body.style.overflow = previous
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [selectedMember, closeEditor])
+
   async function handleApprove(userId) {
     if (!accessToken) return
     setActionLoadingId(userId)
     try {
       const updated = await approveMember(accessToken, userId)
-      setMembers(prev => sortMembers(prev.map(m => (m.id === userId ? updated : m))))
+      setMembers(prev => prev.map(m => (m.id === userId ? updated : m)))
       if (selectedMember?.id === userId) setSelectedMember(null)
     } catch (err) {
       setLoadError(formatRequestError(err))
@@ -88,7 +100,7 @@ export default function AdminPage() {
     setActionLoadingId(userId)
     try {
       await rejectMember(accessToken, userId)
-      setMembers(prev => sortMembers(prev.filter(m => m.id !== userId)))
+      setMembers(prev => prev.filter(m => m.id !== userId))
       if (selectedMember?.id === userId) setSelectedMember(null)
     } catch (err) {
       setLoadError(formatRequestError(err))
@@ -103,9 +115,8 @@ export default function AdminPage() {
     setSaveError('')
     try {
       const updated = await updateAdminMember(accessToken, selectedMember.id, form)
-      setMembers(prev => sortMembers(prev.map(m => (m.id === updated.id ? updated : m))))
-      setSelectedMember(null)
-      setSaveError('')
+      setMembers(prev => prev.map(m => (m.id === updated.id ? updated : m)))
+      closeEditor()
     } catch (err) {
       setSaveError(formatRequestError(err))
     } finally {
@@ -137,34 +148,15 @@ export default function AdminPage() {
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-text-primary" />
             </div>
           ) : (
-            <div className={`grid gap-4 ${isAdmin && selectedMember ? 'lg:grid-cols-5' : 'grid-cols-1'}`}>
-              <div className={isAdmin && selectedMember ? 'lg:col-span-3' : ''}>
-                <MemberTable
-                  members={members}
-                  selectedId={selectedMember?.id}
-                  isAdmin={isAdmin}
-                  actionLoadingId={actionLoadingId}
-                  onSelect={setSelectedMember}
-                  onApprove={handleApprove}
-                  onReject={handleReject}
-                />
-              </div>
-
-              {isAdmin && selectedMember && (
-                <div className="lg:col-span-2">
-                  <MemberEditPanel
-                    member={selectedMember}
-                    saving={saving}
-                    error={saveError}
-                    onSave={handleSave}
-                    onCancel={() => {
-                      setSelectedMember(null)
-                      setSaveError('')
-                    }}
-                  />
-                </div>
-              )}
-            </div>
+            <MemberTable
+              members={members}
+              selectedId={selectedMember?.id}
+              isAdmin={isAdmin}
+              actionLoadingId={actionLoadingId}
+              onSelect={setSelectedMember}
+              onApprove={handleApprove}
+              onReject={handleReject}
+            />
           )}
 
           {!loading && pendingCount === 0 && !isAdmin && (
@@ -173,6 +165,30 @@ export default function AdminPage() {
             </p>
           )}
         </div>
+
+        {isAdmin && selectedMember && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6"
+            onClick={closeEditor}
+            role="presentation"
+          >
+            <div
+              className="w-full max-w-md"
+              onClick={e => e.stopPropagation()}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="edit-member-title"
+            >
+              <MemberEditPanel
+                member={selectedMember}
+                saving={saving}
+                error={saveError}
+                onSave={handleSave}
+                onCancel={closeEditor}
+              />
+            </div>
+          </div>
+        )}
       </main>
     </RoleGuard>
   )

--- a/src/app/api/admin/members/[id]/route.js
+++ b/src/app/api/admin/members/[id]/route.js
@@ -1,8 +1,9 @@
 import { verifyAdminCaller } from '@/lib/adminApi'
-import { SCHOOLS, ROLES } from '@/utils/constants'
+import { syncExecutiveTitle } from '@/lib/syncExecutiveTitle'
+import { SCHOOLS, ROLES, EXECUTIVE_TITLES } from '@/utils/constants'
 import { isValidPhone } from '@/utils/phone'
 
-const EDITABLE_ROLES = [ROLES.MEMBER, ROLES.EXECUTIVE, ROLES.ADMIN]
+const EDITABLE_ROLES = [ROLES.PENDING, ROLES.MEMBER, ROLES.EXECUTIVE, ROLES.ADMIN]
 const EDITABLE_STATUSES = ['student', 'graduate']
 
 const ALLOWED_FIELDS = new Set([
@@ -37,20 +38,33 @@ export async function PATCH(request, { params }) {
     updates[key] = value
   }
 
-  if (Object.keys(updates).length === 0) {
+  const hasTitleField = Object.prototype.hasOwnProperty.call(body, 'executive_title')
+  const requestedTitle = hasTitleField
+    ? (body.executive_title === '' || body.executive_title == null ? null : body.executive_title)
+    : undefined
+
+  if (Object.keys(updates).length === 0 && !hasTitleField) {
     return Response.json({ error: 'No valid fields to update' }, { status: 400 })
   }
 
-  if (updates.first_name !== undefined && !String(updates.first_name).trim()) {
-    return Response.json({ error: 'First name is required' }, { status: 400 })
+  const revertingToPending = updates.role === ROLES.PENDING
+
+  if (!revertingToPending) {
+    if (updates.first_name !== undefined && !String(updates.first_name).trim()) {
+      return Response.json({ error: 'First name is required' }, { status: 400 })
+    }
+
+    if (updates.last_name !== undefined && !String(updates.last_name).trim()) {
+      return Response.json({ error: 'Last name is required' }, { status: 400 })
+    }
   }
 
-  if (updates.last_name !== undefined && !String(updates.last_name).trim()) {
-    return Response.json({ error: 'Last name is required' }, { status: 400 })
-  }
-
-  if (updates.school !== undefined && !SCHOOLS.includes(updates.school)) {
+  if (updates.school !== undefined && updates.school !== '' && !SCHOOLS.includes(updates.school)) {
     return Response.json({ error: 'Invalid school' }, { status: 400 })
+  }
+
+  if (!revertingToPending && updates.school !== undefined && !updates.school) {
+    return Response.json({ error: 'School is required' }, { status: 400 })
   }
 
   if (updates.role !== undefined && !EDITABLE_ROLES.includes(updates.role)) {
@@ -68,25 +82,107 @@ export async function PATCH(request, { params }) {
     return Response.json({ error: 'Phone must match (XXX) XXX-XXXX' }, { status: 400 })
   }
 
+  if (requestedTitle !== undefined && requestedTitle !== null && !EXECUTIVE_TITLES.includes(requestedTitle)) {
+    return Response.json({ error: 'Invalid executive title' }, { status: 400 })
+  }
+
   if (updates.first_name) updates.first_name = String(updates.first_name).trim()
   if (updates.last_name) updates.last_name = String(updates.last_name).trim()
 
-  if (updates.role && updates.role !== ROLES.PENDING) {
+  if (updates.role === ROLES.PENDING) {
+    updates.application_status = 'pending'
+  } else if (updates.role) {
     updates.application_status = 'approved'
   }
 
-  const { serviceClient } = auth
+  const { serviceClient, user } = auth
 
-  const { data, error } = await serviceClient
-    .from('profiles')
-    .update(updates)
-    .eq('id', id)
-    .select('id, first_name, last_name, email, avatar_url, school, cohort, phone, status, role, application_status, created_at')
-    .single()
-
-  if (error) {
-    return Response.json({ error: error.message }, { status: 500 })
+  if (updates.role === ROLES.PENDING && id === user.id) {
+    return Response.json({ error: 'You cannot set your own account to pending' }, { status: 400 })
   }
 
-  return Response.json({ profile: data })
+  const { data: existing, error: existingError } = await serviceClient
+    .from('profiles')
+    .select('id, role, school')
+    .eq('id', id)
+    .single()
+
+  if (existingError || !existing) {
+    return Response.json({ error: 'Member not found' }, { status: 404 })
+  }
+
+  let profile = existing
+
+  if (Object.keys(updates).length > 0) {
+    const { data, error } = await serviceClient
+      .from('profiles')
+      .update(updates)
+      .eq('id', id)
+      .select('id, first_name, last_name, email, avatar_url, school, cohort, phone, status, role, application_status, created_at')
+      .single()
+
+    if (error) {
+      return Response.json({ error: error.message }, { status: 500 })
+    }
+    profile = data
+  } else {
+    const { data, error } = await serviceClient
+      .from('profiles')
+      .select('id, first_name, last_name, email, avatar_url, school, cohort, phone, status, role, application_status, created_at')
+      .eq('id', id)
+      .single()
+
+    if (error) {
+      return Response.json({ error: error.message }, { status: 500 })
+    }
+    profile = data
+  }
+
+  let executiveTitle = null
+
+  if (hasTitleField || updates.role !== undefined || updates.school !== undefined) {
+    const nextRole = profile.role
+    const nextSchool = profile.school
+    let nextTitle = requestedTitle
+
+    if (!hasTitleField) {
+      const { data: activeRole, error: activeRoleError } = await serviceClient
+        .from('executive_roles')
+        .select('title')
+        .eq('user_id', id)
+        .is('end_date', null)
+        .maybeSingle()
+
+      if (activeRoleError) {
+        return Response.json({ error: activeRoleError.message }, { status: 500 })
+      }
+      nextTitle = activeRole?.title ?? null
+    }
+
+    try {
+      executiveTitle = await syncExecutiveTitle(serviceClient, {
+        userId: id,
+        role: nextRole,
+        school: nextSchool,
+        title: nextTitle,
+      })
+    } catch (err) {
+      return Response.json({ error: err.message }, { status: 400 })
+    }
+  } else {
+    const { data: activeRole } = await serviceClient
+      .from('executive_roles')
+      .select('title')
+      .eq('user_id', id)
+      .is('end_date', null)
+      .maybeSingle()
+    executiveTitle = activeRole?.title ?? null
+  }
+
+  return Response.json({
+    profile: {
+      ...profile,
+      executive_title: executiveTitle,
+    },
+  })
 }

--- a/src/app/api/admin/members/route.js
+++ b/src/app/api/admin/members/route.js
@@ -16,7 +16,25 @@ export async function GET(request) {
     return Response.json({ error: error.message }, { status: 500 })
   }
 
-  const sorted = [...(data ?? [])].sort((a, b) => {
+  const { data: activeRoles, error: rolesError } = await serviceClient
+    .from('executive_roles')
+    .select('user_id, title')
+    .is('end_date', null)
+
+  if (rolesError) {
+    return Response.json({ error: rolesError.message }, { status: 500 })
+  }
+
+  const titleByUserId = Object.fromEntries(
+    (activeRoles ?? []).map((row) => [row.user_id, row.title])
+  )
+
+  const members = (data ?? []).map((row) => ({
+    ...row,
+    executive_title: titleByUserId[row.id] ?? null,
+  }))
+
+  const sorted = [...members].sort((a, b) => {
     const aPending = a.role === 'pending' && a.application_status === 'pending'
     const bPending = b.role === 'pending' && b.application_status === 'pending'
     if (aPending !== bPending) return aPending ? -1 : 1

--- a/src/app/members/page.js
+++ b/src/app/members/page.js
@@ -4,7 +4,76 @@ import MemberCard from '@/components/members/MemberCard'
 import { useEffect, useState, useMemo } from 'react'
 import { fetchMembers } from '@/services/membersService'
 import { cohortLabel } from '@/utils/cohort'
+import { compareNumberLike, compareText } from '@/utils/memberSort'
 
+const SORT_OPTIONS = [
+  { value: 'name-asc', label: 'Name(↑)' },
+  { value: 'name-desc', label: 'Name(↓)' },
+  { value: 'school-asc', label: 'School(↑)' },
+  { value: 'school-desc', label: 'School(↓)' },
+  { value: 'cohort-asc', label: 'Cohort(↑)' },
+  { value: 'cohort-desc', label: 'Cohort(↓)' },
+  { value: 'company-asc', label: 'Company(↑)' },
+  { value: 'company-desc', label: 'Company(↓)' },
+  { value: 'role-asc', label: 'Role(↑)' },
+  { value: 'role-desc', label: 'Role(↓)' },
+]
+
+function memberName(member) {
+  return [member.firstName, member.lastName].filter(Boolean).join(' ')
+}
+
+function formatRole(role) {
+  if (role === 'executive' || role === 'admin') return 'Executive'
+  return 'Member'
+}
+
+function hasCompany(member) {
+  return Boolean(member.company?.trim())
+}
+
+function matchesStatus(memberStatus, filter) {
+  if (!filter) return true
+  if (filter === 'student') return memberStatus === 'student'
+  return memberStatus === 'graduate' || memberStatus === 'graduated'
+}
+
+function compareBySort(a, b, sortValue) {
+  const [key, dir] = sortValue.split('-')
+
+  if (key === 'company') {
+    const aHas = hasCompany(a)
+    const bHas = hasCompany(b)
+    if (aHas !== bHas) return aHas ? -1 : 1
+    if (!aHas) return compareText(memberName(a), memberName(b))
+    const companyCmp = compareText(a.company, b.company)
+    if (companyCmp !== 0) return dir === 'asc' ? companyCmp : -companyCmp
+    return compareText(memberName(a), memberName(b))
+  }
+
+  let result = 0
+  switch (key) {
+    case 'school':
+      result = compareText(a.school, b.school)
+      break
+    case 'cohort':
+      result = compareNumberLike(a.cohort, b.cohort)
+      break
+    case 'role':
+      result = compareText(formatRole(a.role), formatRole(b.role))
+      break
+    case 'name':
+    default:
+      result = compareText(memberName(a), memberName(b))
+      break
+  }
+
+  if (result === 0 && key !== 'name') {
+    result = compareText(memberName(a), memberName(b))
+  }
+
+  return dir === 'asc' ? result : -result
+}
 
 export default function MembersPage() {
   const [members, setMembers] = useState([])
@@ -14,6 +83,8 @@ export default function MembersPage() {
   const [school, setSchool] = useState('')
   const [status, setStatus] = useState('')
   const [role, setRole] = useState('')
+  const [company, setCompany] = useState('')
+  const [sort, setSort] = useState('name-asc')
 
   useEffect(() => {
     let cancelled = false
@@ -36,22 +107,37 @@ export default function MembersPage() {
     return nums.sort((a, b) => Number(a) - Number(b))
   }, [members])
 
-  const filteredMembers = members.filter((m) => {
-    if (cohort && m.cohort !== cohort) return false
-    if (school && m.school !== school) return false
-    if (status && m.status !== status) return false
-    if (role) {
-      const isExec = m.role === 'executive' || m.role === 'admin'
-      if (role === 'executive' && !isExec) return false
-      if (role === 'member' && m.role !== 'member') return false
-    }
-    return true
-  })
+  const companyOptions = useMemo(() => {
+    const names = [...new Set(members.map(m => m.company?.trim()).filter(Boolean))]
+    return names.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+  }, [members])
+
+  const filteredMembers = useMemo(() => {
+    const filtered = members.filter((m) => {
+      if (cohort && m.cohort !== cohort) return false
+      if (school && m.school !== school) return false
+      if (!matchesStatus(m.status, status)) return false
+      if (role) {
+        const isExec = m.role === 'executive' || m.role === 'admin'
+        if (role === 'executive' && !isExec) return false
+        if (role === 'member' && m.role !== 'member') return false
+      }
+      if (company === '__none__') {
+        if (hasCompany(m)) return false
+      } else if (company && m.company?.trim() !== company) {
+        return false
+      }
+      return true
+    })
+
+    return [...filtered].sort((a, b) => compareBySort(a, b, sort))
+  }, [members, cohort, school, status, role, company, sort])
+
+  const selectClass = 'border border-border-strong rounded-md px-3 py-2 text-sm text-text-primary bg-bg-base focus:outline-none focus:ring-2 focus:ring-border'
 
   return (
     <RoleGuard>
       <main className="min-h-screen">
-        {/*HEADER SECTION*/}
         <section className="bg-bg-base py-8 px-6">
           <div className="max-w-6xl mx-auto">
             <h1 className="font-montserrat text-4xl font-bold text-text-primary">
@@ -63,45 +149,53 @@ export default function MembersPage() {
           </div>
         </section>
 
-        {/*FILTER ROW*/}
         <section className="bg-bg-base border-b border-border py-4 px-6">
           <div className="max-w-6xl mx-auto flex flex-row gap-3 flex-wrap">
-            <select className="border border-border-strong rounded-md px-3 py-2 text-sm text-text-primary bg-bg-base focus:outline-none focus:ring-2 focus:ring-border"
-            value={cohort} onChange={(e) => setCohort(e.target.value)}>
+            <select className={selectClass} value={cohort} onChange={(e) => setCohort(e.target.value)}>
               <option value="">All Cohorts</option>
               {cohortOptions.map(n => (
                 <option key={n} value={n}>{cohortLabel(n)}</option>
               ))}
             </select>
 
-            <select className="border border-border-strong rounded-md px-3 py-2 text-sm text-text-primary bg-bg-base focus:outline-none focus:ring-2 focus:ring-border"
-            value={school} onChange={(e) => setSchool(e.target.value)}>
+            <select className={selectClass} value={school} onChange={(e) => setSchool(e.target.value)}>
               <option value="">All Schools</option>
               <option value="Seneca College">Seneca College</option>
               <option value="York University">York University</option>
             </select>
 
-            <select className="border border-border-strong rounded-md px-3 py-2 text-sm text-text-primary bg-bg-base focus:outline-none focus:ring-2 focus:ring-border"
-            value={status} onChange={(e) => setStatus(e.target.value)}>
+            <select className={selectClass} value={status} onChange={(e) => setStatus(e.target.value)}>
               <option value="">All Status</option>
               <option value="student">Student</option>
-              <option value="graduated">Graduate</option>
+              <option value="graduate">Graduate</option>
             </select>
 
-            <select className="border border-border-strong rounded-md px-3 py-2 text-sm text-text-primary bg-bg-base focus:outline-none focus:ring-2 focus:ring-border"
-            value={role} onChange={(e) => setRole(e.target.value)}>
+            <select className={selectClass} value={role} onChange={(e) => setRole(e.target.value)}>
               <option value="">All Roles</option>
               <option value="member">Member</option>
               <option value="executive">Executive</option>
             </select>
+
+            <select className={selectClass} value={company} onChange={(e) => setCompany(e.target.value)}>
+              <option value="">All Companies</option>
+              <option value="__none__">No company</option>
+              {companyOptions.map(name => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+
+            <select className={selectClass} value={sort} onChange={(e) => setSort(e.target.value)} aria-label="Sort members">
+              {SORT_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
           </div>
         </section>
 
-        {/*MEMBER GRID*/}
         <section className="bg-bg-base py-8 px-6">
           <div className="max-w-6xl mx-auto">
             {loading && <p className="text-text-secondary">Loading members…</p>}
-            {error && <p className="text-accent">Couldn't load members. Try refreshing.</p>}
+            {error && <p className="text-accent">Couldn&apos;t load members. Try refreshing.</p>}
 
             {!loading && !error && filteredMembers.length === 0 && (
               <p className="text-text-secondary">No members yet.</p>

--- a/src/lib/syncExecutiveTitle.js
+++ b/src/lib/syncExecutiveTitle.js
@@ -1,0 +1,86 @@
+import { EXECUTIVE_TITLES, ROLES } from '@/utils/constants'
+
+function todayDate() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function canHoldTitle(role) {
+  return role === ROLES.EXECUTIVE || role === ROLES.ADMIN
+}
+
+/**
+ * Keep executive_roles in sync with an admin member edit.
+ * - One active title per user
+ * - One active holder per (title, school)
+ * - Assigning a taken seat ends the previous holder's term
+ */
+export async function syncExecutiveTitle(serviceClient, { userId, role, school, title }) {
+  const nextTitle = canHoldTitle(role) && title ? title : null
+
+  if (nextTitle && !EXECUTIVE_TITLES.includes(nextTitle)) {
+    throw new Error('Invalid executive title')
+  }
+
+  if (nextTitle && !school) {
+    throw new Error('School is required to assign an executive title')
+  }
+
+  const today = todayDate()
+
+  const { data: userRoles, error: userRolesError } = await serviceClient
+    .from('executive_roles')
+    .select('id, title, school')
+    .eq('user_id', userId)
+    .is('end_date', null)
+
+  if (userRolesError) throw new Error(userRolesError.message)
+
+  const current = userRoles?.[0] ?? null
+
+  if (!nextTitle) {
+    if (userRoles?.length) {
+      const { error } = await serviceClient
+        .from('executive_roles')
+        .update({ end_date: today })
+        .eq('user_id', userId)
+        .is('end_date', null)
+      if (error) throw new Error(error.message)
+    }
+    return null
+  }
+
+  if (current && current.title === nextTitle && current.school === school) {
+    return nextTitle
+  }
+
+  if (userRoles?.length) {
+    const { error } = await serviceClient
+      .from('executive_roles')
+      .update({ end_date: today })
+      .eq('user_id', userId)
+      .is('end_date', null)
+    if (error) throw new Error(error.message)
+  }
+
+  const { error: vacateError } = await serviceClient
+    .from('executive_roles')
+    .update({ end_date: today })
+    .eq('title', nextTitle)
+    .eq('school', school)
+    .is('end_date', null)
+
+  if (vacateError) throw new Error(vacateError.message)
+
+  const { error: insertError } = await serviceClient
+    .from('executive_roles')
+    .insert({
+      user_id: userId,
+      title: nextTitle,
+      school,
+      start_date: today,
+    })
+
+  if (insertError) throw new Error(insertError.message)
+
+  return nextTitle
+}

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -39,6 +39,7 @@ function mapMember(row) {
     role: row.role,
     applicationStatus: row.application_status,
     createdAt: row.created_at,
+    executiveTitle: row.executive_title ?? null,
   }
 }
 
@@ -84,5 +85,6 @@ export function memberToForm(member) {
     role: member.role ?? 'member',
     status,
     phone: member.phone ?? '',
+    executive_title: member.executiveTitle ?? '',
   }
 }

--- a/src/services/executiveService.js
+++ b/src/services/executiveService.js
@@ -30,6 +30,7 @@ export async function getCurrentExecutives() {
   return (data ?? []).map((row) => ({
     id: row.id,
     title: row.title,
+    // Campus seat comes from executive_roles.school (not profile.school)
     school: row.school,
     startDate: row.start_date,
     term: row.term,
@@ -38,7 +39,6 @@ export async function getCurrentExecutives() {
     lastName: row.profiles?.last_name,
     nickname: row.profiles?.nickname,
     avatarUrl: row.profiles?.avatar_url,
-    school: row.profiles?.school,
     linkedinUrl: row.profiles?.linkedin,
     githubUrl: row.profiles?.github,
   }))

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,5 +1,7 @@
 export const SCHOOLS = ['Seneca College', 'York University']
 
+export const EXECUTIVE_TITLES = ['President', 'Vice President', 'Treasurer']
+
 export const ROLES = {
   PENDING: 'pending',
   MEMBER: 'member',

--- a/src/utils/memberSort.js
+++ b/src/utils/memberSort.js
@@ -1,0 +1,22 @@
+export function compareText(a, b) {
+  return String(a ?? '').localeCompare(String(b ?? ''), undefined, { sensitivity: 'base' })
+}
+
+export function compareNumberLike(a, b) {
+  const na = Number(a)
+  const nb = Number(b)
+  if (!Number.isNaN(na) && !Number.isNaN(nb)) return na - nb
+  return compareText(a, b)
+}
+
+export function toggleSort(currentKey, currentDir, nextKey) {
+  if (currentKey === nextKey) {
+    return { key: nextKey, dir: currentDir === 'asc' ? 'desc' : 'asc' }
+  }
+  return { key: nextKey, dir: 'asc' }
+}
+
+export function sortIndicator(activeKey, activeDir, key) {
+  if (activeKey !== key) return ''
+  return activeDir === 'asc' ? '(↑)' : '(↓)'
+}


### PR DESCRIPTION
## Summary
- Let admins assign Our Team positions (President / Vice President / Treasurer) from the member edit modal; syncs `executive_roles` and clears titles when demoting to pending
- Fix About → Our Team campus seat mapping to use `executive_roles.school`
- Admin list: always show Cohort, clickable column sort as `Name(↑)`, open Edit member in a modal by clicking the name, allow reverting members to Pending without filling required profile fields
- Members page: simple filter row with Company filter and sort options like `Name(↑)` / `Company(↓)` (companies with values first)

## Test plan
- [ ] Admin: open a member by name → edit modal appears (not a bottom side panel)
- [ ] Admin: set Kai (or another exec) to Executive + Vice President → appears in About → Our Team for their school
- [ ] Admin: set Role to Pending with empty name/school/cohort → Save succeeds; member returns to approval queue
- [ ] Admin: cannot set own account to Pending
- [ ] Admin: click column headers to sort; Cohort column is visible
- [ ] Members: filter by Company; sort by Company(↑)/(↓) puts filled companies first
- [ ] Members: filter UI stays a simple select row