### PR TITLE
fix: block profile privilege escalation on self-update (#165)

### DIFF
--- a/docs/schema/tables/profiles.sql
+++ b/docs/schema/tables/profiles.sql
@@ -36,3 +36,69 @@ CREATE TRIGGER set_profiles_updated_at
     BEFORE UPDATE ON public.profiles
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
+
+-- Blocks non-admins from changing role / application_status, and from
+-- changing name / email / cohort / avatar once set. Empty → filled is
+-- allowed for JoinModal onboarding. See migration
+-- 20260722160000_protect_profiles_admin_columns.sql
+CREATE OR REPLACE FUNCTION public.protect_profiles_admin_columns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  jwt_role text := coalesce(auth.jwt() ->> 'role', '');
+  caller_role public.member_role;
+BEGIN
+  IF jwt_role = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  caller_role := public.get_my_role();
+
+  IF caller_role = 'admin'::public.member_role THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.role IS DISTINCT FROM OLD.role THEN
+    RAISE EXCEPTION 'Cannot change role' USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.application_status IS DISTINCT FROM OLD.application_status THEN
+    RAISE EXCEPTION 'Cannot change application_status' USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.first_name IS DISTINCT FROM OLD.first_name
+     AND OLD.first_name IS NOT NULL AND btrim(OLD.first_name) <> '' THEN
+    RAISE EXCEPTION 'Cannot change first_name' USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.last_name IS DISTINCT FROM OLD.last_name
+     AND OLD.last_name IS NOT NULL AND btrim(OLD.last_name) <> '' THEN
+    RAISE EXCEPTION 'Cannot change last_name' USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.email IS DISTINCT FROM OLD.email
+     AND OLD.email IS NOT NULL AND btrim(OLD.email) <> '' THEN
+    RAISE EXCEPTION 'Cannot change email' USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.cohort IS DISTINCT FROM OLD.cohort
+     AND OLD.cohort IS NOT NULL AND btrim(OLD.cohort) <> '' THEN
+    RAISE EXCEPTION 'Cannot change cohort' USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.avatar_url IS DISTINCT FROM OLD.avatar_url
+     AND OLD.avatar_url IS NOT NULL AND btrim(OLD.avatar_url) <> '' THEN
+    RAISE EXCEPTION 'Cannot change avatar_url' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER protect_profiles_admin_columns
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.protect_profiles_admin_columns();

--- a/docs/schema/tables/rls_policies.sql
+++ b/docs/schema/tables/rls_policies.sql
@@ -63,6 +63,11 @@ WITH CHECK (
   auth.uid() = id
 );
 
+-- Column-level protection for self-updates is enforced by the
+-- protect_profiles_admin_columns BEFORE UPDATE trigger on profiles
+-- (see docs/schema/tables/profiles.sql and migration
+-- 20260722160000_protect_profiles_admin_columns.sql).
+
 CREATE POLICY problems_select_member_plus
 ON public.problems
 FOR SELECT

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -35,6 +35,9 @@ export async function fetchProfile(userId) {
 }
 
 export async function createProfile({ id, first_name, last_name, nickname, email, avatarUrl, school, cohort, phone, status, company, occupation, linkedin, github }) {
+  // JoinModal onboarding: fills empty identity fields. DB trigger
+  // protect_profiles_admin_columns blocks changes once those fields are set,
+  // and always blocks role / application_status for non-admins.
   const request = supabase
     .from('profiles')
     .update({

--- a/src/services/membersService.js
+++ b/src/services/membersService.js
@@ -45,6 +45,8 @@ export async function fetchMemberById(id) {
 }
 
 export async function updateMyProfile({ nickname, bio, linkedin, github, status, profile_visibility, company, occupation, phone, school }) {
+  // Only user-editable fields. role / name / email / cohort / avatar are
+  // protected by protect_profiles_admin_columns (DB trigger).
   const { data: { user } } = await supabase.auth.getUser()
   const { error } = await supabase
     .from('profiles')

--- a/supabase/migrations/20260722160000_protect_profiles_admin_columns.sql
+++ b/supabase/migrations/20260722160000_protect_profiles_admin_columns.sql
@@ -1,0 +1,82 @@
+-- Prevent privilege escalation via client-side profiles updates.
+-- Non-admins cannot change role / application_status, and cannot change
+-- identity fields (name, email, cohort, avatar) once they are already set.
+-- Empty → filled is allowed so JoinModal onboarding still works.
+-- Admins (JWT role) and the service_role key (Admin API) can update anything.
+
+CREATE OR REPLACE FUNCTION public.protect_profiles_admin_columns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  jwt_role text := coalesce(auth.jwt() ->> 'role', '');
+  caller_role public.member_role;
+BEGIN
+  -- Admin API uses the service role key (bypasses RLS, not triggers)
+  IF jwt_role = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  caller_role := public.get_my_role();
+
+  IF caller_role = 'admin'::public.member_role THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.role IS DISTINCT FROM OLD.role THEN
+    RAISE EXCEPTION 'Cannot change role'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.application_status IS DISTINCT FROM OLD.application_status THEN
+    RAISE EXCEPTION 'Cannot change application_status'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.first_name IS DISTINCT FROM OLD.first_name
+     AND OLD.first_name IS NOT NULL
+     AND btrim(OLD.first_name) <> '' THEN
+    RAISE EXCEPTION 'Cannot change first_name'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.last_name IS DISTINCT FROM OLD.last_name
+     AND OLD.last_name IS NOT NULL
+     AND btrim(OLD.last_name) <> '' THEN
+    RAISE EXCEPTION 'Cannot change last_name'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.email IS DISTINCT FROM OLD.email
+     AND OLD.email IS NOT NULL
+     AND btrim(OLD.email) <> '' THEN
+    RAISE EXCEPTION 'Cannot change email'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.cohort IS DISTINCT FROM OLD.cohort
+     AND OLD.cohort IS NOT NULL
+     AND btrim(OLD.cohort) <> '' THEN
+    RAISE EXCEPTION 'Cannot change cohort'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.avatar_url IS DISTINCT FROM OLD.avatar_url
+     AND OLD.avatar_url IS NOT NULL
+     AND btrim(OLD.avatar_url) <> '' THEN
+    RAISE EXCEPTION 'Cannot change avatar_url'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS protect_profiles_admin_columns ON public.profiles;
+
+CREATE TRIGGER protect_profiles_admin_columns
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.protect_profiles_admin_columns();


### PR DESCRIPTION
## Summary
- Add a `BEFORE UPDATE` trigger on `profiles` so non-admins cannot change `role` / `application_status`, or rewrite identity fields once set (`first_name`, `last_name`, `email`, `cohort`, `avatar_url`)
- Allow empty → filled updates so JoinModal onboarding still works
- Admin JWT and `service_role` (Admin API) can still update any column
- Migration applied to remote Supabase via `supabase db push`

Closes #165

## Test plan
- [ ] As a member, profile edit (`updateMyProfile`) for bio/nickname/etc. still succeeds
- [ ] As a pending user, JoinModal can fill name/school/cohort when those fields are empty
- [ ] Direct client update `role: 'admin'` on own profile is rejected
- [ ] Admin member edit via `/api/admin/members/:id` still changes role successfully