### PR TITLE
fix: keep homepage hero at a fixed aspect ratio with gutters (#137)

### DIFF
--- a/docs/design/page-specs/home.md
+++ b/docs/design/page-specs/home.md
@@ -17,11 +17,12 @@
 - Accent `#C0392B` used ONLY on: [Join Us →] primary button. Nowhere else.
 - Do NOT add animations, parallax, scroll effects, hero text overlay on the photo, or decorative illustrations.
 - Do NOT add a carousel, news ticker, or any auto-rotating element.
-- The group photo is a full-width image with NO text on top of it. It is purely a photo.
+- The group photo sits in the page content column (`max-w-6xl` + horizontal padding), uses a fixed `16/7` aspect ratio, and scales without changing crop. Do NOT use viewport-height-based hero sizing (`50vh` / `70vh`) — that crops differently per screen.
+- The group photo has NO text on top of it. It is purely a photo.
 - The Elfsight social feed is a single embedded widget block — render as a gray placeholder box labeled "Elfsight Social Feed (Instagram + LinkedIn)" centered, width 100%, height 300px.
 - The two CTA buttons are side by side: [Join Us →] on the LEFT (primary red), [About Us →] on the RIGHT (secondary outline). Do NOT swap order.
 - [Log In] button in navbar: Secondary outline style — border 1px `#CCCCCC`, text `#555555`, radius 6px. Do NOT make it red.
-- Mobile: group photo height reduces to 280px. Elfsight feed stacks full width. CTA buttons stack vertically (Join Us on top).
+- Mobile: hero keeps the same `16/7` aspect ratio (height scales with width). Elfsight feed stacks full width. CTA buttons stack vertically (Join Us on top).
 - Navbar collapses to hamburger icon on mobile (≤768px). Social icons move to bottom of mobile menu.
 - Navbar has EXACTLY these items in this order (left to right):
   LEFT SIDE: [codeXperts logo] · Home · About▾ · Updates▾ · Events · (Practice▾) · (Members) · Join Us · {⚙}
@@ -82,9 +83,9 @@ RIGHT SIDE (icons + auth):
 │ NAVBAR                                    [Log In]  │
 ├─────────────────────────────────────────────────────┤
 │                                                     │
-│  [Full-width club group photo]                      │
-│   width: 100%, height: ~500px, object-fit: cover    │
-│                                                     │
+│  [Club group photo — max-w-6xl, gutters, aspect 16/7]│
+│   object-fit: cover, object-position: center          │
+│   (same crop on all breakpoints)                      │
 ├─────────────────────────────────────────────────────┤
 │                                                     │
 │  ELFSIGHT SOCIAL FEED                               │

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -31,17 +31,21 @@ export default function HomePage() {
   return (
     <main className="min-h-screen bg-bg-base">
 
-      {/* Hero — full width, no padding */}
-      <section className="relative">
-        <Image
-          src={src}
-          alt="group photo of codeXperts"
-          width={1920}
-          height={1080}
-          className="object-cover object-[0%_60%] w-full h-[50vh] md:h-[70vh]"
-          priority
-        />
-        <HeroImageEditor onUpdate={setHeroUrl} />
+      {/* Hero — fixed aspect ratio with page gutters so crop stays consistent */}
+      <section className="w-full bg-bg-base pt-4 md:pt-6">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6">
+          <div className="relative w-full aspect-[16/7] overflow-hidden bg-bg-layer1">
+            <Image
+              src={src}
+              alt="group photo of codeXperts"
+              fill
+              sizes="(max-width: 1152px) 100vw, 1152px"
+              className="object-cover object-center"
+              priority
+            />
+            <HeroImageEditor onUpdate={setHeroUrl} />
+          </div>
+        </div>
       </section>
 
       {/* Social Feed — full width bg-bg-base, inner container matches footer */}

--- a/src/components/home/HeroImageEditor.js
+++ b/src/components/home/HeroImageEditor.js
@@ -7,9 +7,7 @@ import { canAccessAdminRoutes } from '@/utils/constants'
 import { uploadImage } from '@/services/cloudinaryService'
 import { supabase } from '@/lib/supabase'
 import { IconEdit } from '@/components/ui/Icons'
-
-// Hero aspect ratio: matches w-full h-[70vh] on desktop
-const HERO_ASPECT = 16 / 7
+import { HERO_ASPECT } from '@/lib/heroImage'
 
 async function getCroppedBlob(imageSrc, pixelCrop) {
   const res = await fetch(imageSrc)

--- a/src/lib/heroImage.js
+++ b/src/lib/heroImage.js
@@ -1,0 +1,2 @@
+// Shared hero crop/display ratio. Keep cropper and homepage in sync.
+export const HERO_ASPECT = 16 / 7


### PR DESCRIPTION
## Summary
- Replace viewport-height hero sizing (`50vh` / `70vh`) with a fixed `16/7` aspect box so the crop stays consistent across screen sizes
- Add page gutters (`max-w-6xl` + horizontal padding) around the hero to match other home sections
- Share the crop/display ratio via `src/lib/heroImage.js` so the editor and homepage stay aligned

Related to #137

## Test plan
- [ ] Homepage hero keeps the same crop when resizing from desktop to mobile
- [ ] Left/right gutters match the Social Feed / Who We Are content width
- [ ] Exec/admin hero edit crop preview still matches the displayed ratio
- [ ] Fallback `/hero.jpg` and Cloudinary hero URLs both render correctly