### PR TITLE
feat: problem sample I/O and Run pass/fail (#199)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -37,10 +37,11 @@ app.add_middleware(
 def health():
     return {"status": "ok"}
 
-from routers import documents, execute, submissions
+from routers import documents, execute, execute_samples, submissions
 
 app.include_router(documents.router)
 app.include_router(execute.router)
+app.include_router(execute_samples.router)
 app.include_router(submissions.router)
 
 # Routers added in later sprints:

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,4 +1,5 @@
 # Route modules:
-# execute.py     — POST /execute (Judge0 RapidAPI proxy)
-# submissions.py — POST /submissions (Supabase upsert)
-# attendance.py  — W4: POST /attendance/verify (QR check-in)
+# execute.py         — POST /execute (Judge0 RapidAPI proxy)
+# execute_samples.py — POST /execute/samples (run against problem sample_tests)
+# submissions.py     — POST /submissions (Supabase upsert)
+# attendance.py      — W4: POST /attendance/verify (QR check-in)

--- a/backend/routers/execute_samples.py
+++ b/backend/routers/execute_samples.py
@@ -1,0 +1,146 @@
+"""POST /execute/samples — run member code against problem sample tests."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from auth import AuthUser, require_member_plus
+from services import judge0, rate_limit, samples
+from services.supabase_rest import rest_client, service_headers, supabase_url
+
+router = APIRouter(tags=["execute"])
+
+
+class SampleExecuteRequest(BaseModel):
+    problem_id: int = Field(..., gt=0)
+    language: str = Field(..., min_length=1)
+    code: str = Field(..., min_length=1)
+
+
+class SampleResult(BaseModel):
+    index: int
+    passed: bool
+    stdin: str
+    expected_stdout: str
+    stdout: str
+    stderr: str
+    runtime: float
+    exit_code: int
+
+
+class SampleExecuteResponse(BaseModel):
+    results: list[SampleResult]
+    passed: int
+    total: int
+
+
+def _fetch_sample_tests(problem_id: int) -> list[dict[str, str]]:
+    url = f"{supabase_url()}/rest/v1/problems"
+    params = {
+        "id": f"eq.{problem_id}",
+        "select": "sample_tests",
+    }
+    with rest_client() as client:
+        response = client.get(url, headers=service_headers(), params=params)
+
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Failed to load problem samples",
+        )
+
+    rows = response.json()
+    if not isinstance(rows, list) or not rows:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Problem not found",
+        )
+
+    return samples.parse_sample_tests(rows[0].get("sample_tests"))
+
+
+@router.post("/execute/samples", response_model=SampleExecuteResponse)
+def execute_samples(
+    body: SampleExecuteRequest,
+    user: AuthUser = Depends(require_member_plus),
+) -> SampleExecuteResponse:
+    if body.language not in judge0.SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    try:
+        judge0.validate_code_size(body.code)
+    except judge0.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+
+    sample_list = _fetch_sample_tests(body.problem_id)
+    if not sample_list:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No sample tests configured for this problem",
+        )
+
+    try:
+        rate_limit.check_and_increment(user.id, amount=len(sample_list))
+    except rate_limit.DailyLimitExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    results: list[SampleResult] = []
+    try:
+        for index, sample in enumerate(sample_list, start=1):
+            run = judge0.execute_code(
+                language=body.language,
+                code=body.code,
+                stdin=sample["stdin"],
+            )
+            passed = (
+                run.exit_code == 0
+                and samples.outputs_match(run.stdout, sample["expected_stdout"])
+            )
+            results.append(
+                SampleResult(
+                    index=index,
+                    passed=passed,
+                    stdin=sample["stdin"],
+                    expected_stdout=sample["expected_stdout"],
+                    stdout=run.stdout,
+                    stderr=run.stderr,
+                    runtime=run.runtime,
+                    exit_code=run.exit_code,
+                )
+            )
+    except judge0.UnsupportedLanguageError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    except judge0.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+    except judge0.ExecutionTimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_408_REQUEST_TIMEOUT,
+            detail="Execution timed out",
+        )
+    except judge0.ExecutionUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Code execution service unavailable",
+        )
+
+    passed_count = sum(1 for row in results if row.passed)
+    return SampleExecuteResponse(
+        results=results,
+        passed=passed_count,
+        total=len(results),
+    )

--- a/backend/services/rate_limit.py
+++ b/backend/services/rate_limit.py
@@ -26,19 +26,23 @@ def _today_utc() -> str:
     return datetime.now(timezone.utc).date().isoformat()
 
 
-def check_and_increment(user_id: str) -> int:
-    """Increment the user's daily counter. Returns remaining quota after this call.
+def check_and_increment(user_id: str, amount: int = 1) -> int:
+    """Increment the user's daily counter by ``amount``.
 
-    Raises DailyLimitExceededError when the limit is already reached.
+    Returns remaining quota after this call.
+    Raises DailyLimitExceededError when the limit would be exceeded.
     """
+    if amount < 1:
+        raise ValueError("amount must be >= 1")
+
     key = (user_id, _today_utc())
     with _lock:
         used = _counts.get(key, 0)
-        if used >= DAILY_EXECUTE_LIMIT:
+        if used + amount > DAILY_EXECUTE_LIMIT:
             raise DailyLimitExceededError(
                 f"Daily execute limit of {DAILY_EXECUTE_LIMIT} reached"
             )
-        used += 1
+        used += amount
         _counts[key] = used
         return DAILY_EXECUTE_LIMIT - used
 

--- a/backend/services/samples.py
+++ b/backend/services/samples.py
@@ -1,0 +1,39 @@
+"""Compare Judge0 stdout to expected sample output."""
+
+from __future__ import annotations
+
+
+def normalize_stdout(text: str | None) -> str:
+    """Trim trailing whitespace per line and strip trailing blank lines."""
+    normalized = (text or "").replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.rstrip() for line in normalized.split("\n")]
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
+
+
+def outputs_match(actual: str | None, expected: str | None) -> bool:
+    return normalize_stdout(actual) == normalize_stdout(expected)
+
+
+def parse_sample_tests(raw) -> list[dict[str, str]]:
+    """Return up to 10 usable sample pairs from a problems.sample_tests value."""
+    if not isinstance(raw, list):
+        return []
+
+    samples: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        stdin = item.get("stdin")
+        expected = item.get("expected_stdout")
+        if stdin is None and expected is None:
+            continue
+        stdin_s = "" if stdin is None else str(stdin)
+        expected_s = "" if expected is None else str(expected)
+        if stdin_s.strip() == "" and expected_s.strip() == "":
+            continue
+        samples.append({"stdin": stdin_s, "expected_stdout": expected_s})
+        if len(samples) >= 10:
+            break
+    return samples

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -346,3 +346,89 @@ def test_submissions_upsert_success(authed_client, monkeypatch):
     assert body["message"] == "Solution submitted!"
     assert body["submission_id"] == 42
     assert body["submitted_at"] == "2026-07-23T12:00:00+00:00"
