### PR TITLE
feat: Solutions Evaluate (Gemini), custom input, and Docs (#60)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,7 @@
 
 # CORS — comma-separated list of explicit allowed origins.
 # Vercel preview URLs are matched by CORS_ORIGIN_REGEX (default covers them).
-CORS_ORIGINS=http://localhost:3000,https://codexperts.ca,https://www.codexperts.ca
+CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:3002,http://127.0.0.1:3002,https://codexperts.ca,https://www.codexperts.ca
 # Optional override for the preview URL regex.
 # CORS_ORIGIN_REGEX=https://codexperts-web.*\.vercel\.app
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,10 @@ EXECUTE_DAILY_LIMIT=20
 # SUPABASE_URL value matches NEXT_PUBLIC_SUPABASE_URL on the frontend.
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Gemini (POST /evaluate — issue #60)
+# Create the key in Google AI Studio with the club Google account.
+# Model target: gemini-3.5-flash-lite (Free Tier).
+# Heroku: heroku config:set GEMINI_API_KEY=... -a <app>
+GEMINI_API_KEY=your-gemini-api-key
+# EVALUATE_DAILY_LIMIT=20

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,11 +37,12 @@ app.add_middleware(
 def health():
     return {"status": "ok"}
 
-from routers import documents, execute, execute_samples, submissions
+from routers import documents, evaluate, execute, execute_samples, submissions
 
 app.include_router(documents.router)
 app.include_router(execute.router)
 app.include_router(execute_samples.router)
+app.include_router(evaluate.router)
 app.include_router(submissions.router)
 
 # Routers added in later sprints:

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,5 +1,6 @@
 # Route modules:
 # execute.py         — POST /execute (Judge0 RapidAPI proxy)
 # execute_samples.py — POST /execute/samples (run against problem sample_tests)
+# evaluate.py        — POST /evaluate (soft forbidden + Gemini)
 # submissions.py     — POST /submissions (Supabase upsert)
 # attendance.py      — W4: POST /attendance/verify (QR check-in)

--- a/backend/routers/evaluate.py
+++ b/backend/routers/evaluate.py
@@ -1,0 +1,84 @@
+"""POST /evaluate — soft forbidden hints + Gemini Big O / duplication."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from auth import AuthUser, require_member_plus
+from services import forbidden, gemini_evaluate, judge0, rate_limit
+
+router = APIRouter(tags=["evaluate"])
+
+
+class EvaluateRequest(BaseModel):
+    problem_id: int = Field(..., gt=0)
+    language: str = Field(..., min_length=1)
+    code: str = Field(..., min_length=1)
+    samples_passed: bool = False
+
+
+class ForbiddenHint(BaseModel):
+    rule: str
+    hint: str
+    line: int | None = None
+
+
+class EvaluateResponse(BaseModel):
+    forbidden_hints: list[ForbiddenHint]
+    big_o: str
+    big_o_reason: str
+    duplicates: list[str]
+
+
+@router.post("/evaluate", response_model=EvaluateResponse)
+def evaluate(
+    body: EvaluateRequest,
+    user: AuthUser = Depends(require_member_plus),
+) -> EvaluateResponse:
+    if body.language not in judge0.SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    try:
+        judge0.validate_code_size(body.code)
+    except judge0.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+
+    if not body.samples_passed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="All sample tests must pass before Evaluate",
+        )
+
+    try:
+        rate_limit.check_and_increment(user.id, kind="evaluate")
+    except rate_limit.DailyLimitExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    hits = forbidden.check_forbidden(body.code, body.language)
+    forbidden_hints = [
+        ForbiddenHint(rule=hit.rule, hint=hit.hint, line=hit.line) for hit in hits
+    ]
+
+    try:
+        result = gemini_evaluate.evaluate_code(body.language, body.code)
+    except gemini_evaluate.GeminiUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+    return EvaluateResponse(
+        forbidden_hints=forbidden_hints,
+        big_o=result.big_o,
+        big_o_reason=result.big_o_reason,
+        duplicates=result.duplicates,
+    )

--- a/backend/services/forbidden.py
+++ b/backend/services/forbidden.py
@@ -1,0 +1,108 @@
+"""Soft forbidden-pattern checks for Evaluate (do not affect Sample Pass/Fail)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ForbiddenHit:
+    rule: str
+    hint: str
+    line: int | None
+
+
+# Preset A: contest-style coaching, not correctness.
+_RULES: dict[str, list[tuple[str, str, str]]] = {
+    # language -> list of (rule_id, regex, hint)
+    "*": [
+        (
+            "break",
+            r"\bbreak\b",
+            "Not a failure. Some courses and contests discourage break; try structured loops instead.",
+        ),
+    ],
+    "python": [
+        (
+            "builtin-sort",
+            r"\bsorted\s*\(|\.sort\s*\(",
+            "Not a failure. Contests often ban built-in sort so you practice implementing it yourself.",
+        ),
+    ],
+    "java": [
+        (
+            "builtin-sort",
+            r"\bArrays\s*\.\s*sort\s*\(|\bCollections\s*\.\s*sort\s*\(",
+            "Not a failure. Contests often ban built-in sort so you practice implementing it yourself.",
+        ),
+    ],
+    "c": [
+        (
+            "builtin-sort",
+            r"\bqsort\s*\(",
+            "Not a failure. Contests often ban library sort so you practice implementing it yourself.",
+        ),
+    ],
+    "cpp": [
+        (
+            "builtin-sort",
+            r"\bstd\s*::\s*sort\s*\(|\bsort\s*\(",
+            "Not a failure. Contests often ban std::sort so you practice implementing it yourself.",
+        ),
+        (
+            "stl-map",
+            r"\b(?:std\s*::\s*)?map\s*<",
+            "Not a failure. Some assignments disallow std::map; try arrays or your own structure.",
+        ),
+        (
+            "stl-set",
+            r"\b(?:std\s*::\s*)?set\s*<",
+            "Not a failure. Some assignments disallow std::set; try another approach.",
+        ),
+        (
+            "stl-priority-queue",
+            r"\b(?:std\s*::\s*)?priority_queue\s*<",
+            "Not a failure. Some assignments disallow priority_queue; try implementing a heap yourself.",
+        ),
+    ],
+    "javascript": [
+        (
+            "builtin-sort",
+            r"\.sort\s*\(",
+            "Not a failure. Contests often ban built-in sort so you practice implementing it yourself.",
+        ),
+    ],
+    "typescript": [
+        (
+            "builtin-sort",
+            r"\.sort\s*\(",
+            "Not a failure. Contests often ban built-in sort so you practice implementing it yourself.",
+        ),
+    ],
+}
+
+
+def _line_number(code: str, index: int) -> int:
+    return code.count("\n", 0, index) + 1
+
+
+def check_forbidden(code: str, language: str) -> list[ForbiddenHit]:
+    hits: list[ForbiddenHit] = []
+    seen: set[str] = set()
+    rules = list(_RULES.get("*", [])) + list(_RULES.get(language, []))
+    for rule_id, pattern, hint in rules:
+        if rule_id in seen:
+            continue
+        match = re.search(pattern, code)
+        if not match:
+            continue
+        seen.add(rule_id)
+        hits.append(
+            ForbiddenHit(
+                rule=rule_id,
+                hint=hint,
+                line=_line_number(code, match.start()),
+            )
+        )
+    return hits

--- a/backend/services/gemini_evaluate.py
+++ b/backend/services/gemini_evaluate.py
@@ -1,0 +1,138 @@
+"""Gemini Flash-Lite client for Solutions Evaluate."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+
+import httpx
+
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-3.5-flash-lite")
+GEMINI_TIMEOUT_SECONDS = float(os.getenv("GEMINI_TIMEOUT_SECONDS", "45"))
+
+SYSTEM_INSTRUCTION = """You are a programming coach for a competitive programming club.
+Analyze the student's code ONLY for:
+1) asymptotic time complexity (Big O)
+2) duplicated or near-duplicated logic
+
+Rules:
+- Do NOT provide the correct solution, algorithms to use, or step-by-step fixes.
+- Do NOT rewrite the student's code.
+- Do NOT mention test cases, expected output, or problem answers.
+- If unsure about Big O, pick the best estimate and say so briefly in big_o_reason.
+- Respond with JSON only matching the schema. No markdown.
+"""
+
+
+class GeminiUnavailableError(Exception):
+    """Raised when Gemini is not configured or the API call fails."""
+
+
+@dataclass(frozen=True)
+class GeminiEvaluation:
+    big_o: str
+    big_o_reason: str
+    duplicates: list[str]
+
+
+def _api_key() -> str:
+    key = (os.getenv("GEMINI_API_KEY") or "").strip()
+    if not key or key == "your-gemini-api-key":
+        raise GeminiUnavailableError("Evaluate service is not configured")
+    return key
+
+
+def _extract_json(text: str) -> dict:
+    raw = (text or "").strip()
+    if not raw:
+        raise GeminiUnavailableError("Evaluate service unavailable")
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+    match = re.search(r"\{.*\}", raw, flags=re.DOTALL)
+    if not match:
+        raise GeminiUnavailableError("Evaluate service unavailable")
+    data = json.loads(match.group(0))
+    if not isinstance(data, dict):
+        raise GeminiUnavailableError("Evaluate service unavailable")
+    return data
+
+
+def evaluate_code(language: str, code: str) -> GeminiEvaluation:
+    """Call Gemini and return Big O + duplication notes."""
+    api_key = _api_key()
+    url = (
+        f"https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{GEMINI_MODEL}:generateContent"
+    )
+    payload = {
+        "systemInstruction": {
+            "parts": [{"text": SYSTEM_INSTRUCTION}],
+        },
+        "contents": [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "text": (
+                            f"Language: {language}\n\nCode:\n```\n{code}\n```\n\n"
+                            "Return JSON with keys big_o (string), big_o_reason "
+                            "(one short sentence), duplicates (array of short notes; "
+                            "empty if none)."
+                        ),
+                    }
+                ],
+            }
+        ],
+        "generationConfig": {
+            "responseMimeType": "application/json",
+            "responseSchema": {
+                "type": "object",
+                "properties": {
+                    "big_o": {"type": "string"},
+                    "big_o_reason": {"type": "string"},
+                    "duplicates": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["big_o", "big_o_reason", "duplicates"],
+            },
+        },
+    }
+
+    try:
+        with httpx.Client(timeout=GEMINI_TIMEOUT_SECONDS) as client:
+            response = client.post(url, params={"key": api_key}, json=payload)
+    except httpx.TimeoutException as exc:
+        raise GeminiUnavailableError("Evaluate timed out") from exc
+    except httpx.HTTPError as exc:
+        raise GeminiUnavailableError("Evaluate service unavailable") from exc
+
+    if response.status_code == 429:
+        raise GeminiUnavailableError("Evaluate rate limited by provider")
+    if response.status_code >= 400:
+        raise GeminiUnavailableError("Evaluate service unavailable")
+
+    try:
+        body = response.json()
+        text = body["candidates"][0]["content"]["parts"][0]["text"]
+        data = _extract_json(text)
+    except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise GeminiUnavailableError("Evaluate service unavailable") from exc
+
+    duplicates_raw = data.get("duplicates") or []
+    if not isinstance(duplicates_raw, list):
+        duplicates_raw = []
+    duplicates = [str(item).strip() for item in duplicates_raw if str(item).strip()]
+
+    return GeminiEvaluation(
+        big_o=str(data.get("big_o") or "Unknown").strip() or "Unknown",
+        big_o_reason=str(data.get("big_o_reason") or "").strip(),
+        duplicates=duplicates,
+    )

--- a/backend/services/rate_limit.py
+++ b/backend/services/rate_limit.py
@@ -1,4 +1,4 @@
-"""Simple per-user daily rate limits for /execute.
+"""Simple per-user daily rate limits for /execute and /evaluate.
 
 In-memory counters reset on process restart. Fine for a single Heroku dyno MVP;
 replace with Redis/DB if we scale to multiple dynos.
@@ -12,39 +12,50 @@ from threading import Lock
 
 # Member may run code this many times per UTC day.
 DAILY_EXECUTE_LIMIT = int(os.getenv("EXECUTE_DAILY_LIMIT", "20"))
+DAILY_EVALUATE_LIMIT = int(os.getenv("EVALUATE_DAILY_LIMIT", "20"))
 
 _lock = Lock()
-# key: (user_id, YYYY-MM-DD) → count
-_counts: dict[tuple[str, str], int] = {}
+# key: (kind, user_id, YYYY-MM-DD) → count
+_counts: dict[tuple[str, str, str], int] = {}
 
 
 class DailyLimitExceededError(Exception):
-    """Raised when the user has no remaining daily execute quota."""
+    """Raised when the user has no remaining daily quota."""
 
 
 def _today_utc() -> str:
     return datetime.now(timezone.utc).date().isoformat()
 
 
-def check_and_increment(user_id: str, amount: int = 1) -> int:
-    """Increment the user's daily counter by ``amount``.
+def _limit_for(kind: str) -> int:
+    if kind == "evaluate":
+        return DAILY_EVALUATE_LIMIT
+    return DAILY_EXECUTE_LIMIT
+
+
+def check_and_increment(user_id: str, amount: int = 1, *, kind: str = "execute") -> int:
+    """Increment the user's daily counter by ``amount`` for ``kind``.
 
     Returns remaining quota after this call.
     Raises DailyLimitExceededError when the limit would be exceeded.
     """
     if amount < 1:
         raise ValueError("amount must be >= 1")
+    if kind not in ("execute", "evaluate"):
+        raise ValueError("kind must be execute or evaluate")
 
-    key = (user_id, _today_utc())
+    limit = _limit_for(kind)
+    key = (kind, user_id, _today_utc())
     with _lock:
         used = _counts.get(key, 0)
-        if used + amount > DAILY_EXECUTE_LIMIT:
+        if used + amount > limit:
+            label = "evaluate" if kind == "evaluate" else "execute"
             raise DailyLimitExceededError(
-                f"Daily execute limit of {DAILY_EXECUTE_LIMIT} reached"
+                f"Daily {label} limit of {limit} reached"
             )
         used += amount
         _counts[key] = used
-        return DAILY_EXECUTE_LIMIT - used
+        return limit - used
 
 
 def reset_for_tests() -> None:

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -432,3 +432,53 @@ def test_execute_samples_no_samples(authed_client, monkeypatch):
 
     assert response.status_code == 400
     assert response.json()["detail"] == "No sample tests configured for this problem"
+
+
+def test_forbidden_detects_python_sort():
+    from services.forbidden import check_forbidden
+
+    hits = check_forbidden("nums.sort()\nprint(nums)\n", "python")
+    assert any(h.rule == "builtin-sort" for h in hits)
+
+
+def test_evaluate_requires_samples_passed(authed_client, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    response = authed_client.post(
+        "/evaluate",
+        json={
+            "problem_id": 1,
+            "language": "python",
+            "code": "print(1)",
+            "samples_passed": False,
+        },
+    )
+    assert response.status_code == 400
+    assert "sample" in response.json()["detail"].lower()
+
+
+def test_evaluate_success(authed_client, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    mock_eval = MagicMock()
+    mock_eval.big_o = "O(n)"
+    mock_eval.big_o_reason = "Single loop."
+    mock_eval.duplicates = []
+
+    with patch(
+        "services.gemini_evaluate.evaluate_code",
+        return_value=mock_eval,
+    ):
+        response = authed_client.post(
+            "/evaluate",
+            json={
+                "problem_id": 1,
+                "language": "python",
+                "code": "for i in range(n):\n    break\n",
+                "samples_passed": True,
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["big_o"] == "O(n)"
+    assert any(h["rule"] == "break" for h in body["forbidden_hints"])

--- a/docs/design/page-specs/solutions.md
+++ b/docs/design/page-specs/solutions.md
@@ -148,26 +148,21 @@
 ### [▶ Run]
 ```
 Style: Primary — bg #C0392B, text white, radius 6px
-Action: Sends code to Piston API for execution
-        Shows Output panel below editor
-        Output: stdout, stderr, runtime
-        Running state: button shows spinner, disabled
+Action:
+  - If samples exist: run each sample via Judge0 → Pass/Fail vs expected
+  - If Custom input is filled: also run with that stdin → Custom output (raw, no Pass/Fail)
+  - If no samples and no custom: single run with empty stdin
+Docs link: language official docs (syntax help; no AI)
 ```
 
-### [✦ Evaluate] — ⚠️ P3 / Post-MVP (deferred from W3)
-> AI Evaluate is excluded from MVP scope. Run + Submit only for W3.
-> Tracked in GitHub issue #60.
+### [Evaluate] — #60
 ```
 Style: Secondary outline
-Action: Sends code to Gemma 4 API for evaluation
-        Returns two sections:
-          1. Forbidden Patterns — checklist per rule
-             ✅ rule name — "not used"
-             ❌ rule name — "detected — Line N"
-          2. Time Complexity
-             Estimated Big-O + Score out of 10
-        Does NOT reveal the answer or solution approach
-        Loading state: button shows spinner, disabled
+Enabled only when the latest Run has all samples Pass
+Action: soft forbidden regex hints + Gemini 3.5 Flash-Lite (Big O + duplication)
+Forbidden hints are NOT failures ("contests often disallow… try another approach")
+Does NOT reveal the answer or rewrite the solution
+No AI syntax hints (use stderr + Docs)
 ```
 
 ### [⬆ Submit]
@@ -183,16 +178,10 @@ Action: Saves current editor code as member's official submission
 
 ## Evaluation Rules Config
 ```
-Forbidden patterns are configurable per problem (not global).
-Admin sets rules when creating a problem.
-Examples:
-  - break statement
-  - STL containers (map, set, sort, etc.)
-  - built-in sort functions
-  - recursion (if iterative solution required)
-
-Gemma 4 receives: { code, language, forbidden_rules[] }
-Returns: { patterns: [{rule, detected, line}], complexity: {big_o, score} }
+MVP: global soft-forbidden preset (break, builtin sort, C++ map/set/priority_queue).
+Per-problem toggles: later (#31).
+Gemini receives: { code, language } only (no problem statement / answers).
+Returns: { forbidden_hints[], big_o, big_o_reason, duplicates[] }
 ```
 
 ---

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -661,12 +661,12 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
         <p className="text-sm font-inter text-accent">{fileError}</p>
       )}
 
-      <div className="border border-border rounded-md bg-bg-base p-4 space-y-4">
+      <div className="border border-border rounded-md bg-bg-base p-4 space-y-3">
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="font-inter text-sm font-medium text-text-primary">Sample tests</p>
             <p className="font-inter text-xs text-text-secondary mt-1">
-              Used when members click Run on Solutions. Start with one pair; add up to {MAX_SAMPLE_TESTS}.
+              Used on Solutions Run. Up to {MAX_SAMPLE_TESTS} pairs.
             </p>
           </div>
           <button
@@ -685,9 +685,9 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
         </div>
 
         {(form.sampleTests?.length ? form.sampleTests : [emptySamplePair()]).map((sample, index) => (
-          <div key={index} className="space-y-2 border-t border-border pt-4 first:border-t-0 first:pt-0">
+          <div key={index} className="space-y-2 border-t border-border pt-3 first:border-t-0 first:pt-0">
             <div className="flex items-center justify-between gap-2">
-              <p className="font-inter text-sm font-medium text-text-primary">
+              <p className="font-inter text-xs font-medium text-text-secondary">
                 Sample
                 {' '}
                 {index + 1}
@@ -711,42 +711,30 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
                 </button>
               )}
             </div>
-            <label className="block space-y-1">
-              <span className="font-inter text-xs text-text-secondary">
-                Sample Input
-                {' '}
-                {index + 1}
-              </span>
-              <textarea
-                value={sample.stdin}
-                onChange={(e) => onChange((prev) => {
-                  const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
-                  next[index] = { ...next[index], stdin: e.target.value }
-                  return { ...prev, sampleTests: next }
-                })}
-                rows={3}
-                spellCheck={false}
-                className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
-              />
-            </label>
-            <label className="block space-y-1">
-              <span className="font-inter text-xs text-text-secondary">
-                Sample Output
-                {' '}
-                {index + 1}
-              </span>
-              <textarea
-                value={sample.expected_stdout}
-                onChange={(e) => onChange((prev) => {
-                  const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
-                  next[index] = { ...next[index], expected_stdout: e.target.value }
-                  return { ...prev, sampleTests: next }
-                })}
-                rows={3}
-                spellCheck={false}
-                className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
-              />
-            </label>
+            <input
+              type="text"
+              value={sample.stdin}
+              onChange={(e) => onChange((prev) => {
+                const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
+                next[index] = { ...next[index], stdin: e.target.value }
+                return { ...prev, sampleTests: next }
+              })}
+              spellCheck={false}
+              placeholder={`Sample Input ${index + 1}`}
+              className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+            />
+            <input
+              type="text"
+              value={sample.expected_stdout}
+              onChange={(e) => onChange((prev) => {
+                const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
+                next[index] = { ...next[index], expected_stdout: e.target.value }
+                return { ...prev, sampleTests: next }
+              })}
+              spellCheck={false}
+              placeholder={`Sample Output ${index + 1}`}
+              className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+            />
           </div>
         ))}
       </div>

--- a/src/app/solutions/[id]/page.js
+++ b/src/app/solutions/[id]/page.js
@@ -4,23 +4,24 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { ChevronDown, ChevronUp, Columns2, Loader2, Rows2 } from 'lucide-react'
+import { BookOpen, ChevronDown, ChevronUp, Columns2, Loader2, Rows2 } from 'lucide-react'
 import RoleGuard from '@/components/auth/RoleGuard'
 import { useAuth } from '@/hooks/useAuth'
 import { ProblemBody } from '@/app/problems/_shared'
-import { fetchProblemById } from '@/services/problemsService'
+import { fetchProblemById, normalizeSampleTests } from '@/services/problemsService'
 import {
   fetchCommunitySubmissions,
   fetchOwnSubmission,
 } from '@/services/submissionsService'
 import {
+  LANGUAGE_DOCS,
   SOLUTION_LANGUAGES,
+  evaluateSolution,
   executeCode,
   executeSamples,
   languageLabel,
   submitSolution,
 } from '@/services/solutionService'
-import { normalizeSampleTests } from '@/services/problemsService'
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), { ssr: false })
 
