### PR TITLE
fix: guard announcement mutations and surface errors (#168)

### DIFF
--- a/src/app/announcements/[id]/page.js
+++ b/src/app/announcements/[id]/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { canAccessAdminRoutes } from '@/utils/constants'
+import { formatRequestError } from '@/utils/requestErrors'
 import {
   fetchAnnouncements,
   createAnnouncement,
@@ -24,6 +25,8 @@ export default function AnnouncementPostPage() {
   const [editMode, setEditMode] = useState(false)
   const [form, setForm] = useState({ title: '', content: '' })
   const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState('')
+  const [actionError, setActionError] = useState('')
 
   useEffect(() => {
     fetchAnnouncements()
@@ -35,18 +38,42 @@ export default function AnnouncementPostPage() {
   const idx = announcements.findIndex(a => a.id === numId)
   const post = idx !== -1 ? announcements[idx] : null
 
-  function openNew() { setEditMode(false); setForm({ title: '', content: '' }); setShowForm(true) }
-  function openEdit() { setEditMode(true); setForm({ title: post.title, content: post.content }); setShowForm(true) }
-  function cancelForm() { setShowForm(false); setEditMode(false); setForm({ title: '', content: '' }) }
+  function openNew() {
+    setEditMode(false)
+    setForm({ title: '', content: '' })
+    setFormError('')
+    setActionError('')
+    setShowForm(true)
+  }
+  function openEdit() {
+    setEditMode(true)
+    setForm({ title: post.title, content: post.content })
+    setFormError('')
+    setActionError('')
+    setShowForm(true)
+  }
+  function cancelForm() {
+    setShowForm(false)
+    setEditMode(false)
+    setForm({ title: '', content: '' })
+    setFormError('')
+  }
 
   async function handlePublish() {
     if (!form.title.trim()) return
+    if (!user || !isAdmin) {
+      setFormError('You do not have permission to do that.')
+      return
+    }
     setSubmitting(true)
+    setFormError('')
     try {
       const created = await createAnnouncement(form.title.trim(), form.content, user.id)
       setAnnouncements(prev => [created, ...prev])
       cancelForm()
       router.push(`/announcements/${created.id}`)
+    } catch (err) {
+      setFormError(formatRequestError(err))
     } finally {
       setSubmitting(false)
     }
@@ -54,24 +81,41 @@ export default function AnnouncementPostPage() {
 
   async function handleUpdate() {
     if (!form.title.trim()) return
+    if (!user || !isAdmin) {
+      setFormError('You do not have permission to do that.')
+      return
+    }
     setSubmitting(true)
+    setFormError('')
     try {
       const updated = await updateAnnouncement(numId, form.title.trim(), form.content)
       setAnnouncements(prev => prev.map(a => a.id === numId ? updated : a))
       cancelForm()
+    } catch (err) {
+      setFormError(formatRequestError(err))
     } finally {
       setSubmitting(false)
     }
   }
 
   async function handleDelete() {
-    await deleteAnnouncement(numId)
-    const remaining = announcements.filter(a => a.id !== numId)
-    setAnnouncements(remaining)
-    if (remaining.length > 0) {
-      router.push(`/announcements/${remaining[0].id}`)
-    } else {
-      router.push('/announcements')
+    if (!user || !isAdmin) {
+      setActionError('You do not have permission to do that.')
+      throw new Error('Forbidden')
+    }
+    setActionError('')
+    try {
+      await deleteAnnouncement(numId)
+      const remaining = announcements.filter(a => a.id !== numId)
+      setAnnouncements(remaining)
+      if (remaining.length > 0) {
+        router.push(`/announcements/${remaining[0].id}`)
+      } else {
+        router.push('/announcements')
+      }
+    } catch (err) {
+      setActionError(formatRequestError(err))
+      throw err
     }
   }
 
@@ -111,6 +155,14 @@ export default function AnnouncementPostPage() {
     <main className="min-h-screen bg-white">
       <PageHeader isAdmin={isAdmin} onNew={openNew} />
 
+      {actionError && !showForm && (
+        <div className="bg-white px-4 sm:px-6 pt-4">
+          <div className="max-w-[800px] mx-auto">
+            <p className="text-sm text-error font-inter">{actionError}</p>
+          </div>
+        </div>
+      )}
+
       {showForm && (
         <div className="bg-white py-8 px-4 sm:px-6">
           <div className="max-w-[800px] mx-auto">
@@ -121,6 +173,7 @@ export default function AnnouncementPostPage() {
               onCancel={cancelForm}
               submitting={submitting}
               editMode={editMode}
+              error={formError}
             />
           </div>
         </div>

--- a/src/app/announcements/_shared.js
+++ b/src/app/announcements/_shared.js
@@ -98,7 +98,7 @@ function EditorTabs({ activeTab, onTabChange }) {
   )
 }
 
-export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editMode = false }) {
+export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editMode = false, error = '' }) {
   const [tab, setTab] = useState('Write')
 
   return (
@@ -131,6 +131,10 @@ export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editM
           </div>
         )}
       </div>
+
+      {error && (
+        <p className="text-sm text-error font-inter">{error}</p>
+      )}
 
       <div className="flex gap-3 justify-end">
         <button
@@ -201,9 +205,14 @@ export function NavRow({ onPrev, onNext, onList, onDelete, onEdit, prevDisabled,
 
   async function handleDelete() {
     setDeleting(true)
-    await onDelete()
-    setDeleting(false)
-    setShowDeleteModal(false)
+    try {
+      await onDelete()
+      setShowDeleteModal(false)
+    } catch {
+      // Parent surfaces the error message
+    } finally {
+      setDeleting(false)
+    }
   }
 
   const btnBase = 'px-4 py-2 border rounded-md text-sm font-inter transition-colors'

--- a/src/app/announcements/page.js
+++ b/src/app/announcements/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { canAccessAdminRoutes } from '@/utils/constants'
+import { formatRequestError } from '@/utils/requestErrors'
 import {
   fetchAnnouncements,
   createAnnouncement,
@@ -14,7 +15,19 @@ import { formatDate, PageHeader, PostContent, NavRow, PostForm } from './_shared
 
 const ITEMS_PER_PAGE = 20
 
-function ListView({ announcements, isAdmin, onNew, showForm, form, onFormChange, onPublish, onCancelForm, publishing }) {
+function ListView({
+  announcements,
+  isAdmin,
+  onNew,
+  showForm,
+  form,
+  onFormChange,
+  onPublish,
+  onCancelForm,
+  publishing,
+  formError,
+  actionError,
+}) {
   const router = useRouter()
   const [page, setPage] = useState(1)
   const totalPages = Math.ceil(announcements.length / ITEMS_PER_PAGE)
@@ -25,6 +38,14 @@ function ListView({ announcements, isAdmin, onNew, showForm, form, onFormChange,
     <>
       <PageHeader isAdmin={isAdmin} onNew={onNew} />
 
+      {actionError && !showForm && (
+        <div className="bg-white px-4 sm:px-6 pt-4">
+          <div className="max-w-[800px] mx-auto">
+            <p className="text-sm text-error font-inter">{actionError}</p>
+          </div>
+        </div>
+      )}
+
       {showForm && (
         <div className="bg-white py-8 px-4 sm:px-6">
           <div className="max-w-[800px] mx-auto">
@@ -34,6 +55,7 @@ function ListView({ announcements, isAdmin, onNew, showForm, form, onFormChange,
               onSubmit={onPublish}
               onCancel={onCancelForm}
               submitting={publishing}
+              error={formError}
             />
           </div>
         </div>
@@ -112,6 +134,8 @@ function AnnouncementsContent() {
   const [editMode, setEditMode] = useState(false)
   const [form, setForm] = useState({ title: '', content: '' })
   const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState('')
+  const [actionError, setActionError] = useState('')
 
   const view = searchParams.get('view')
 
@@ -121,18 +145,42 @@ function AnnouncementsContent() {
       .finally(() => setLoading(false))
   }, [])
 
-  function openNew() { setEditMode(false); setForm({ title: '', content: '' }); setShowForm(true) }
-  function openEdit(post) { setEditMode(true); setForm({ title: post.title, content: post.content }); setShowForm(true) }
-  function cancelForm() { setShowForm(false); setEditMode(false); setForm({ title: '', content: '' }) }
+  function openNew() {
+    setEditMode(false)
+    setForm({ title: '', content: '' })
+    setFormError('')
+    setActionError('')
+    setShowForm(true)
+  }
+  function openEdit(post) {
+    setEditMode(true)
+    setForm({ title: post.title, content: post.content })
+    setFormError('')
+    setActionError('')
+    setShowForm(true)
+  }
+  function cancelForm() {
+    setShowForm(false)
+    setEditMode(false)
+    setForm({ title: '', content: '' })
+    setFormError('')
+  }
 
   async function handlePublish() {
     if (!form.title.trim()) return
+    if (!user || !isAdmin) {
+      setFormError('You do not have permission to do that.')
+      return
+    }
     setSubmitting(true)
+    setFormError('')
     try {
       const post = await createAnnouncement(form.title.trim(), form.content, user.id)
       setAnnouncements(prev => [post, ...prev])
       cancelForm()
       router.push(`/announcements/${post.id}`)
+    } catch (err) {
+      setFormError(formatRequestError(err))
     } finally {
       setSubmitting(false)
     }
@@ -140,24 +188,41 @@ function AnnouncementsContent() {
 
   async function handleUpdate(id) {
     if (!form.title.trim()) return
+    if (!user || !isAdmin) {
+      setFormError('You do not have permission to do that.')
+      return
+    }
     setSubmitting(true)
+    setFormError('')
     try {
       const updated = await updateAnnouncement(id, form.title.trim(), form.content)
       setAnnouncements(prev => prev.map(a => a.id === id ? updated : a))
       cancelForm()
+    } catch (err) {
+      setFormError(formatRequestError(err))
     } finally {
       setSubmitting(false)
     }
   }
 
   async function handleDelete(id) {
-    await deleteAnnouncement(id)
-    const remaining = announcements.filter(a => a.id !== id)
-    setAnnouncements(remaining)
-    if (remaining.length > 0) {
-      router.push(`/announcements/${remaining[0].id}`)
-    } else {
-      router.push('/announcements')
+    if (!user || !isAdmin) {
+      setActionError('You do not have permission to do that.')
+      throw new Error('Forbidden')
+    }
+    setActionError('')
+    try {
+      await deleteAnnouncement(id)
+      const remaining = announcements.filter(a => a.id !== id)
+      setAnnouncements(remaining)
+      if (remaining.length > 0) {
+        router.push(`/announcements/${remaining[0].id}`)
+      } else {
+        router.push('/announcements')
+      }
+    } catch (err) {
+      setActionError(formatRequestError(err))
+      throw err
     }
   }
 
@@ -181,6 +246,8 @@ function AnnouncementsContent() {
         onPublish={handlePublish}
         onCancelForm={cancelForm}
         publishing={submitting}
+        formError={formError}
+        actionError={actionError}
       />
     )
   }
@@ -190,6 +257,14 @@ function AnnouncementsContent() {
   return (
     <>
       <PageHeader isAdmin={isAdmin} onNew={openNew} />
+
+      {actionError && !showForm && (
+        <div className="bg-white px-4 sm:px-6 pt-4">
+          <div className="max-w-[800px] mx-auto">
+            <p className="text-sm text-error font-inter">{actionError}</p>
+          </div>
+        </div>
+      )}
 
       {showForm && (
         <div className="bg-white py-8 px-4 sm:px-6">
@@ -201,6 +276,7 @@ function AnnouncementsContent() {
               onCancel={cancelForm}
               submitting={submitting}
               editMode={editMode}
+              error={formError}
             />
           </div>
         </div>

--- a/src/utils/requestErrors.js
+++ b/src/utils/requestErrors.js
@@ -13,6 +13,10 @@ export function formatRequestError(error) {
     return 'Network error. Check your internet connection and try again.'
   }
 
+  if (message.includes('row-level security') || message.includes('permission denied') || message.includes('42501')) {
+    return 'You do not have permission to do that.'
+  }
+
   if (message.includes('application_status') || message.includes('column')) {
     return 'Database is out of date. Ask a developer to run the latest Supabase migration.'
   }


### PR DESCRIPTION
## Summary
- Guard create/update/delete behind authenticated exec/admin checks
- Surface form and action errors instead of failing silently
- Map RLS/permission failures to a clear message

Stacked on #193 (`fix/announcements-markdown-sanitize`).

Closes #168

## Test plan
- [ ] Exec/admin can still create, edit, and delete announcements
- [ ] Unauthorized mutation attempt shows a permission error (no silent fail)
- [ ] Network/RLS failures show a visible error near the form or page