+
+
+def test_normalize_stdout_trims_lines():
+    from services.samples import normalize_stdout, outputs_match, parse_sample_tests
+
+    assert normalize_stdout("a  \n b \n\n") == "a\n b"
+    assert outputs_match("4 1\n", "4 1")
+    assert parse_sample_tests([
+        {"stdin": "a 1", "expected_stdout": "4 1"},
+        {"stdin": "  ", "expected_stdout": ""},
+        {"stdin": "b 0", "expected_stdout": "8 8"},
+    ]) == [
+        {"stdin": "a 1", "expected_stdout": "4 1"},
+        {"stdin": "b 0", "expected_stdout": "8 8"},
+    ]
+
+
+def test_execute_samples_success(authed_client, monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-key")
+
+    problem_response = MagicMock()
+    problem_response.status_code = 200
+    problem_response.json.return_value = [{
+        "sample_tests": [
+            {"stdin": "a 1 5 6", "expected_stdout": "4 1"},
+            {"stdin": "b 0", "expected_stdout": "8 8"},
+        ],
+    }]
+
+    mock_run = MagicMock()
+    mock_run.stdout = "4 1\n"
+    mock_run.stderr = ""
+    mock_run.runtime = 0.01
+    mock_run.exit_code = 0
+
+    mock_run_fail = MagicMock()
+    mock_run_fail.stdout = "0 0\n"
+    mock_run_fail.stderr = ""
+    mock_run_fail.runtime = 0.02
+    mock_run_fail.exit_code = 0
+
+    with patch("routers.execute_samples.rest_client") as mock_rest, \
+            patch("services.judge0.execute_code", side_effect=[mock_run, mock_run_fail]) as mock_exec:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.get.return_value = problem_response
+        mock_rest.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute/samples",
+            json={"problem_id": 5, "language": "python", "code": "print(1)"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["passed"] == 1
+    assert body["total"] == 2
+    assert body["results"][0]["passed"] is True
+    assert body["results"][1]["passed"] is False
+    assert mock_exec.call_count == 2
+
+
+def test_execute_samples_no_samples(authed_client, monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-key")
+
+    problem_response = MagicMock()
+    problem_response.status_code = 200
+    problem_response.json.return_value = [{"sample_tests": []}]
+
+    with patch("routers.execute_samples.rest_client") as mock_rest:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.get.return_value = problem_response
+        mock_rest.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute/samples",
+            json={"problem_id": 5, "language": "python", "code": "print(1)"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "No sample tests configured for this problem"

--- a/docs/schema/tables/problems.sql
+++ b/docs/schema/tables/problems.sql
@@ -3,6 +3,7 @@ CREATE TABLE problems (
   id BIGSERIAL PRIMARY KEY,
   title TEXT NOT NULL, -- Title of the problem
   description TEXT NOT NULL,
-  file_url TEXT NOT NULL,
-  created_at TIMESTAMP DEFAULT NOW()
+  file_url TEXT,
+  created_at TIMESTAMP DEFAULT NOW(),
+  sample_tests JSONB NOT NULL DEFAULT '[]'::jsonb -- [{stdin, expected_stdout}, ...] max 10 in app
 );

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -4,7 +4,7 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { Upload } from 'lucide-react'
+import { Plus, Upload, X } from 'lucide-react'
 
 const PdfViewer = dynamic(() => import('@/components/problems/PdfViewer'), { ssr: false })
 import { uploadImage } from '@/services/cloudinaryService'
@@ -13,8 +13,11 @@ import { extractFilesFromZip, isZipFile } from '@/utils/zipImport'
 import {
   CONTENT_TYPE,
   FILE_FORMAT,
+  MAX_SAMPLE_TESTS,
   detectProblemFileType,
   downloadProblemDocument,
+  emptySamplePair,
+  normalizeSampleTests,
   previewDocxAsPdf,
 } from '@/services/problemsService'
 
@@ -73,10 +76,12 @@ export function emptyProblemForm() {
     sourceFileUrl: null,
     documentName: null,
     pendingImageFiles: [],
+    sampleTests: [emptySamplePair()],
   }
 }
 
 export function problemToForm(problem) {
+  const samples = normalizeSampleTests(problem.sample_tests)
   return {
     title: problem.title ?? '',
     week: problem.week != null ? String(problem.week) : '',
@@ -90,6 +95,7 @@ export function problemToForm(problem) {
     sourceFileUrl: problem.source_file_url ?? null,
     documentName: problem.file_url ? problem.file_url.split('/').pop() : null,
     pendingImageFiles: [],
+    sampleTests: samples.length > 0 ? samples : [emptySamplePair()],
   }
 }
 
@@ -654,6 +660,96 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
       {fileError && (
         <p className="text-sm font-inter text-accent">{fileError}</p>
       )}
+
+      <div className="border border-border rounded-md bg-bg-base p-4 space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-inter text-sm font-medium text-text-primary">Sample tests</p>
+            <p className="font-inter text-xs text-text-secondary mt-1">
+              Used when members click Run on Solutions. Start with one pair; add up to {MAX_SAMPLE_TESTS}.
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={(form.sampleTests?.length ?? 0) >= MAX_SAMPLE_TESTS}
+            onClick={() => onChange((prev) => ({
+              ...prev,
+              sampleTests: [...(prev.sampleTests ?? [emptySamplePair()]), emptySamplePair()]
+                .slice(0, MAX_SAMPLE_TESTS),
+            }))}
+            className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 font-inter text-sm text-text-primary hover:bg-bg-surface disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Plus size={14} />
+            Add
+          </button>
+        </div>
+
+        {(form.sampleTests?.length ? form.sampleTests : [emptySamplePair()]).map((sample, index) => (
+          <div key={index} className="space-y-2 border-t border-border pt-4 first:border-t-0 first:pt-0">
+            <div className="flex items-center justify-between gap-2">
+              <p className="font-inter text-sm font-medium text-text-primary">
+                Sample
+                {' '}
+                {index + 1}
+              </p>
+              {(form.sampleTests?.length ?? 0) > 1 && (
+                <button
+                  type="button"
+                  onClick={() => onChange((prev) => {
+                    const next = [...(prev.sampleTests ?? [])]
+                    next.splice(index, 1)
+                    return {
+                      ...prev,
+                      sampleTests: next.length > 0 ? next : [emptySamplePair()],
+                    }
+                  })}
+                  className="inline-flex items-center gap-1 font-inter text-xs text-text-secondary hover:text-accent"
+                  aria-label={`Remove sample ${index + 1}`}
+                >
+                  <X size={14} />
+                  Remove
+                </button>
+              )}
+            </div>
+            <label className="block space-y-1">
+              <span className="font-inter text-xs text-text-secondary">
+                Sample Input
+                {' '}
+                {index + 1}
+              </span>
+              <textarea
+                value={sample.stdin}
+                onChange={(e) => onChange((prev) => {
+                  const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
+                  next[index] = { ...next[index], stdin: e.target.value }
+                  return { ...prev, sampleTests: next }
+                })}
+                rows={3}
+                spellCheck={false}
+                className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+              />
+            </label>
+            <label className="block space-y-1">
+              <span className="font-inter text-xs text-text-secondary">
+                Sample Output
+                {' '}
+                {index + 1}
+              </span>
+              <textarea
+                value={sample.expected_stdout}
+                onChange={(e) => onChange((prev) => {
+                  const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
+                  next[index] = { ...next[index], expected_stdout: e.target.value }
+                  return { ...prev, sampleTests: next }
+                })}
+                rows={3}
+                spellCheck={false}
+                className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+              />
+            </label>
+          </div>
+        ))}
+      </div>
 
       <input
         ref={fileInputRef}

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -477,6 +477,7 @@ function ProblemsContent() {
           dueDate,
           school,
           contentType: CONTENT_TYPE.DOCUMENT,
+          sampleTests: form.sampleTests,
           createdBy: user?.id,
         })
         createdId = row.id
@@ -486,6 +487,7 @@ function ProblemsContent() {
           sourceFileUrl: sourcePath,
           fileFormat,
           contentType: CONTENT_TYPE.DOCUMENT,
+          sampleTests: form.sampleTests,
         })
         cancelForm()
         await loadProblems()
@@ -502,6 +504,7 @@ function ProblemsContent() {
         dueDate,
         school,
         contentType: CONTENT_TYPE.MARKDOWN,
+        sampleTests: form.sampleTests,
         createdBy: user?.id,
       })
       cancelForm()
@@ -550,6 +553,7 @@ function ProblemsContent() {
           sourceFileUrl,
           fileFormat,
           description: '',
+          sampleTests: form.sampleTests,
         })
       } else {
         if (existing?.content_type === CONTENT_TYPE.DOCUMENT) {
@@ -567,6 +571,7 @@ function ProblemsContent() {
           fileFormat: null,
           fileUrl: null,
           sourceFileUrl: null,
+          sampleTests: form.sampleTests,
         })
       }
 

