### PR TITLE
feat: upload announcement images via drag and paste (#159)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ CONTACT_EMAIL_USER=your-gmail@gmail.com
 CONTACT_EMAIL_PASS=xxxx-xxxx-xxxx-xxxx
 
 # Cloudinary (image uploads: hero, events, problems, profiles, announcements)
+# Used by /api/upload (signed). Set these in Vercel for production too.
 NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=your-cloud-name
 CLOUDINARY_API_KEY=your-api-key
 CLOUDINARY_API_SECRET=your-api-secret
+# Announcements editor: drag/paste images upload to the `announcements` folder via /api/upload

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/user-event": "^13.5.0",
         "@uiw/react-codemirror": "^4.25.10",
         "@uiw/react-md-editor": "^4.1.1",
+        "browser-image-compression": "^2.0.2",
         "cloudinary": "^2.10.0",
         "docx-preview": "^0.3.7",
         "jszip": "^3.10.1",
@@ -1547,6 +1548,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -4949,6 +4959,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
       "license": "MIT"
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@uiw/react-codemirror": "^4.25.10",
     "@uiw/react-md-editor": "^4.1.1",
+    "browser-image-compression": "^2.0.2",
     "cloudinary": "^2.10.0",
     "docx-preview": "^0.3.7",
     "jszip": "^3.10.1",

--- a/src/app/announcements/_editor.js
+++ b/src/app/announcements/_editor.js
@@ -14,6 +14,10 @@ const customTheme = EditorView.theme({
   '.cm-editor': { borderRadius: '0 0 6px 6px' },
 })
 
+function collectImageFiles(fileList) {
+  return Array.from(fileList ?? []).filter((file) => file.type.startsWith('image/'))
+}
+
 export default function MarkdownCodeEditor({ value, onChange, height = '360px', onFilesDrop }) {
   const extensions = [markdown(), customTheme]
 
@@ -26,12 +30,23 @@ export default function MarkdownCodeEditor({ value, onChange, height = '360px', 
         }
         return false
       },
-      drop(event) {
-        const files = Array.from(event.dataTransfer?.files ?? [])
+      drop(event, view) {
+        const files = collectImageFiles(event.dataTransfer?.files)
         if (files.length === 0) return false
         event.preventDefault()
         event.stopPropagation()
-        onFilesDrop(files)
+        onFilesDrop(files, view)
+        return true
+      },
+      paste(event, view) {
+        const items = Array.from(event.clipboardData?.items ?? [])
+        const files = items
+          .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+          .map((item) => item.getAsFile())
+          .filter(Boolean)
+        if (files.length === 0) return false
+        event.preventDefault()
+        onFilesDrop(files, view)
         return true
       },
     }))

--- a/src/app/announcements/_shared.js
+++ b/src/app/announcements/_shared.js
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import Markdown from 'react-markdown'
+import imageCompression from 'browser-image-compression'
 
 import { IconEdit, IconTrash, IconNew } from '@/components/ui/Icons'
 import { sanitizeMarkdownUrl } from '@/utils/sanitizeMarkdownUrl'
@@ -11,6 +12,8 @@ import {
   ANNOUNCEMENT_TITLE_MAX,
   getAnnouncementLengthError,
 } from '@/utils/announcementLimits'
+import { uploadImage } from '@/services/cloudinaryService'
+import { formatRequestError } from '@/utils/requestErrors'
 
 const MarkdownCodeEditor = dynamic(() => import('./_editor'), { ssr: false })
 
@@ -105,9 +108,46 @@ function EditorTabs({ activeTab, onTabChange }) {
 
 export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editMode = false, error = '' }) {
   const [tab, setTab] = useState('Write')
+  const [uploading, setUploading] = useState(false)
+  const [uploadError, setUploadError] = useState('')
   const lengthError = getAnnouncementLengthError(form.title, form.content)
-  const displayError = error || lengthError
+  const displayError = error || uploadError || lengthError
   const overLimit = Boolean(lengthError)
+
+  async function handleImageFiles(files, view) {
+    const images = files.filter((file) => file.type.startsWith('image/'))
+    if (images.length === 0) return
+
+    setUploading(true)
+    setUploadError('')
+    try {
+      for (const file of images) {
+        const compressed = await imageCompression(file, {
+          maxSizeMB: 1,
+          maxWidthOrHeight: 1920,
+          useWebWorker: true,
+        })
+        const uploadFile = compressed instanceof File
+          ? compressed
+          : new File([compressed], file.name, { type: compressed.type || file.type })
+        const { url } = await uploadImage(uploadFile, 'announcements')
+        const markdown = `![${file.name}](${url})\n`
+        if (view) {
+          const pos = view.state.selection.main.head
+          view.dispatch({
+            changes: { from: pos, insert: markdown },
+            selection: { anchor: pos + markdown.length },
+          })
+        } else {
+          onChange((prev) => ({ ...prev, content: `${prev.content}${markdown}` }))
+        }
+      }
+    } catch (err) {
+      setUploadError(formatRequestError(err))
+    } finally {
+      setUploading(false)
+    }
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -129,11 +169,17 @@ export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editM
         <EditorTabs activeTab={tab} onTabChange={setTab} />
 
         {tab === 'Write' ? (
-          <div className="bg-white">
+          <div className="bg-white relative">
             <MarkdownCodeEditor
               value={form.content}
               onChange={val => onChange(prev => ({ ...prev, content: val ?? '' }))}
+              onFilesDrop={handleImageFiles}
             />
+            {uploading && (
+              <div className="absolute inset-0 bg-white/70 flex items-center justify-center">
+                <p className="text-sm font-inter text-text-secondary">Uploading image…</p>
+              </div>
+            )}
           </div>
         ) : (
           <div className="min-h-[360px] bg-white px-6 py-4">
@@ -147,6 +193,8 @@ export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editM
       </div>
       <p className="text-xs text-text-hint font-inter text-right -mt-2">
         {form.content.length}/{ANNOUNCEMENT_CONTENT_MAX}
+        {' · '}
+        Drop or paste images in Write
       </p>
 
       {displayError && (
@@ -162,7 +210,7 @@ export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editM
         </button>
         <button
           onClick={onSubmit}
-          disabled={!form.title.trim() || submitting || overLimit}
+          disabled={!form.title.trim() || submitting || overLimit || uploading}
           className="px-5 py-2 bg-accent text-white rounded-md text-sm font-medium font-inter hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {submitting ? (editMode ? 'Saving...' : 'Publishing...') : (editMode ? 'Save' : 'Publish')}


### PR DESCRIPTION
## Summary
- Wire announcements Write editor drag-and-drop and clipboard paste to Cloudinary via existing `/api/upload?folder=announcements`
- Compress images client-side (max 1MB / 1920px) before upload
- Insert `![filename](url)` at the cursor and show an uploading overlay

Stacked on #195 (`fix/announcements-length-limits`).

Uses signed `/api/upload` (same as hero/events), not an unsigned Cloudinary preset.

Closes #159

## Test plan
- [ ] Exec/admin: New announcement → drop an image into Write → markdown image inserted
- [ ] Paste an image from clipboard → same behavior
- [ ] Upload overlay appears while uploading; Publish disabled during upload
- [ ] Manual `![alt](https://...)` markdown still works
- [ ] Production/preview has Cloudinary env vars on Vercel