@@ -76,6 +77,10 @@ function SolutionWorkspace() {
   const [language, setLanguage] = useState('python')
   const [code, setCode] = useState(STARTER.python)
   const [output, setOutput] = useState(null)
+  const [customInput, setCustomInput] = useState('')
+  const [samplesAllPassed, setSamplesAllPassed] = useState(false)
+  const [evaluation, setEvaluation] = useState(null)
+  const [evaluating, setEvaluating] = useState(false)
   const [running, setRunning] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [statusMessage, setStatusMessage] = useState('')
@@ -185,6 +190,8 @@ function SolutionWorkspace() {
   }
   function handleLanguageChange(next) {
     setLanguage(next)
+    setSamplesAllPassed(false)
+    setEvaluation(null)
     setCode((prev) => {
       const isStarter = Object.values(STARTER).includes(prev)
       if (!prev.trim() || isStarter) return STARTER[next] || ''
@@ -195,10 +202,16 @@ function SolutionWorkspace() {
   async function handleRun() {
     setStatusMessage('')
     setError('')
+    setEvaluation(null)
+    setSamplesAllPassed(false)
     setRunning(true)
     setOutput({ pending: true })
     try {
       const samples = normalizeSampleTests(problem?.sample_tests)
+      const hasCustom = customInput.trim() !== ''
+      let sampleBlock = null
+      let customBlock = null
+
       if (samples.length > 0) {
         const result = await executeSamples({
           accessToken,
@@ -206,18 +219,37 @@ function SolutionWorkspace() {
           language,
           code,
         })
-        setOutput({
-          pending: false,
-          mode: 'samples',
+        sampleBlock = {
           passed: result.passed,
           total: result.total,
           results: result.results || [],
-        })
-      } else {
+        }
+        setSamplesAllPassed(
+          result.total > 0 && result.passed === result.total,
+        )
+      }
+
+      if (hasCustom) {
         const result = await executeCode({
           accessToken,
           language,
           code,
+          stdin: customInput,
+        })
+        customBlock = {
+          stdout: result.stdout || '',
+          stderr: result.stderr || '',
+          runtime: result.runtime,
+          exitCode: result.exit_code,
+        }
+      }
+
+      if (!sampleBlock && !customBlock) {
+        const result = await executeCode({
+          accessToken,
+          language,
+          code,
+          stdin: '',
         })
         setOutput({
           pending: false,
@@ -227,12 +259,50 @@ function SolutionWorkspace() {
           runtime: result.runtime,
           exitCode: result.exit_code,
         })
+        return
       }
+
+      setOutput({
+        pending: false,
+        mode: sampleBlock ? 'samples' : 'custom',
+        samples: sampleBlock,
+        custom: customBlock,
+        // legacy fields for samples-only rendering helpers
+        passed: sampleBlock?.passed,
+        total: sampleBlock?.total,
+        results: sampleBlock?.results,
+      })
     } catch (err) {
       setOutput(null)
+      setSamplesAllPassed(false)
       setError(err.message || 'Run failed')
     } finally {
       setRunning(false)
+    }
+  }
+
+  async function handleEvaluate() {
+    setStatusMessage('')
+    setError('')
+    if (!samplesAllPassed) {
+      setError('All sample tests must pass before Evaluate')
+      return
+    }
+    setEvaluating(true)
+    setEvaluation(null)
+    try {
+      const result = await evaluateSolution({
+        accessToken,
+        problemId,
+        language,
+        code,
+        samplesPassed: true,
+      })
+      setEvaluation(result)
+    } catch (err) {
+      setError(err.message || 'Evaluate failed')
+    } finally {
+      setEvaluating(false)
     }
   }
 
@@ -457,7 +527,11 @@ function SolutionWorkspace() {
                     language={monacoLanguage}
                     theme="vs-dark"
                     value={code}
-                    onChange={(value) => setCode(value ?? '')}
+                    onChange={(value) => {
+                      setCode(value ?? '')
+                      setSamplesAllPassed(false)
+                      setEvaluation(null)
+                    }}
                     options={{
                       minimap: { enabled: false },
                       fontSize: 14,
@@ -468,7 +542,21 @@ function SolutionWorkspace() {
                   />
                 </div>
 
-                <div className="flex flex-col sm:flex-row gap-3 shrink-0">
+                <label className="block shrink-0 space-y-1">
+                  <span className="font-inter text-xs text-text-secondary">
+                    Custom input (optional)
+                  </span>
+                  <textarea
+                    value={customInput}
+                    onChange={(e) => setCustomInput(e.target.value)}
+                    rows={3}
+                    spellCheck={false}
+                    placeholder="Leave empty to check samples only. If filled, also runs with this stdin (raw output, no Pass/Fail)."
+                    className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+                  />
+                </label>
+
+                <div className="flex flex-col sm:flex-row gap-3 shrink-0 flex-wrap">
                   <button
                     type="button"
                     onClick={handleRun}
@@ -480,11 +568,17 @@ function SolutionWorkspace() {
                   </button>
                   <button
                     type="button"
-                    disabled
-                    title="Evaluate is deferred to a later release"
-                    className="inline-flex items-center justify-center rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-hint cursor-not-allowed"
+                    onClick={handleEvaluate}
+                    disabled={evaluating || !accessToken || !samplesAllPassed}
+                    title={
+                      samplesAllPassed
+                        ? 'Quality feedback after all samples pass'
+                        : 'All sample tests must pass before Evaluate'
+                    }
+                    className="inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-primary hover:bg-bg-surface disabled:opacity-60 disabled:cursor-not-allowed"
                   >
-                    Evaluate
+                    {evaluating && <Loader2 size={16} className="animate-spin" />}
+                    {evaluating ? 'Evaluating…' : 'Evaluate'}
                   </button>
                   <button
                     type="button"
@@ -495,28 +589,39 @@ function SolutionWorkspace() {
                     {submitting && <Loader2 size={16} className="animate-spin" />}
                     {submitting ? 'Submitting…' : 'Submit'}
                   </button>
+                  {LANGUAGE_DOCS[language] && (
+                    <a
+                      href={LANGUAGE_DOCS[language].href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-secondary hover:bg-bg-surface"
+                    >
+                      <BookOpen size={16} />
+                      Docs
+                    </a>
+                  )}
                 </div>
 
                 {output && (
-                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-64 overflow-y-auto">
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-72 overflow-y-auto space-y-4">
                     {output.pending && (
                       <>
                         <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
                         <pre className="font-mono text-[13px] text-text-primary">{'> Running...\n'}</pre>
                       </>
                     )}
-                    {!output.pending && output.mode === 'samples' && (
+                    {!output.pending && output.samples && (
                       <div className="space-y-3">
                         <p className="font-inter text-sm font-medium text-text-primary">
                           Samples
                           {' '}
-                          {output.passed}
+                          {output.samples.passed}
                           /
-                          {output.total}
+                          {output.samples.total}
                           {' '}
                           passed
                         </p>
-                        {(output.results || []).map((row) => (
+                        {(output.samples.results || []).map((row) => (
                           <div key={row.index} className="border border-border rounded-md bg-bg-base p-3 space-y-1">
                             <p className={`font-inter text-sm font-medium ${
                               row.passed ? 'text-success' : 'text-accent'
@@ -546,7 +651,25 @@ function SolutionWorkspace() {
                         ))}
                       </div>
                     )}
-                    {!output.pending && output.mode !== 'samples' && (
+                    {!output.pending && output.custom && (
+                      <div className="space-y-2">
+                        <p className="font-inter text-sm font-medium text-text-primary">
+                          Custom output
+                        </p>
+                        <p className="font-inter text-xs text-text-secondary">
+                          Experimental run only (no Pass/Fail).
+                        </p>
+                        <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words bg-bg-base border border-border rounded-md p-3">
+                          {output.custom.stdout ? `${output.custom.stdout}` : ''}
+                          {output.custom.stderr ? `\n${output.custom.stderr}` : ''}
+                          {typeof output.custom.runtime === 'number'
+                            ? `\nRuntime: ${output.custom.runtime}s`
+                            : ''}
+                          {!output.custom.stdout && !output.custom.stderr ? '(empty)' : ''}
+                        </pre>
+                      </div>
+                    )}
+                    {!output.pending && output.mode === 'raw' && (
                       <>
                         <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
                         <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
@@ -556,8 +679,69 @@ function SolutionWorkspace() {
                             ? `\nRuntime: ${output.runtime}s`
                             : ''}
                         </pre>
+                        {output.stderr && (
+                          <p className="font-inter text-xs text-text-secondary mt-2">
+                            Use the error message and Docs to fix syntax or runtime issues.
+                          </p>
+                        )}
                       </>
                     )}
+                  </div>
+                )}
+
+                {evaluation && (
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-72 overflow-y-auto space-y-4 border border-border">
+                    <p className="font-inter text-sm font-medium text-text-primary">Evaluation</p>
+                    {(evaluation.forbidden_hints || []).length > 0 && (
+                      <div className="space-y-2">
+                        <p className="font-inter text-xs font-medium text-text-secondary uppercase tracking-wide">
+                          Style hints (not failures)
+                        </p>
+                        {evaluation.forbidden_hints.map((hint) => (
+                          <div
+                            key={`${hint.rule}-${hint.line}`}
+                            className="rounded-md border border-border bg-bg-base p-3"
+                          >
+                            <p className="font-inter text-sm text-text-primary">
+                              {hint.rule}
+                              {hint.line != null ? ` (line ${hint.line})` : ''}
+                            </p>
+                            <p className="font-inter text-xs text-text-secondary mt-1">
+                              {hint.hint}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div>
+                      <p className="font-inter text-xs font-medium text-text-secondary uppercase tracking-wide mb-1">
+                        Big O (estimate)
+                      </p>
+                      <p className="font-inter text-sm font-medium text-text-primary">
+                        {evaluation.big_o}
+                      </p>
+                      {evaluation.big_o_reason && (
+                        <p className="font-inter text-xs text-text-secondary mt-1">
+                          {evaluation.big_o_reason}
+                        </p>
+                      )}
+                    </div>
+                    <div>
+                      <p className="font-inter text-xs font-medium text-text-secondary uppercase tracking-wide mb-1">
+                        Duplication
+                      </p>
+                      {(evaluation.duplicates || []).length === 0 ? (
+                        <p className="font-inter text-sm text-text-secondary">None noted.</p>
+                      ) : (
+                        <ul className="list-disc pl-5 space-y-1">
+                          {evaluation.duplicates.map((note) => (
+                            <li key={note} className="font-inter text-sm text-text-primary">
+                              {note}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/app/solutions/[id]/page.js
+++ b/src/app/solutions/[id]/page.js
@@ -26,18 +26,23 @@ import {
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), { ssr: false })
 
 const STARTER = {
-  python: 'def solution():\n    pass\n',
-  java: 'public class Main {\n    public static void main(String[] args) {\n        \n    }\n}\n',
-  c: '#include <stdio.h>\n\nint main(void) {\n    return 0;\n}\n',
-  cpp: '#include <iostream>\nusing namespace std;\n\nint main() {\n    return 0;\n}\n',
-  javascript: 'function solution() {\n  \n}\n',
-  typescript: 'function solution(): void {\n  \n}\n',
+  python: 'a, b = map(int, input().split())\n',
+  java: 'import java.util.Scanner;\n\npublic class Main {\n    public static void main(String[] args) {\n        Scanner sc = new Scanner(System.in);\n        int a = sc.nextInt();\n        int b = sc.nextInt();\n    }\n}\n',
+  c: '#include <stdio.h>\n\nint main(void) {\n    int a, b;\n    if (scanf("%d %d", &a, &b) != 2) return 1;\n    return 0;\n}\n',
+  cpp: '#include <iostream>\nusing namespace std;\n\nint main() {\n    int a, b;\n    if (!(cin >> a >> b)) return 1;\n    return 0;\n}\n',
+  javascript: 'const fs = require("fs");\nconst [a, b] = fs.readFileSync(0, "utf8").trim().split(/\\s+/).map(Number);\n',
+  typescript: 'const fs = require("fs");\nconst [a, b] = fs.readFileSync(0, "utf8").trim().split(/\\s+/).map(Number);\n',
 }
 
 const PROBLEM_SIZE_MIN = 22
 const PROBLEM_SIZE_MAX = 78
+const STACK_PROBLEM_VH_MIN = 18
+const STACK_PROBLEM_VH_MAX = 45
 
-function clampProblemSize(value) {
+function clampProblemSize(value, layout = 'split') {
+  if (layout === 'stack') {
+    return Math.min(STACK_PROBLEM_VH_MAX, Math.max(STACK_PROBLEM_VH_MIN, value))
+  }
   return Math.min(PROBLEM_SIZE_MAX, Math.max(PROBLEM_SIZE_MIN, value))
 }
 
@@ -78,7 +83,6 @@ function SolutionWorkspace() {
   const [code, setCode] = useState(STARTER.python)
   const [output, setOutput] = useState(null)
   const [customInput, setCustomInput] = useState('')
-  const [samplesAllPassed, setSamplesAllPassed] = useState(false)
   const [evaluation, setEvaluation] = useState(null)
   const [evaluating, setEvaluating] = useState(false)
   const [running, setRunning] = useState(false)
@@ -91,7 +95,7 @@ function SolutionWorkspace() {
   const [communityLoading, setCommunityLoading] = useState(false)
   const [problemOpen, setProblemOpen] = useState(true)
   const [layout, setLayout] = useState('split') // 'split' | 'stack'
-  const [problemSize, setProblemSize] = useState(48) // percent of workspace
+  const [problemSize, setProblemSize] = useState(36) // split: width %, stack: problem vh
   const workspaceRef = useRef(null)
   const draggingRef = useRef(false)
 
@@ -99,6 +103,20 @@ function SolutionWorkspace() {
     () => SOLUTION_LANGUAGES.find((l) => l.value === language)?.monaco || 'python',
     [language],
   )
+
+  const samplesAllPassed = Boolean(
+    output
+    && !output.pending
+    && output.samples
+    && Number(output.samples.total) > 0
+    && Number(output.samples.passed) === Number(output.samples.total),
+  )
+
+  const evaluateDisabledReason = !accessToken
+    ? 'Sign in to evaluate'
+    : !samplesAllPassed
+      ? 'All sample tests must pass before Evaluate'
+      : ''
 
   useEffect(() => {
     let cancelled = false
@@ -160,10 +178,11 @@ function SolutionWorkspace() {
       const rect = workspaceRef.current.getBoundingClientRect()
       if (layout === 'split') {
         const next = ((event.clientX - rect.left) / rect.width) * 100
-        setProblemSize(clampProblemSize(next))
+        setProblemSize(clampProblemSize(next, 'split'))
       } else {
-        const next = ((event.clientY - rect.top) / rect.height) * 100
-        setProblemSize(clampProblemSize(next))
+        // Stack: problem height as vh so the rest of the page can scroll naturally.
+        const next = ((event.clientY - rect.top) / window.innerHeight) * 100
+        setProblemSize(clampProblemSize(next, 'stack'))
       }
     }
 
@@ -190,8 +209,8 @@ function SolutionWorkspace() {
   }
   function handleLanguageChange(next) {
     setLanguage(next)
-    setSamplesAllPassed(false)
     setEvaluation(null)
+    setOutput(null)
     setCode((prev) => {
       const isStarter = Object.values(STARTER).includes(prev)
       if (!prev.trim() || isStarter) return STARTER[next] || ''
@@ -203,7 +222,6 @@ function SolutionWorkspace() {
     setStatusMessage('')
     setError('')
     setEvaluation(null)
-    setSamplesAllPassed(false)
     setRunning(true)
     setOutput({ pending: true })
     try {
@@ -220,13 +238,10 @@ function SolutionWorkspace() {
           code,
         })
         sampleBlock = {
-          passed: result.passed,
-          total: result.total,
+          passed: Number(result.passed) || 0,
+          total: Number(result.total) || 0,
           results: result.results || [],
         }
-        setSamplesAllPassed(
-          result.total > 0 && result.passed === result.total,
-        )
       }
 
       if (hasCustom) {
@@ -267,15 +282,19 @@ function SolutionWorkspace() {
         mode: sampleBlock ? 'samples' : 'custom',
         samples: sampleBlock,
         custom: customBlock,
-        // legacy fields for samples-only rendering helpers
         passed: sampleBlock?.passed,
         total: sampleBlock?.total,
         results: sampleBlock?.results,
       })
     } catch (err) {
+      const message = err.message || 'Run failed'
       setOutput(null)
-      setSamplesAllPassed(false)
-      setError(err.message || 'Run failed')
+      if (/daily .+ limit/i.test(message)) {
+        window.alert(message)
+        setError('')
+      } else {
+        setError(message)
+      }
     } finally {
       setRunning(false)
     }
@@ -300,7 +319,13 @@ function SolutionWorkspace() {
       })
       setEvaluation(result)
     } catch (err) {
-      setError(err.message || 'Evaluate failed')
+      const message = err.message || 'Evaluate failed'
+      if (/daily .+ limit/i.test(message)) {
+        window.alert(message)
+        setError('')
+      } else {
+        setError(message)
+      }
     } finally {
       setEvaluating(false)
     }
@@ -398,7 +423,7 @@ function SolutionWorkspace() {
         </div>
       </div>
 
-      <section className="max-w-[1400px] mx-auto px-4 sm:px-6 py-8 pb-16">
+      <section className="max-w-[1400px] mx-auto px-4 sm:px-6 py-8 pb-24">
         {error && (
           <p className="font-inter text-sm text-accent mb-4">{error}</p>
         )}
@@ -421,7 +446,10 @@ function SolutionWorkspace() {
                 <div className="inline-flex rounded-md border border-border overflow-hidden">
                   <button
                     type="button"
-                    onClick={() => setLayout('stack')}
+                    onClick={() => {
+                      setLayout('stack')
+                      setProblemSize((size) => clampProblemSize(size, 'stack'))
+                    }}
                     title="Stack vertically"
                     className={`inline-flex items-center gap-1.5 px-3 py-1.5 font-inter text-sm ${
                       layout === 'stack'
@@ -434,7 +462,10 @@ function SolutionWorkspace() {
                   </button>
                   <button
                     type="button"
-                    onClick={() => setLayout('split')}
+                    onClick={() => {
+                      setLayout('split')
+                      setProblemSize((size) => clampProblemSize(size, 'split'))
+                    }}
                     title="Side by side"
                     className={`inline-flex items-center gap-1.5 px-3 py-1.5 font-inter text-sm border-l border-border ${
                       layout === 'split'
@@ -463,11 +494,11 @@ function SolutionWorkspace() {
 
             <div
               ref={workspaceRef}
-              className={`min-h-[560px] h-[calc(100vh-260px)] ${
+              className={
                 problemOpen && layout === 'split'
-                  ? 'flex flex-row'
+                  ? 'min-h-[560px] h-[calc(100vh-260px)] overflow-hidden flex flex-row'
                   : 'flex flex-col'
-              }`}
+              }
             >
               {problemOpen && (
                 <>
@@ -476,7 +507,10 @@ function SolutionWorkspace() {
                     style={
                       layout === 'split'
                         ? { width: `${problemSize}%`, flexShrink: 0 }
-                        : { height: `${problemSize}%`, flexShrink: 0 }
+                        : {
+                          height: `${clampProblemSize(problemSize, 'stack')}vh`,
+                          flexShrink: 0,
+                        }
                     }
                   >
                     <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-bg-surface shrink-0">
@@ -520,17 +554,32 @@ function SolutionWorkspace() {
                 </>
               )}
 
-              <div className="flex-1 min-w-0 min-h-0 flex flex-col gap-3">
-                <div className="border border-border rounded-md overflow-hidden bg-white flex-1 min-h-[200px]">
+              <div
+                className={
+                  layout === 'split'
+                    ? 'flex-1 min-w-0 min-h-0 flex flex-col gap-3 overflow-y-auto'
+                    : 'w-full flex flex-col gap-3'
+                }
+              >
+                <div
+                  className={
+                    layout === 'split'
+                      ? 'border border-border rounded-md overflow-hidden bg-white flex-1 min-h-[200px]'
+                      : 'border border-border rounded-md overflow-hidden bg-white h-[360px] shrink-0'
+                  }
+                >
                   <MonacoEditor
                     height="100%"
                     language={monacoLanguage}
                     theme="vs-dark"
                     value={code}
                     onChange={(value) => {
-                      setCode(value ?? '')
-                      setSamplesAllPassed(false)
-                      setEvaluation(null)
+                      const next = value ?? ''
+                      if (next !== code) {
+                        setEvaluation(null)
+                        setOutput(null)
+                      }
+                      setCode(next)
                     }}
                     options={{
                       minimap: { enabled: false },
@@ -544,14 +593,14 @@ function SolutionWorkspace() {
 
                 <label className="block shrink-0 space-y-1">
                   <span className="font-inter text-xs text-text-secondary">
-                    Custom input (optional)
+                    Custom input
                   </span>
-                  <textarea
+                  <input
+                    type="text"
                     value={customInput}
                     onChange={(e) => setCustomInput(e.target.value)}
-                    rows={3}
                     spellCheck={false}
-                    placeholder="Leave empty to check samples only. If filled, also runs with this stdin (raw output, no Pass/Fail)."
+                    placeholder="Optional stdin for a raw run"
                     className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
                   />
                 </label>
@@ -566,20 +615,27 @@ function SolutionWorkspace() {
                     {running && <Loader2 size={16} className="animate-spin" />}
                     {running ? 'Running…' : 'Run'}
                   </button>
-                  <button
-                    type="button"
-                    onClick={handleEvaluate}
-                    disabled={evaluating || !accessToken || !samplesAllPassed}
-                    title={
-                      samplesAllPassed
-                        ? 'Quality feedback after all samples pass'
-                        : 'All sample tests must pass before Evaluate'
-                    }
-                    className="inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-primary hover:bg-bg-surface disabled:opacity-60 disabled:cursor-not-allowed"
-                  >
-                    {evaluating && <Loader2 size={16} className="animate-spin" />}
-                    {evaluating ? 'Evaluating…' : 'Evaluate'}
-                  </button>
+                  <span className="relative inline-flex group">
+                    <button
+                      type="button"
+                      onClick={handleEvaluate}
+                      disabled={evaluating || !accessToken || !samplesAllPassed}
+                      className={`inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-primary hover:bg-bg-surface disabled:opacity-60 disabled:cursor-not-allowed${
+                        evaluateDisabledReason ? ' pointer-events-none' : ''
+                      }`}
+                    >
+                      {evaluating && <Loader2 size={16} className="animate-spin" />}
+                      {evaluating ? 'Evaluating…' : 'Evaluate'}
+                    </button>
+                    {evaluateDisabledReason && (
+                      <span
+                        role="tooltip"
+                        className="pointer-events-none absolute left-0 top-full z-30 mt-1.5 max-w-[min(280px,70vw)] rounded-md bg-bg-elevated px-2.5 py-1.5 font-inter text-xs text-bg-base opacity-0 group-hover:opacity-100"
+                      >
+                        {evaluateDisabledReason}
+                      </span>
+                    )}
+                  </span>
                   <button
                     type="button"
                     onClick={handleSubmit}
@@ -602,95 +658,8 @@ function SolutionWorkspace() {
                   )}
                 </div>
 
-                {output && (
-                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-72 overflow-y-auto space-y-4">
-                    {output.pending && (
-                      <>
-                        <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
-                        <pre className="font-mono text-[13px] text-text-primary">{'> Running...\n'}</pre>
-                      </>
-                    )}
-                    {!output.pending && output.samples && (
-                      <div className="space-y-3">
-                        <p className="font-inter text-sm font-medium text-text-primary">
-                          Samples
-                          {' '}
-                          {output.samples.passed}
-                          /
-                          {output.samples.total}
-                          {' '}
-                          passed
-                        </p>
-                        {(output.samples.results || []).map((row) => (
-                          <div key={row.index} className="border border-border rounded-md bg-bg-base p-3 space-y-1">
-                            <p className={`font-inter text-sm font-medium ${
-                              row.passed ? 'text-success' : 'text-accent'
-                            }`}
-                            >
-                              Sample
-                              {' '}
-                              {row.index}
-                              {': '}
-                              {row.passed ? 'Pass' : 'Fail'}
-                            </p>
-                            {!row.passed && (
-                              <pre className="font-mono text-[12px] text-text-primary whitespace-pre-wrap break-words">
-                                {`expected:\n${row.expected_stdout || '(empty)'}\n\ngot:\n${row.stdout || '(empty)'}`}
-                                {row.stderr ? `\n\nstderr:\n${row.stderr}` : ''}
-                              </pre>
-                            )}
-                            {row.passed && typeof row.runtime === 'number' && (
-                              <p className="font-inter text-xs text-text-secondary">
-                                Runtime:
-                                {' '}
-                                {row.runtime}
-                                s
-                              </p>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                    {!output.pending && output.custom && (
-                      <div className="space-y-2">
-                        <p className="font-inter text-sm font-medium text-text-primary">
-                          Custom output
-                        </p>
-                        <p className="font-inter text-xs text-text-secondary">
-                          Experimental run only (no Pass/Fail).
-                        </p>
-                        <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words bg-bg-base border border-border rounded-md p-3">
-                          {output.custom.stdout ? `${output.custom.stdout}` : ''}
-                          {output.custom.stderr ? `\n${output.custom.stderr}` : ''}
-                          {typeof output.custom.runtime === 'number'
-                            ? `\nRuntime: ${output.custom.runtime}s`
-                            : ''}
-                          {!output.custom.stdout && !output.custom.stderr ? '(empty)' : ''}
-                        </pre>
-                      </div>
-                    )}
-                    {!output.pending && output.mode === 'raw' && (
-                      <>
-                        <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
-                        <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
-                          {output.stdout ? `${output.stdout}` : ''}
-                          {output.stderr ? `\n${output.stderr}` : ''}
-                          {typeof output.runtime === 'number'
-                            ? `\nRuntime: ${output.runtime}s`
-                            : ''}
-                        </pre>
-                        {output.stderr && (
-                          <p className="font-inter text-xs text-text-secondary mt-2">
-                            Use the error message and Docs to fix syntax or runtime issues.
-                          </p>
-                        )}
-                      </>
-                    )}
-                  </div>
-                )}
-
                 {evaluation && (
-                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-72 overflow-y-auto space-y-4 border border-border">
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 space-y-4 border border-border">
                     <p className="font-inter text-sm font-medium text-text-primary">Evaluation</p>
                     {(evaluation.forbidden_hints || []).length > 0 && (
                       <div className="space-y-2">
@@ -742,6 +711,95 @@ function SolutionWorkspace() {
                         </ul>
                       )}
                     </div>
+                  </div>
+                )}
+
+                {output && (
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 space-y-4">
+                    {output.pending && (
+                      <>
+                        <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
+                        <pre className="font-mono text-[13px] text-text-primary">{'> Running...\n'}</pre>
+                      </>
+                    )}
+                    {!output.pending && output.samples && (
+                      <div className="space-y-3">
+                        <p className="font-inter text-sm font-medium text-text-primary">
+                          Samples
+                          {' '}
+                          {output.samples.passed}
+                          /
+                          {output.samples.total}
+                          {' '}
+                          passed
+                        </p>
+                        {(output.samples.results || []).map((row) => {
+                          const stdin = (row.stdin ?? '').trim() || '(empty)'
+                          const got = (row.stdout ?? '').trim() || '(empty)'
+                          const expected = (row.expected_stdout ?? '').trim() || '(empty)'
+                          return (
+                            <div key={row.index} className="border border-border rounded-md bg-bg-base p-3 space-y-1">
+                              <p className={`font-inter text-sm font-medium ${
+                                row.passed ? 'text-success' : 'text-accent'
+                              }`}
+                              >
+                                Sample
+                                {' '}
+                                {row.index}
+                                {': '}
+                                {row.passed ? 'Pass' : 'Fail'}
+                              </p>
+                              <pre className="font-mono text-[12px] text-text-secondary whitespace-pre-wrap break-words">
+                                {`in:  ${stdin}\nout: ${got}`}
+                                {!row.passed ? `\nexp: ${expected}` : ''}
+                                {!row.passed && row.stderr ? `\nerr: ${row.stderr}` : ''}
+                              </pre>
+                              {typeof row.runtime === 'number' && (
+                                <p className="font-inter text-xs text-text-hint">
+                                  {row.runtime}
+                                  s
+                                </p>
+                              )}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
+                    {!output.pending && output.custom && (
+                      <div className="space-y-2">
+                        <p className="font-inter text-sm font-medium text-text-primary">
+                          Custom output
+                        </p>
+                        <p className="font-inter text-xs text-text-secondary">
+                          Experimental run only (no Pass/Fail).
+                        </p>
+                        <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words bg-bg-base border border-border rounded-md p-3">
+                          {output.custom.stdout ? `${output.custom.stdout}` : ''}
+                          {output.custom.stderr ? `\n${output.custom.stderr}` : ''}
+                          {typeof output.custom.runtime === 'number'
+                            ? `\nRuntime: ${output.custom.runtime}s`
+                            : ''}
+                          {!output.custom.stdout && !output.custom.stderr ? '(empty)' : ''}
+                        </pre>
+                      </div>
+                    )}
+                    {!output.pending && output.mode === 'raw' && (
+                      <>
+                        <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
+                        <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
+                          {output.stdout ? `${output.stdout}` : ''}
+                          {output.stderr ? `\n${output.stderr}` : ''}
+                          {typeof output.runtime === 'number'
+                            ? `\nRuntime: ${output.runtime}s`
+                            : ''}
+                        </pre>
+                        {output.stderr && (
+                          <p className="font-inter text-xs text-text-secondary mt-2">
+                            Use the error message and Docs to fix syntax or runtime issues.
+                          </p>
+                        )}
+                      </>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -265,16 +265,16 @@ export default function Navbar() {
             {socialIconsRow}
             <div className="w-px h-5 bg-border mx-1" />
             {user ? (
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1.5 xl:gap-2 shrink-0">
                 <Link href={profileHref}><UserChip user={user} profile={profile} /></Link>
                 <button type="button" onClick={signOut}
-                  className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
+                  className="shrink-0 whitespace-nowrap px-2.5 xl:px-4 py-1.5 rounded-md text-xs xl:text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
                   Log out
                 </button>
               </div>
             ) : (
               <button type="button" onClick={handleLogIn} disabled={loggingIn}
-                className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed">
+                className="shrink-0 whitespace-nowrap px-2.5 xl:px-4 py-1.5 rounded-md text-xs xl:text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed">
                 {loggingIn ? 'Redirecting…' : 'Get Started'}
               </button>
             )}

--- a/src/services/solutionService.js
+++ b/src/services/solutionService.js
@@ -33,6 +33,53 @@ export async function executeSamples({ accessToken, problemId, language, code })
   })
 }
 
+export async function evaluateSolution({
+  accessToken,
+  problemId,
+  language,
+  code,
+  samplesPassed,
+}) {
+  return backendFetch('/evaluate', {
+    accessToken,
+    method: 'POST',
+    body: {
+      problem_id: problemId,
+      language,
+      code,
+      samples_passed: samplesPassed,
+    },
+  })
+}
+
+/** Official docs for syntax help (no AI). */
+export const LANGUAGE_DOCS = {
+  python: {
+    label: 'Python docs',
+    href: 'https://docs.python.org/3/tutorial/datastructures.html',
+  },
+  java: {
+    label: 'Java SE API',
+    href: 'https://docs.oracle.com/en/java/javase/17/docs/api/',
+  },
+  c: {
+    label: 'C reference',
+    href: 'https://en.cppreference.com/w/c',
+  },
+  cpp: {
+    label: 'C++ reference',
+    href: 'https://en.cppreference.com/w/cpp',
+  },
+  javascript: {
+    label: 'MDN JavaScript',
+    href: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide',
+  },
+  typescript: {
+    label: 'TypeScript handbook',
+    href: 'https://www.typescriptlang.org/docs/handbook/intro.html',
+  },
+}
+
 export async function submitSolution({ accessToken, problemId, language, code }) {
   return backendFetch('/submissions', {
     accessToken,


### PR DESCRIPTION
## Summary
- Enable **Evaluate** only after all sample tests Pass: soft forbidden regex hints (not failures) plus Gemini 3.5 Flash-Lite Big O and duplication notes
- Add optional **Custom input** on Run: samples still Pass/Fail; custom stdin shows raw Custom output only
- Add language **Docs** link for syntax help without AI
- Add `GEMINI_API_KEY` / `EVALUATE_DAILY_LIMIT` placeholders and separate evaluate daily rate limit

## Test plan
- [ ] Set `GEMINI_API_KEY` on Heroku and deploy backend (`/evaluate` not 404)
- [ ] Problem with samples: Run → all Pass → Evaluate enabled and returns panel
- [ ] Sample Fail → Evaluate stays disabled
- [ ] Custom input filled → Samples panel + Custom output (no Pass/Fail on custom)
- [ ] Code with `break` / builtin sort → Evaluate shows soft style hint, samples still Pass
- [ ] Docs opens the correct official language docs
- [ ] Daily evaluate limit returns 429 when exceeded
- [ ] Backend tests: `pytest` in `backend/` passes