--- a/src/app/solutions/[id]/page.js
+++ b/src/app/solutions/[id]/page.js
@@ -16,9 +16,11 @@ import {
 import {
   SOLUTION_LANGUAGES,
   executeCode,
+  executeSamples,
   languageLabel,
   submitSolution,
 } from '@/services/solutionService'
+import { normalizeSampleTests } from '@/services/problemsService'
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), { ssr: false })
 
@@ -196,18 +198,36 @@ function SolutionWorkspace() {
     setRunning(true)
     setOutput({ pending: true })
     try {
-      const result = await executeCode({
-        accessToken,
-        language,
-        code,
-      })
-      setOutput({
-        pending: false,
-        stdout: result.stdout || '',
-        stderr: result.stderr || '',
-        runtime: result.runtime,
-        exitCode: result.exit_code,
-      })
+      const samples = normalizeSampleTests(problem?.sample_tests)
+      if (samples.length > 0) {
+        const result = await executeSamples({
+          accessToken,
+          problemId,
+          language,
+          code,
+        })
+        setOutput({
+          pending: false,
+          mode: 'samples',
+          passed: result.passed,
+          total: result.total,
+          results: result.results || [],
+        })
+      } else {
+        const result = await executeCode({
+          accessToken,
+          language,
+          code,
+        })
+        setOutput({
+          pending: false,
+          mode: 'raw',
+          stdout: result.stdout || '',
+          stderr: result.stderr || '',
+          runtime: result.runtime,
+          exitCode: result.exit_code,
+        })
+      }
     } catch (err) {
       setOutput(null)
       setError(err.message || 'Run failed')
@@ -478,16 +498,66 @@ function SolutionWorkspace() {
                 </div>
 
                 {output && (
-                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-40 overflow-y-auto">
-                    <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
-                    <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
-                      {output.pending && '> Running...\n'}
-                      {!output.pending && output.stdout ? `${output.stdout}` : ''}
-                      {!output.pending && output.stderr ? `\n${output.stderr}` : ''}
-                      {!output.pending && typeof output.runtime === 'number'
-                        ? `\nRuntime: ${output.runtime}s`
-                        : ''}
-                    </pre>
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-64 overflow-y-auto">
+                    {output.pending && (
+                      <>
+                        <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
+                        <pre className="font-mono text-[13px] text-text-primary">{'> Running...\n'}</pre>
+                      </>
+                    )}
+                    {!output.pending && output.mode === 'samples' && (
+                      <div className="space-y-3">
+                        <p className="font-inter text-sm font-medium text-text-primary">
+                          Samples
+                          {' '}
+                          {output.passed}
+                          /
+                          {output.total}
+                          {' '}
+                          passed
+                        </p>
+                        {(output.results || []).map((row) => (
+                          <div key={row.index} className="border border-border rounded-md bg-bg-base p-3 space-y-1">
+                            <p className={`font-inter text-sm font-medium ${
+                              row.passed ? 'text-success' : 'text-accent'
+                            }`}
+                            >
+                              Sample
+                              {' '}
+                              {row.index}
+                              {': '}
+                              {row.passed ? 'Pass' : 'Fail'}
+                            </p>
+                            {!row.passed && (
+                              <pre className="font-mono text-[12px] text-text-primary whitespace-pre-wrap break-words">
+                                {`expected:\n${row.expected_stdout || '(empty)'}\n\ngot:\n${row.stdout || '(empty)'}`}
+                                {row.stderr ? `\n\nstderr:\n${row.stderr}` : ''}
+                              </pre>
+                            )}
+                            {row.passed && typeof row.runtime === 'number' && (
+                              <p className="font-inter text-xs text-text-secondary">
+                                Runtime:
+                                {' '}
+                                {row.runtime}
+                                s
+                              </p>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    {!output.pending && output.mode !== 'samples' && (
+                      <>
+                        <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
+                        <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
+                          {output.stdout ? `${output.stdout}` : ''}
+                          {output.stderr ? `\n${output.stderr}` : ''}
+                          {typeof output.runtime === 'number'
+                            ? `\nRuntime: ${output.runtime}s`
+                            : ''}
+                        </pre>
+                      </>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -13,6 +13,24 @@ export const FILE_FORMAT = {
   PDF: 'pdf',
 }
 
+export const MAX_SAMPLE_TESTS = 10
+
+export function emptySamplePair() {
+  return { stdin: '', expected_stdout: '' }
+}
+
+/** Keep up to 10 pairs that have any non-whitespace content. */
+export function normalizeSampleTests(samples) {
+  if (!Array.isArray(samples)) return []
+  return samples
+    .slice(0, MAX_SAMPLE_TESTS)
+    .map((s) => ({
+      stdin: String(s?.stdin ?? ''),
+      expected_stdout: String(s?.expected_stdout ?? ''),
+    }))
+    .filter((s) => s.stdin.trim() !== '' || s.expected_stdout.trim() !== '')
+}
+
 const SELECT_FIELDS = '*'
 
 function mapProblem(row) {
@@ -27,6 +45,7 @@ function mapProblem(row) {
     file_format: row.file_format,
     file_url: row.file_url,
     source_file_url: row.source_file_url ?? null,
+    sample_tests: normalizeSampleTests(row.sample_tests),
     created_at: row.created_at,
     created_by: row.created_by,
   }
@@ -97,6 +116,7 @@ export async function createProblem({
   fileFormat = null,
   fileUrl = null,
   sourceFileUrl = null,
+  sampleTests = [],
   createdBy,
 }) {
   const { data, error } = await supabase
@@ -111,6 +131,7 @@ export async function createProblem({
       file_format: fileFormat,
       file_url: fileUrl,
       source_file_url: sourceFileUrl,
+      sample_tests: normalizeSampleTests(sampleTests),
       created_by: createdBy ?? null,
     })
     .select(SELECT_FIELDS)
@@ -131,6 +152,9 @@ export async function updateProblem(id, fields) {
   if (fields.fileFormat !== undefined) payload.file_format = fields.fileFormat
   if (fields.fileUrl !== undefined) payload.file_url = fields.fileUrl
   if (fields.sourceFileUrl !== undefined) payload.source_file_url = fields.sourceFileUrl
+  if (fields.sampleTests !== undefined) {
+    payload.sample_tests = normalizeSampleTests(fields.sampleTests)
+  }
 
   const { data, error } = await supabase
     .from('problems')

--- a/src/services/solutionService.js
+++ b/src/services/solutionService.js
@@ -21,6 +21,18 @@ export async function executeCode({ accessToken, language, code, stdin = '' }) {
   })
 }
 
+export async function executeSamples({ accessToken, problemId, language, code }) {
+  return backendFetch('/execute/samples', {
+    accessToken,
+    method: 'POST',
+    body: {
+      problem_id: problemId,
+      language,
+      code,
+    },
+  })
+}
+
 export async function submitSolution({ accessToken, problemId, language, code }) {
   return backendFetch('/submissions', {
     accessToken,

--- a/supabase/migrations/20260723160000_add_problem_sample_tests.sql
+++ b/supabase/migrations/20260723160000_add_problem_sample_tests.sql
@@ -1,0 +1,6 @@
+-- Sample stdin/stdout pairs for Solutions Run pass/fail checks (max 10 enforced in app).
+ALTER TABLE public.problems
+  ADD COLUMN IF NOT EXISTS sample_tests JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN public.problems.sample_tests IS
+  'Ordered sample I/O pairs: [{ "stdin": string, "expected_stdout": string }, ...]';


### PR DESCRIPTION
## Summary
- Add `sample_tests` on problems (up to 10 Sample Input/Output pairs) editable by Admin and Executive in the problem form
- Add `POST /execute/samples` to run member code against each sample via Judge0 and compare stdout
- Solutions Run shows per-sample Pass/Fail with expected vs got on failure; falls back to raw output when no samples exist

## Test plan
- [ ] Migration `sample_tests` is applied on Supabase (already pushed in this branch’s workflow)
- [ ] Deploy backend so `/execute/samples` is live (not 404)
- [ ] As Admin/Executive: create/edit a problem with 1+ sample pairs, save
- [ ] As member: open `/solutions/:id`, Run with correct code → all Pass
- [ ] Run with wrong output → Fail shows expected vs got
- [ ] Problem with no samples → Run still shows raw Output
- [ ] Daily execute limit counts N samples as N units