### PR TITLE
fix: enforce announcement title and content length limits (#166)

### DIFF
--- a/docs/schema/tables/announcements.sql
+++ b/docs/schema/tables/announcements.sql
@@ -2,7 +2,7 @@
 CREATE TABLE announcements (
   id BIGSERIAL PRIMARY KEY,
   author_id UUID REFERENCES profiles(id) ON DELETE CASCADE,
-  title TEXT NOT NULL,
-  content TEXT,
+  title TEXT NOT NULL CHECK (char_length(title) <= 200),
+  content TEXT CHECK (content IS NULL OR char_length(content) <= 20000),
   created_at TIMESTAMP DEFAULT NOW()
 );

--- a/src/app/announcements/_shared.js
+++ b/src/app/announcements/_shared.js
@@ -6,6 +6,11 @@ import Markdown from 'react-markdown'
 
 import { IconEdit, IconTrash, IconNew } from '@/components/ui/Icons'
 import { sanitizeMarkdownUrl } from '@/utils/sanitizeMarkdownUrl'
+import {
+  ANNOUNCEMENT_CONTENT_MAX,
+  ANNOUNCEMENT_TITLE_MAX,
+  getAnnouncementLengthError,
+} from '@/utils/announcementLimits'
 
 const MarkdownCodeEditor = dynamic(() => import('./_editor'), { ssr: false })
 
@@ -100,16 +105,25 @@ function EditorTabs({ activeTab, onTabChange }) {
 
 export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editMode = false, error = '' }) {
   const [tab, setTab] = useState('Write')
+  const lengthError = getAnnouncementLengthError(form.title, form.content)
+  const displayError = error || lengthError
+  const overLimit = Boolean(lengthError)
 
   return (
     <div className="flex flex-col gap-4">
-      <input
-        type="text"
-        placeholder="Title"
-        value={form.title}
-        onChange={e => onChange(prev => ({ ...prev, title: e.target.value }))}
-        className="w-full border border-border rounded-md px-3 py-2 text-sm font-inter text-text-primary bg-white focus:outline-none focus:border-border-strong"
-      />
+      <div>
+        <input
+          type="text"
+          placeholder="Title"
+          value={form.title}
+          onChange={e => onChange(prev => ({ ...prev, title: e.target.value }))}
+          maxLength={ANNOUNCEMENT_TITLE_MAX}
+          className="w-full border border-border rounded-md px-3 py-2 text-sm font-inter text-text-primary bg-white focus:outline-none focus:border-border-strong"
+        />
+        <p className="mt-1 text-xs text-text-hint font-inter text-right">
+          {form.title.length}/{ANNOUNCEMENT_TITLE_MAX}
+        </p>
+      </div>
 
       <div className="border border-border rounded-md overflow-hidden">
         <EditorTabs activeTab={tab} onTabChange={setTab} />
@@ -131,9 +145,12 @@ export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editM
           </div>
         )}
       </div>
+      <p className="text-xs text-text-hint font-inter text-right -mt-2">
+        {form.content.length}/{ANNOUNCEMENT_CONTENT_MAX}
+      </p>
 
-      {error && (
-        <p className="text-sm text-error font-inter">{error}</p>
+      {displayError && (
+        <p className="text-sm text-error font-inter">{displayError}</p>
       )}
 
       <div className="flex gap-3 justify-end">
@@ -145,7 +162,7 @@ export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editM
         </button>
         <button
           onClick={onSubmit}
-          disabled={!form.title.trim() || submitting}
+          disabled={!form.title.trim() || submitting || overLimit}
           className="px-5 py-2 bg-accent text-white rounded-md text-sm font-medium font-inter hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {submitting ? (editMode ? 'Saving...' : 'Publishing...') : (editMode ? 'Save' : 'Publish')}

--- a/src/services/announcementService.js
+++ b/src/services/announcementService.js
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase'
+import { getAnnouncementLengthError } from '@/utils/announcementLimits'
 
 const SELECT_FIELDS = 'id, title, content, created_at, author_id, profiles(first_name, last_name)'
 
@@ -12,6 +13,11 @@ function map(row) {
   }
 }
 
+function assertLength(title, content) {
+  const error = getAnnouncementLengthError(title, content)
+  if (error) throw new Error(error)
+}
+
 export async function fetchAnnouncements() {
   const { data, error } = await supabase
     .from('announcements')
@@ -22,6 +28,7 @@ export async function fetchAnnouncements() {
 }
 
 export async function createAnnouncement(title, content, authorId) {
+  assertLength(title, content)
   const { data, error } = await supabase
     .from('announcements')
     .insert({ title, content, author_id: authorId })
@@ -32,6 +39,7 @@ export async function createAnnouncement(title, content, authorId) {
 }
 
 export async function updateAnnouncement(id, title, content) {
+  assertLength(title, content)
   const { data, error } = await supabase
     .from('announcements')
     .update({ title, content })

--- a/src/utils/announcementLimits.js
+++ b/src/utils/announcementLimits.js
@@ -1,0 +1,13 @@
+// Keep announcement payloads bounded for storage and render performance.
+export const ANNOUNCEMENT_TITLE_MAX = 200
+export const ANNOUNCEMENT_CONTENT_MAX = 20000
+
+export function getAnnouncementLengthError(title, content) {
+  if ((title ?? '').length > ANNOUNCEMENT_TITLE_MAX) {
+    return `Title must be ${ANNOUNCEMENT_TITLE_MAX} characters or fewer.`
+  }
+  if ((content ?? '').length > ANNOUNCEMENT_CONTENT_MAX) {
+    return `Content must be ${ANNOUNCEMENT_CONTENT_MAX} characters or fewer.`
+  }
+  return null
+}

--- a/supabase/migrations/20260722170000_announcements_length_limits.sql
+++ b/supabase/migrations/20260722170000_announcements_length_limits.sql
@@ -1,0 +1,6 @@
+-- Bound announcement payload size at the database layer.
+ALTER TABLE public.announcements
+  ADD CONSTRAINT announcements_title_length_check
+    CHECK (char_length(title) <= 200),
+  ADD CONSTRAINT announcements_content_length_check
+    CHECK (content IS NULL OR char_length(content) <= 20000);


### PR DESCRIPTION
## Summary
- Cap announcement title at 200 characters and content at 20,000 characters
- Validate in the form UI and `announcementService` before insert/update
- Add matching DB `CHECK` constraints (already applied via `supabase db push`)

Stacked on #194 (`fix/announcements-mutation-guards`).

Closes #166

## Test plan
- [ ] Title counter and content counter show current/max lengths
- [ ] Publish/Save disabled when over limit; error message visible
- [ ] Service rejects oversized payloads even if UI is bypassed
- [ ] Normal-sized create/edit still works