### PR TITLE
Release: Solutions workspace, sample I/O, and Evaluate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The **codeXperts Club** official website — a members-only platform for a codin
 |---------|-------------|
 | **Google OAuth + RBAC** | 4-tier role system (Public → Member → Executive → Admin) with Supabase RLS enforcement |
 | **Coding Problems** | Weekly problems on `/problems` (markdown editor or Word/PDF document mode); exec/admin CRUD; members read-only |
+| **Solutions Workspace** | `/solutions` list + `/solutions/:id` Monaco editor; Run via Judge0, Submit upsert, Community accordion viewer |
 | **QR Attendance** | Admin generates a session token → members scan to check in → auto-expires |
 | **Schedule Page** | Google Calendar API integration — synced events with subscribe/download for members |
 | **Member Directory** | Filterable profile cards with cohort, school, role badges, and per-field visibility controls |
@@ -94,7 +95,8 @@ Frontend (Next.js — Vercel)
 │
 └── FastAPI (Heroku)
     ├── /health            → service health check
-    ├── /execute           → proxy to Piston API (code execution)
+    ├── /execute           → proxy to Judge0 CE (RapidAPI) for code execution
+    ├── /submissions       → upsert member solutions to Supabase
     └── /attendance/verify → QR token validation
 ```
 
@@ -470,17 +472,19 @@ codexperts-web/
 │   └── utils/               # Helper functions, constants
 ├── docs/
 │   ├── design/              # Design system, sitemap, page-level specs
-│   ├── guidelines/          # code-conventions.md, git-workflow.md
+│   ├── guidelines/          # code-conventions, git-workflow, judge0-rapidapi-setup
 │   ├── meeting-notes/       # Sprint meeting records
 │   ├── sprints/             # Sprint plan + weekly specs
 │   └── schema/              # Database schema definitions
 ├── backend/
 │   ├── main.py              # FastAPI entry point
+│   ├── auth.py              # Supabase JWT + member+ role gate
+│   ├── services/            # Judge0 RapidAPI code-execution client
 │   ├── Procfile             # Heroku web process
 │   ├── .profile.d/          # Optional dyno env (LibreOffice via Heroku buildpack)
 │   ├── requirements.txt
 │   ├── .env.example
-│   └── routers/             # documents (DOCX→PDF), future execute/attendance
+│   └── routers/             # documents (DOCX→PDF), execute (Piston proxy)
 ├── scripts/
 │   └── sprint-report.js     # CLI tool — GitHub Issue contribution report per member
 ├── package.json

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,5 +7,17 @@ CORS_ORIGINS=http://localhost:3000,https://codexperts.ca,https://www.codexperts.
 # Optional override for the preview URL regex.
 # CORS_ORIGIN_REGEX=https://codexperts-web.*\.vercel\.app
 
-# Add backend-specific env vars here as needed
-# PISTON_API_URL=https://emkc.org/api/v2/piston
+# Judge0 CE via RapidAPI (POST /execute)
+# Subscribe: https://rapidapi.com/judge0-official/api/judge0-ce
+# Note: RapidAPI "Hard Limit" is set by the API provider on the plan, not by subscribers.
+# We enforce EXECUTE_DAILY_LIMIT per member in our API (default 20/day UTC).
+JUDGE0_RAPIDAPI_KEY=your-rapidapi-key
+EXECUTE_DAILY_LIMIT=20
+# Optional overrides (defaults match Judge0 CE on RapidAPI):
+# JUDGE0_BASE_URL=https://judge0-ce.p.rapidapi.com
+# JUDGE0_RAPIDAPI_HOST=judge0-ce.p.rapidapi.com
+
+# Supabase — server-side names (not NEXT_PUBLIC_*).
+# SUPABASE_URL value matches NEXT_PUBLIC_SUPABASE_URL on the frontend.
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,7 @@
 
 # CORS — comma-separated list of explicit allowed origins.
 # Vercel preview URLs are matched by CORS_ORIGIN_REGEX (default covers them).
-CORS_ORIGINS=http://localhost:3000,https://codexperts.ca,https://www.codexperts.ca
+CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:3002,http://127.0.0.1:3002,https://codexperts.ca,https://www.codexperts.ca
 # Optional override for the preview URL regex.
 # CORS_ORIGIN_REGEX=https://codexperts-web.*\.vercel\.app
 
@@ -21,3 +21,10 @@ EXECUTE_DAILY_LIMIT=20
 # SUPABASE_URL value matches NEXT_PUBLIC_SUPABASE_URL on the frontend.
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Gemini (POST /evaluate — issue #60)
+# Create the key in Google AI Studio with the club Google account.
+# Model target: gemini-3.5-flash-lite (Free Tier).
+# Heroku: heroku config:set GEMINI_API_KEY=... -a <app>
+GEMINI_API_KEY=your-gemini-api-key
+# EVALUATE_DAILY_LIMIT=20

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,137 @@
+"""Supabase JWT auth helpers for FastAPI routes."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import httpx
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+_bearer = HTTPBearer(auto_error=False)
+
+MEMBER_PLUS_ROLES = frozenset({"member", "executive", "admin"})
+
+
+@dataclass(frozen=True)
+class AuthUser:
+    id: str
+    role: str
+
+
+def _supabase_url() -> str:
+    url = (os.getenv("SUPABASE_URL") or "").rstrip("/")
+    if not url:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Auth service is not configured",
+        )
+    return url
+
+
+def _service_role_key() -> str:
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or ""
+    if not key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Auth service is not configured",
+        )
+    return key
+
+
+def require_member_plus(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
+) -> AuthUser:
+    """Validate Bearer JWT and require member / executive / admin role."""
+    if credentials is None or credentials.scheme.lower() != "bearer" or not credentials.credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized",
+        )
+
+    token = credentials.credentials
+    base_url = _supabase_url()
+    service_key = _service_role_key()
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            user_response = client.get(
+                f"{base_url}/auth/v1/user",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "apikey": service_key,
+                },
+            )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Auth service is not configured",
+        ) from exc
+
+    if user_response.status_code != 200:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized",
+        )
+
+    try:
+        user_body = user_response.json()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized",
+        ) from exc
+
+    user_id = user_body.get("id")
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized",
+        )
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            profile_response = client.get(
+                f"{base_url}/rest/v1/profiles",
+                params={"id": f"eq.{user_id}", "select": "role"},
+                headers={
+                    "Authorization": f"Bearer {service_key}",
+                    "apikey": service_key,
+                    "Accept": "application/json",
+                },
+            )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Auth service is not configured",
+        ) from exc
+
+    if profile_response.status_code != 200:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized",
+        )
+
+    try:
+        rows = profile_response.json()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized",
+        ) from exc
+
+    if not isinstance(rows, list) or not rows:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized",
+        )
+
+    role = rows[0].get("role")
+    if role not in MEMBER_PLUS_ROLES:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden",
+        )
+
+    return AuthUser(id=str(user_id), role=str(role))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,10 @@
 import os
 
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+load_dotenv()
 
 app = FastAPI(title="codeXperts API")
 
@@ -34,11 +37,12 @@ app.add_middleware(
 def health():
     return {"status": "ok"}
 
-from routers import documents
+from routers import documents, execute, submissions
 
 app.include_router(documents.router)
+app.include_router(execute.router)
+app.include_router(submissions.router)
 
 # Routers added in later sprints:
-# from routers import execute, attendance
-# app.include_router(execute.router)     # W3: /execute
+# from routers import attendance
 # app.include_router(attendance.router)  # W4: /attendance/verify

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,11 +37,12 @@ app.add_middleware(
 def health():
     return {"status": "ok"}
 
-from routers import documents, execute, execute_samples, submissions
+from routers import documents, evaluate, execute, execute_samples, submissions
 
 app.include_router(documents.router)
 app.include_router(execute.router)
 app.include_router(execute_samples.router)
+app.include_router(evaluate.router)
 app.include_router(submissions.router)
 
 # Routers added in later sprints:

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,10 +37,11 @@ app.add_middleware(
 def health():
     return {"status": "ok"}
 
-from routers import documents, execute, submissions
+from routers import documents, execute, execute_samples, submissions
 
 app.include_router(documents.router)
 app.include_router(execute.router)
+app.include_router(execute_samples.router)
 app.include_router(submissions.router)
 
 # Routers added in later sprints:

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,5 +1,0 @@
-[build]
-builder = "nixpacks"
-
-[deploy]
-startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,3 +1,4 @@
-# Route modules added in later sprints:
-# execute.py   — W3: POST /execute (Piston API proxy)
-# attendance.py — W4: POST /attendance/verify (QR check-in)
+# Route modules:
+# execute.py     — POST /execute (Judge0 RapidAPI proxy)
+# submissions.py — POST /submissions (Supabase upsert)
+# attendance.py  — W4: POST /attendance/verify (QR check-in)

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,5 +1,6 @@
 # Route modules:
 # execute.py         — POST /execute (Judge0 RapidAPI proxy)
 # execute_samples.py — POST /execute/samples (run against problem sample_tests)
+# evaluate.py        — POST /evaluate (soft forbidden + Gemini)
 # submissions.py     — POST /submissions (Supabase upsert)
 # attendance.py      — W4: POST /attendance/verify (QR check-in)

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,4 +1,5 @@
 # Route modules:
-# execute.py     — POST /execute (Judge0 RapidAPI proxy)
-# submissions.py — POST /submissions (Supabase upsert)
-# attendance.py  — W4: POST /attendance/verify (QR check-in)
+# execute.py         — POST /execute (Judge0 RapidAPI proxy)
+# execute_samples.py — POST /execute/samples (run against problem sample_tests)
+# submissions.py     — POST /submissions (Supabase upsert)
+# attendance.py      — W4: POST /attendance/verify (QR check-in)

--- a/backend/routers/evaluate.py
+++ b/backend/routers/evaluate.py
@@ -1,0 +1,84 @@
+"""POST /evaluate — soft forbidden hints + Gemini Big O / duplication."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from auth import AuthUser, require_member_plus
+from services import forbidden, gemini_evaluate, judge0, rate_limit
+
+router = APIRouter(tags=["evaluate"])
+
+
+class EvaluateRequest(BaseModel):
+    problem_id: int = Field(..., gt=0)
+    language: str = Field(..., min_length=1)
+    code: str = Field(..., min_length=1)
+    samples_passed: bool = False
+
+
+class ForbiddenHint(BaseModel):
+    rule: str
+    hint: str
+    line: int | None = None
+
+
+class EvaluateResponse(BaseModel):
+    forbidden_hints: list[ForbiddenHint]
+    big_o: str
+    big_o_reason: str
+    duplicates: list[str]
+
+
+@router.post("/evaluate", response_model=EvaluateResponse)
+def evaluate(
+    body: EvaluateRequest,
+    user: AuthUser = Depends(require_member_plus),
+) -> EvaluateResponse:
+    if body.language not in judge0.SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    try:
+        judge0.validate_code_size(body.code)
+    except judge0.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+
+    if not body.samples_passed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="All sample tests must pass before Evaluate",
+        )
+
+    try:
+        rate_limit.check_and_increment(user.id, kind="evaluate")
+    except rate_limit.DailyLimitExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    hits = forbidden.check_forbidden(body.code, body.language)
+    forbidden_hints = [
+        ForbiddenHint(rule=hit.rule, hint=hit.hint, line=hit.line) for hit in hits
+    ]
+
+    try:
+        result = gemini_evaluate.evaluate_code(body.language, body.code)
+    except gemini_evaluate.GeminiUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+    return EvaluateResponse(
+        forbidden_hints=forbidden_hints,
+        big_o=result.big_o,
+        big_o_reason=result.big_o_reason,
+        duplicates=result.duplicates,
+    )

--- a/backend/routers/execute.py
+++ b/backend/routers/execute.py
@@ -1,0 +1,85 @@
+"""POST /execute — proxy member code to Judge0 (RapidAPI)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from auth import AuthUser, require_member_plus
+from services import judge0, rate_limit
+
+router = APIRouter(tags=["execute"])
+
+
+class ExecuteRequest(BaseModel):
+    language: str = Field(..., min_length=1)
+    code: str = Field(..., min_length=1)
+    stdin: str = ""
+
+
+class ExecuteResponse(BaseModel):
+    stdout: str
+    stderr: str
+    runtime: float
+    exit_code: int
+
+
+@router.post("/execute", response_model=ExecuteResponse)
+def execute(
+    body: ExecuteRequest,
+    user: AuthUser = Depends(require_member_plus),
+) -> ExecuteResponse:
+    if body.language not in judge0.SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    try:
+        judge0.validate_code_size(body.code)
+    except judge0.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+
+    try:
+        rate_limit.check_and_increment(user.id)
+    except rate_limit.DailyLimitExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    try:
+        result = judge0.execute_code(
+            language=body.language,
+            code=body.code,
+            stdin=body.stdin,
+        )
+    except judge0.UnsupportedLanguageError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    except judge0.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+    except judge0.ExecutionTimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_408_REQUEST_TIMEOUT,
+            detail="Execution timed out",
+        )
+    except judge0.ExecutionUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Code execution service unavailable",
+        )
+
+    return ExecuteResponse(
+        stdout=result.stdout,
+        stderr=result.stderr,
+        runtime=result.runtime,
+        exit_code=result.exit_code,
+    )

--- a/backend/routers/execute_samples.py
+++ b/backend/routers/execute_samples.py
@@ -1,0 +1,146 @@
+"""POST /execute/samples — run member code against problem sample tests."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from auth import AuthUser, require_member_plus
+from services import judge0, rate_limit, samples
+from services.supabase_rest import rest_client, service_headers, supabase_url
+
+router = APIRouter(tags=["execute"])
+
+
+class SampleExecuteRequest(BaseModel):
+    problem_id: int = Field(..., gt=0)
+    language: str = Field(..., min_length=1)
+    code: str = Field(..., min_length=1)
+
+
+class SampleResult(BaseModel):
+    index: int
+    passed: bool
+    stdin: str
+    expected_stdout: str
+    stdout: str
+    stderr: str
+    runtime: float
+    exit_code: int
+
+
+class SampleExecuteResponse(BaseModel):
+    results: list[SampleResult]
+    passed: int
+    total: int
+
+
+def _fetch_sample_tests(problem_id: int) -> list[dict[str, str]]:
+    url = f"{supabase_url()}/rest/v1/problems"
+    params = {
+        "id": f"eq.{problem_id}",
+        "select": "sample_tests",
+    }
+    with rest_client() as client:
+        response = client.get(url, headers=service_headers(), params=params)
+
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Failed to load problem samples",
+        )
+
+    rows = response.json()
+    if not isinstance(rows, list) or not rows:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Problem not found",
+        )
+
+    return samples.parse_sample_tests(rows[0].get("sample_tests"))
+
+
+@router.post("/execute/samples", response_model=SampleExecuteResponse)
+def execute_samples(
+    body: SampleExecuteRequest,
+    user: AuthUser = Depends(require_member_plus),
+) -> SampleExecuteResponse:
+    if body.language not in judge0.SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    try:
+        judge0.validate_code_size(body.code)
+    except judge0.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+
+    sample_list = _fetch_sample_tests(body.problem_id)
+    if not sample_list:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No sample tests configured for this problem",
+        )
+
+    try:
+        rate_limit.check_and_increment(user.id, amount=len(sample_list))
+    except rate_limit.DailyLimitExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    results: list[SampleResult] = []
+    try:
+        for index, sample in enumerate(sample_list, start=1):
+            run = judge0.execute_code(
+                language=body.language,
+                code=body.code,
+                stdin=sample["stdin"],
+            )
+            passed = (
+                run.exit_code == 0
+                and samples.outputs_match(run.stdout, sample["expected_stdout"])
+            )
+            results.append(
+                SampleResult(
+                    index=index,
+                    passed=passed,
+                    stdin=sample["stdin"],
+                    expected_stdout=sample["expected_stdout"],
+                    stdout=run.stdout,
+                    stderr=run.stderr,
+                    runtime=run.runtime,
+                    exit_code=run.exit_code,
+                )
+            )
+    except judge0.UnsupportedLanguageError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    except judge0.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+    except judge0.ExecutionTimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_408_REQUEST_TIMEOUT,
+            detail="Execution timed out",
+        )
+    except judge0.ExecutionUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Code execution service unavailable",
+        )
+
+    passed_count = sum(1 for row in results if row.passed)
+    return SampleExecuteResponse(
+        results=results,
+        passed=passed_count,
+        total=len(results),
+    )

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -1,0 +1,63 @@
+"""POST /submissions — upsert a member solution for a problem."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from auth import AuthUser, require_member_plus
+from services import submissions
+
+router = APIRouter(tags=["submissions"])
+
+
+class SubmissionRequest(BaseModel):
+    problem_id: int = Field(..., gt=0)
+    language: str = Field(..., min_length=1)
+    code: str = Field(..., min_length=1)
+
+
+class SubmissionResponse(BaseModel):
+    message: str
+    submission_id: int
+    submitted_at: str
+
+
+@router.post("/submissions", response_model=SubmissionResponse)
+def create_submission(
+    body: SubmissionRequest,
+    user: AuthUser = Depends(require_member_plus),
+) -> SubmissionResponse:
+    try:
+        result = submissions.upsert_submission(
+            profile_id=user.id,
+            problem_id=body.problem_id,
+            language=body.language,
+            code=body.code,
+        )
+    except submissions.UnsupportedLanguageError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Language not supported",
+        )
+    except submissions.CodeTooLargeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Code size limit exceeded",
+        )
+    except submissions.ProblemNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Problem not found",
+        )
+    except submissions.SubmissionUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Submission service unavailable",
+        )
+
+    return SubmissionResponse(
+        message="Solution submitted!",
+        submission_id=result.submission_id,
+        submitted_at=result.submitted_at,
+    )

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+# Backend service modules

--- a/backend/services/forbidden.py
+++ b/backend/services/forbidden.py
@@ -1,0 +1,108 @@
+"""Soft forbidden-pattern checks for Evaluate (do not affect Sample Pass/Fail)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ForbiddenHit:
+    rule: str
+    hint: str
+    line: int | None
+
+
+# Preset A: contest-style coaching, not correctness.
+_RULES: dict[str, list[tuple[str, str, str]]] = {
+    # language -> list of (rule_id, regex, hint)
+    "*": [
+        (
+            "break",
+            r"\bbreak\b",
+            "Not a failure. Some courses and contests discourage break; try structured loops instead.",
+        ),
+    ],
+    "python": [
+        (
+            "builtin-sort",
+            r"\bsorted\s*\(|\.sort\s*\(",
+            "Not a failure. Contests often ban built-in sort so you practice implementing it yourself.",
+        ),
+    ],
+    "java": [
+        (
+            "builtin-sort",
+            r"\bArrays\s*\.\s*sort\s*\(|\bCollections\s*\.\s*sort\s*\(",
+            "Not a failure. Contests often ban built-in sort so you practice implementing it yourself.",
+        ),
+    ],
+    "c": [
+        (
+            "builtin-sort",
+            r"\bqsort\s*\(",
+            "Not a failure. Contests often ban library sort so you practice implementing it yourself.",
+        ),
+    ],
+    "cpp": [
+        (
+            "builtin-sort",
+            r"\bstd\s*::\s*sort\s*\(|\bsort\s*\(",
+            "Not a failure. Contests often ban std::sort so you practice implementing it yourself.",
+        ),
+        (
+            "stl-map",
+            r"\b(?:std\s*::\s*)?map\s*<",
+            "Not a failure. Some assignments disallow std::map; try arrays or your own structure.",
+        ),
+        (
+            "stl-set",
+            r"\b(?:std\s*::\s*)?set\s*<",
+            "Not a failure. Some assignments disallow std::set; try another approach.",
+        ),
+        (
+            "stl-priority-queue",
+            r"\b(?:std\s*::\s*)?priority_queue\s*<",
+            "Not a failure. Some assignments disallow priority_queue; try implementing a heap yourself.",
+        ),
+    ],
+    "javascript": [
+        (
+            "builtin-sort",
+            r"\.sort\s*\(",
+            "Not a failure. Contests often ban built-in sort so you practice implementing it yourself.",
+        ),
+    ],
+    "typescript": [
+        (
+            "builtin-sort",
+            r"\.sort\s*\(",
+            "Not a failure. Contests often ban built-in sort so you practice implementing it yourself.",
+        ),
+    ],
+}
+
+
+def _line_number(code: str, index: int) -> int:
+    return code.count("\n", 0, index) + 1
+
+
+def check_forbidden(code: str, language: str) -> list[ForbiddenHit]:
+    hits: list[ForbiddenHit] = []
+    seen: set[str] = set()
+    rules = list(_RULES.get("*", [])) + list(_RULES.get(language, []))
+    for rule_id, pattern, hint in rules:
+        if rule_id in seen:
+            continue
+        match = re.search(pattern, code)
+        if not match:
+            continue
+        seen.add(rule_id)
+        hits.append(
+            ForbiddenHit(
+                rule=rule_id,
+                hint=hint,
+                line=_line_number(code, match.start()),
+            )
+        )
+    return hits

--- a/backend/services/gemini_evaluate.py
+++ b/backend/services/gemini_evaluate.py
@@ -1,0 +1,138 @@
+"""Gemini Flash-Lite client for Solutions Evaluate."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+
+import httpx
+
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-3.5-flash-lite")
+GEMINI_TIMEOUT_SECONDS = float(os.getenv("GEMINI_TIMEOUT_SECONDS", "45"))
+
+SYSTEM_INSTRUCTION = """You are a programming coach for a competitive programming club.
+Analyze the student's code ONLY for:
+1) asymptotic time complexity (Big O)
+2) duplicated or near-duplicated logic
+
+Rules:
+- Do NOT provide the correct solution, algorithms to use, or step-by-step fixes.
+- Do NOT rewrite the student's code.
+- Do NOT mention test cases, expected output, or problem answers.
+- If unsure about Big O, pick the best estimate and say so briefly in big_o_reason.
+- Respond with JSON only matching the schema. No markdown.
+"""
+
+
+class GeminiUnavailableError(Exception):
+    """Raised when Gemini is not configured or the API call fails."""
+
+
+@dataclass(frozen=True)
+class GeminiEvaluation:
+    big_o: str
+    big_o_reason: str
+    duplicates: list[str]
+
+
+def _api_key() -> str:
+    key = (os.getenv("GEMINI_API_KEY") or "").strip()
+    if not key or key == "your-gemini-api-key":
+        raise GeminiUnavailableError("Evaluate service is not configured")
+    return key
+
+
+def _extract_json(text: str) -> dict:
+    raw = (text or "").strip()
+    if not raw:
+        raise GeminiUnavailableError("Evaluate service unavailable")
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+    match = re.search(r"\{.*\}", raw, flags=re.DOTALL)
+    if not match:
+        raise GeminiUnavailableError("Evaluate service unavailable")
+    data = json.loads(match.group(0))
+    if not isinstance(data, dict):
+        raise GeminiUnavailableError("Evaluate service unavailable")
+    return data
+
+
+def evaluate_code(language: str, code: str) -> GeminiEvaluation:
+    """Call Gemini and return Big O + duplication notes."""
+    api_key = _api_key()
+    url = (
+        f"https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{GEMINI_MODEL}:generateContent"
+    )
+    payload = {
+        "systemInstruction": {
+            "parts": [{"text": SYSTEM_INSTRUCTION}],
+        },
+        "contents": [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "text": (
+                            f"Language: {language}\n\nCode:\n```\n{code}\n```\n\n"
+                            "Return JSON with keys big_o (string), big_o_reason "
+                            "(one short sentence), duplicates (array of short notes; "
+                            "empty if none)."
+                        ),
+                    }
+                ],
+            }
+        ],
+        "generationConfig": {
+            "responseMimeType": "application/json",
+            "responseSchema": {
+                "type": "object",
+                "properties": {
+                    "big_o": {"type": "string"},
+                    "big_o_reason": {"type": "string"},
+                    "duplicates": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["big_o", "big_o_reason", "duplicates"],
+            },
+        },
+    }
+
+    try:
+        with httpx.Client(timeout=GEMINI_TIMEOUT_SECONDS) as client:
+            response = client.post(url, params={"key": api_key}, json=payload)
+    except httpx.TimeoutException as exc:
+        raise GeminiUnavailableError("Evaluate timed out") from exc
+    except httpx.HTTPError as exc:
+        raise GeminiUnavailableError("Evaluate service unavailable") from exc
+
+    if response.status_code == 429:
+        raise GeminiUnavailableError("Evaluate rate limited by provider")
+    if response.status_code >= 400:
+        raise GeminiUnavailableError("Evaluate service unavailable")
+
+    try:
+        body = response.json()
+        text = body["candidates"][0]["content"]["parts"][0]["text"]
+        data = _extract_json(text)
+    except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise GeminiUnavailableError("Evaluate service unavailable") from exc
+
+    duplicates_raw = data.get("duplicates") or []
+    if not isinstance(duplicates_raw, list):
+        duplicates_raw = []
+    duplicates = [str(item).strip() for item in duplicates_raw if str(item).strip()]
+
+    return GeminiEvaluation(
+        big_o=str(data.get("big_o") or "Unknown").strip() or "Unknown",
+        big_o_reason=str(data.get("big_o_reason") or "").strip(),
+        duplicates=duplicates,
+    )

--- a/backend/services/judge0.py
+++ b/backend/services/judge0.py
@@ -1,0 +1,162 @@
+"""Judge0 CE client via RapidAPI for sandboxed code execution."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+import httpx
+
+JUDGE0_BASE_URL = os.getenv(
+    "JUDGE0_BASE_URL",
+    "https://judge0-ce.p.rapidapi.com",
+).rstrip("/")
+JUDGE0_RAPIDAPI_HOST = os.getenv(
+    "JUDGE0_RAPIDAPI_HOST",
+    "judge0-ce.p.rapidapi.com",
+)
+
+MAX_CODE_BYTES = 50 * 1024
+EXECUTION_TIMEOUT_SECONDS = 10.0
+
+# Frontend language keys → Judge0 CE language_id
+# IDs from https://ce.judge0.com/languages
+SUPPORTED_LANGUAGES: dict[str, int] = {
+    "python": 100,  # Python 3.12.5
+    "java": 91,  # Java (JDK 17.0.6)
+    "c": 103,  # C (GCC 14.1.0)
+    "cpp": 105,  # C++ (GCC 14.1.0)
+    "javascript": 93,  # JavaScript (Node.js 18.15.0)
+    "typescript": 101,  # TypeScript 5.6.2
+}
+
+# Judge0 status.id reference: 3 = Accepted
+STATUS_ACCEPTED = 3
+STATUS_TIME_LIMIT = 5
+
+
+class ExecutionError(Exception):
+    """Base error for code execution failures."""
+
+
+class UnsupportedLanguageError(ExecutionError):
+    """Raised when the requested language is not supported."""
+
+
+class CodeTooLargeError(ExecutionError):
+    """Raised when submitted code exceeds MAX_CODE_BYTES."""
+
+
+class ExecutionUnavailableError(ExecutionError):
+    """Raised when Judge0 cannot be reached or is misconfigured."""
+
+
+class ExecutionTimeoutError(ExecutionError):
+    """Raised when execution exceeds EXECUTION_TIMEOUT_SECONDS."""
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    stdout: str
+    stderr: str
+    runtime: float
+    exit_code: int
+
+
+def validate_code_size(code: str) -> None:
+    if len(code.encode("utf-8")) > MAX_CODE_BYTES:
+        raise CodeTooLargeError("Code size limit exceeded")
+
+
+def _rapidapi_key() -> str:
+    key = (os.getenv("JUDGE0_RAPIDAPI_KEY") or "").strip()
+    if not key:
+        raise ExecutionUnavailableError("Code execution service unavailable")
+    return key
+
+
+def execute_code(language: str, code: str, stdin: str = "") -> ExecutionResult:
+    """Submit code to Judge0 (wait=true) and map the response."""
+    language_id = SUPPORTED_LANGUAGES.get(language)
+    if language_id is None:
+        raise UnsupportedLanguageError("Language not supported")
+
+    validate_code_size(code)
+    api_key = _rapidapi_key()
+
+    payload = {
+        "language_id": language_id,
+        "source_code": code,
+        "stdin": stdin or "",
+    }
+    params = {
+        "base64_encoded": "false",
+        "wait": "true",
+        "fields": "*",
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "X-RapidAPI-Key": api_key,
+        "X-RapidAPI-Host": JUDGE0_RAPIDAPI_HOST,
+    }
+
+    url = f"{JUDGE0_BASE_URL}/submissions"
+    started = time.perf_counter()
+
+    try:
+        with httpx.Client(timeout=EXECUTION_TIMEOUT_SECONDS) as client:
+            response = client.post(url, params=params, headers=headers, json=payload)
+    except httpx.TimeoutException as exc:
+        raise ExecutionTimeoutError("Execution timed out") from exc
+    except httpx.HTTPError as exc:
+        raise ExecutionUnavailableError("Code execution service unavailable") from exc
+
+    elapsed = time.perf_counter() - started
+
+    if response.status_code == 429:
+        raise ExecutionUnavailableError("Code execution service unavailable")
+
+    if response.status_code >= 500:
+        raise ExecutionUnavailableError("Code execution service unavailable")
+
+    if response.status_code >= 400:
+        raise ExecutionUnavailableError("Code execution service unavailable")
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise ExecutionUnavailableError("Code execution service unavailable") from exc
+
+    status = data.get("status") or {}
+    status_id = status.get("id")
+    if status_id == STATUS_TIME_LIMIT:
+        raise ExecutionTimeoutError("Execution timed out")
+
+    stdout = data.get("stdout") or ""
+    stderr_parts = [
+        part
+        for part in (
+            data.get("compile_output") or "",
+            data.get("stderr") or "",
+            status.get("description") if status_id not in (None, STATUS_ACCEPTED) else "",
+        )
+        if part
+    ]
+    # Avoid duplicating Accepted noise; keep judge messages for failures only.
+    stderr = "\n".join(stderr_parts).strip()
+
+    time_value = data.get("time")
+    try:
+        runtime = float(time_value) if time_value is not None else round(elapsed, 3)
+    except (TypeError, ValueError):
+        runtime = round(elapsed, 3)
+
+    exit_code = 0 if status_id == STATUS_ACCEPTED else 1
+
+    return ExecutionResult(
+        stdout=stdout,
+        stderr=stderr,
+        runtime=round(runtime, 3),
+        exit_code=exit_code,
+    )

--- a/backend/services/rate_limit.py
+++ b/backend/services/rate_limit.py
@@ -1,4 +1,4 @@
-"""Simple per-user daily rate limits for /execute.
+"""Simple per-user daily rate limits for /execute and /evaluate.
 
 In-memory counters reset on process restart. Fine for a single Heroku dyno MVP;
 replace with Redis/DB if we scale to multiple dynos.
@@ -12,39 +12,50 @@ from threading import Lock
 
 # Member may run code this many times per UTC day.
 DAILY_EXECUTE_LIMIT = int(os.getenv("EXECUTE_DAILY_LIMIT", "20"))
+DAILY_EVALUATE_LIMIT = int(os.getenv("EVALUATE_DAILY_LIMIT", "20"))
 
 _lock = Lock()
-# key: (user_id, YYYY-MM-DD) → count
-_counts: dict[tuple[str, str], int] = {}
+# key: (kind, user_id, YYYY-MM-DD) → count
+_counts: dict[tuple[str, str, str], int] = {}
 
 
 class DailyLimitExceededError(Exception):
-    """Raised when the user has no remaining daily execute quota."""
+    """Raised when the user has no remaining daily quota."""
 
 
 def _today_utc() -> str:
     return datetime.now(timezone.utc).date().isoformat()
 
 
-def check_and_increment(user_id: str, amount: int = 1) -> int:
-    """Increment the user's daily counter by ``amount``.
+def _limit_for(kind: str) -> int:
+    if kind == "evaluate":
+        return DAILY_EVALUATE_LIMIT
+    return DAILY_EXECUTE_LIMIT
+
+
+def check_and_increment(user_id: str, amount: int = 1, *, kind: str = "execute") -> int:
+    """Increment the user's daily counter by ``amount`` for ``kind``.
 
     Returns remaining quota after this call.
     Raises DailyLimitExceededError when the limit would be exceeded.
     """
     if amount < 1:
         raise ValueError("amount must be >= 1")
+    if kind not in ("execute", "evaluate"):
+        raise ValueError("kind must be execute or evaluate")
 
-    key = (user_id, _today_utc())
+    limit = _limit_for(kind)
+    key = (kind, user_id, _today_utc())
     with _lock:
         used = _counts.get(key, 0)
-        if used + amount > DAILY_EXECUTE_LIMIT:
+        if used + amount > limit:
+            label = "evaluate" if kind == "evaluate" else "execute"
             raise DailyLimitExceededError(
-                f"Daily execute limit of {DAILY_EXECUTE_LIMIT} reached"
+                f"Daily {label} limit of {limit} reached"
             )
         used += amount
         _counts[key] = used
-        return DAILY_EXECUTE_LIMIT - used
+        return limit - used
 
 
 def reset_for_tests() -> None:

--- a/backend/services/rate_limit.py
+++ b/backend/services/rate_limit.py
@@ -26,19 +26,23 @@ def _today_utc() -> str:
     return datetime.now(timezone.utc).date().isoformat()
 
 
-def check_and_increment(user_id: str) -> int:
-    """Increment the user's daily counter. Returns remaining quota after this call.
+def check_and_increment(user_id: str, amount: int = 1) -> int:
+    """Increment the user's daily counter by ``amount``.
 
-    Raises DailyLimitExceededError when the limit is already reached.
+    Returns remaining quota after this call.
+    Raises DailyLimitExceededError when the limit would be exceeded.
     """
+    if amount < 1:
+        raise ValueError("amount must be >= 1")
+
     key = (user_id, _today_utc())
     with _lock:
         used = _counts.get(key, 0)
-        if used >= DAILY_EXECUTE_LIMIT:
+        if used + amount > DAILY_EXECUTE_LIMIT:
             raise DailyLimitExceededError(
                 f"Daily execute limit of {DAILY_EXECUTE_LIMIT} reached"
             )
-        used += 1
+        used += amount
         _counts[key] = used
         return DAILY_EXECUTE_LIMIT - used
 

--- a/backend/services/rate_limit.py
+++ b/backend/services/rate_limit.py
@@ -1,0 +1,49 @@
+"""Simple per-user daily rate limits for /execute.
+
+In-memory counters reset on process restart. Fine for a single Heroku dyno MVP;
+replace with Redis/DB if we scale to multiple dynos.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from threading import Lock
+
+# Member may run code this many times per UTC day.
+DAILY_EXECUTE_LIMIT = int(os.getenv("EXECUTE_DAILY_LIMIT", "20"))
+
+_lock = Lock()
+# key: (user_id, YYYY-MM-DD) → count
+_counts: dict[tuple[str, str], int] = {}
+
+
+class DailyLimitExceededError(Exception):
+    """Raised when the user has no remaining daily execute quota."""
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def check_and_increment(user_id: str) -> int:
+    """Increment the user's daily counter. Returns remaining quota after this call.
+
+    Raises DailyLimitExceededError when the limit is already reached.
+    """
+    key = (user_id, _today_utc())
+    with _lock:
+        used = _counts.get(key, 0)
+        if used >= DAILY_EXECUTE_LIMIT:
+            raise DailyLimitExceededError(
+                f"Daily execute limit of {DAILY_EXECUTE_LIMIT} reached"
+            )
+        used += 1
+        _counts[key] = used
+        return DAILY_EXECUTE_LIMIT - used
+
+
+def reset_for_tests() -> None:
+    """Clear counters (tests only)."""
+    with _lock:
+        _counts.clear()

--- a/backend/services/samples.py
+++ b/backend/services/samples.py
@@ -1,0 +1,39 @@
+"""Compare Judge0 stdout to expected sample output."""
+
+from __future__ import annotations
+
+
+def normalize_stdout(text: str | None) -> str:
+    """Trim trailing whitespace per line and strip trailing blank lines."""
+    normalized = (text or "").replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.rstrip() for line in normalized.split("\n")]
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
+
+
+def outputs_match(actual: str | None, expected: str | None) -> bool:
+    return normalize_stdout(actual) == normalize_stdout(expected)
+
+
+def parse_sample_tests(raw) -> list[dict[str, str]]:
+    """Return up to 10 usable sample pairs from a problems.sample_tests value."""
+    if not isinstance(raw, list):
+        return []
+
+    samples: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        stdin = item.get("stdin")
+        expected = item.get("expected_stdout")
+        if stdin is None and expected is None:
+            continue
+        stdin_s = "" if stdin is None else str(stdin)
+        expected_s = "" if expected is None else str(expected)
+        if stdin_s.strip() == "" and expected_s.strip() == "":
+            continue
+        samples.append({"stdin": stdin_s, "expected_stdout": expected_s})
+        if len(samples) >= 10:
+            break
+    return samples

--- a/backend/services/submissions.py
+++ b/backend/services/submissions.py
@@ -1,0 +1,127 @@
+"""Persist member code submissions to Supabase."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+from services import judge0
+from services.supabase_rest import rest_client, service_headers, supabase_url
+
+SUPPORTED_LANGUAGES = frozenset(judge0.SUPPORTED_LANGUAGES.keys())
+MAX_CODE_BYTES = judge0.MAX_CODE_BYTES
+
+
+class SubmissionError(Exception):
+    """Base error for submission persistence."""
+
+
+class UnsupportedLanguageError(SubmissionError):
+    pass
+
+
+class CodeTooLargeError(SubmissionError):
+    pass
+
+
+class ProblemNotFoundError(SubmissionError):
+    pass
+
+
+class SubmissionUnavailableError(SubmissionError):
+    pass
+
+
+@dataclass(frozen=True)
+class SubmissionResult:
+    submission_id: int
+    submitted_at: str
+
+
+def validate_language(language: str) -> None:
+    if language not in SUPPORTED_LANGUAGES:
+        raise UnsupportedLanguageError("Language not supported")
+
+
+def validate_code_size(code: str) -> None:
+    if len(code.encode("utf-8")) > MAX_CODE_BYTES:
+        raise CodeTooLargeError("Code size limit exceeded")
+
+
+def problem_exists(problem_id: int) -> bool:
+    url = f"{supabase_url()}/rest/v1/problems"
+    try:
+        with rest_client() as client:
+            response = client.get(
+                url,
+                params={"id": f"eq.{problem_id}", "select": "id"},
+                headers=service_headers(),
+            )
+    except httpx.HTTPError as exc:
+        raise SubmissionUnavailableError("Submission service unavailable") from exc
+
+    if response.status_code != 200:
+        raise SubmissionUnavailableError("Submission service unavailable")
+
+    try:
+        rows = response.json()
+    except ValueError as exc:
+        raise SubmissionUnavailableError("Submission service unavailable") from exc
+
+    return isinstance(rows, list) and len(rows) > 0
+
+
+def upsert_submission(
+    *,
+    profile_id: str,
+    problem_id: int,
+    language: str,
+    code: str,
+) -> SubmissionResult:
+    validate_language(language)
+    validate_code_size(code)
+
+    if not problem_exists(problem_id):
+        raise ProblemNotFoundError("Problem not found")
+
+    url = f"{supabase_url()}/rest/v1/submissions"
+    payload = {
+        "profile_id": profile_id,
+        "problem_id": problem_id,
+        "language": language,
+        "code": code,
+    }
+    headers = service_headers(
+        prefer="resolution=merge-duplicates,return=representation",
+    )
+    # PostgREST upsert on unique (profile_id, problem_id)
+    params = {"on_conflict": "profile_id,problem_id"}
+
+    try:
+        with rest_client() as client:
+            response = client.post(url, params=params, headers=headers, json=payload)
+    except httpx.HTTPError as exc:
+        raise SubmissionUnavailableError("Submission service unavailable") from exc
+
+    if response.status_code not in (200, 201):
+        raise SubmissionUnavailableError("Submission service unavailable")
+
+    try:
+        rows = response.json()
+    except ValueError as exc:
+        raise SubmissionUnavailableError("Submission service unavailable") from exc
+
+    if not isinstance(rows, list) or not rows:
+        raise SubmissionUnavailableError("Submission service unavailable")
+
+    row = rows[0]
+    submission_id = row.get("id")
+    submitted_at = row.get("updated_at") or row.get("created_at")
+    if submission_id is None or not submitted_at:
+        raise SubmissionUnavailableError("Submission service unavailable")
+
+    return SubmissionResult(
+        submission_id=int(submission_id),
+        submitted_at=str(submitted_at),
+    )

--- a/backend/services/supabase_rest.py
+++ b/backend/services/supabase_rest.py
@@ -1,0 +1,45 @@
+"""Supabase REST helpers for FastAPI services."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+from fastapi import HTTPException, status
+
+
+def supabase_url() -> str:
+    url = (os.getenv("SUPABASE_URL") or "").rstrip("/")
+    if not url:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Auth service is not configured",
+        )
+    return url
+
+
+def service_role_key() -> str:
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or ""
+    if not key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Auth service is not configured",
+        )
+    return key
+
+
+def service_headers(*, prefer: str | None = None) -> dict[str, str]:
+    key = service_role_key()
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "apikey": key,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    if prefer:
+        headers["Prefer"] = prefer
+    return headers
+
+
+def rest_client(timeout: float = 10.0) -> httpx.Client:
+    return httpx.Client(timeout=timeout)

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -432,3 +432,53 @@ def test_execute_samples_no_samples(authed_client, monkeypatch):
 
     assert response.status_code == 400
     assert response.json()["detail"] == "No sample tests configured for this problem"
+
+
+def test_forbidden_detects_python_sort():
+    from services.forbidden import check_forbidden
+
+    hits = check_forbidden("nums.sort()\nprint(nums)\n", "python")
+    assert any(h.rule == "builtin-sort" for h in hits)
+
+
+def test_evaluate_requires_samples_passed(authed_client, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    response = authed_client.post(
+        "/evaluate",
+        json={
+            "problem_id": 1,
+            "language": "python",
+            "code": "print(1)",
+            "samples_passed": False,
+        },
+    )
+    assert response.status_code == 400
+    assert "sample" in response.json()["detail"].lower()
+
+
+def test_evaluate_success(authed_client, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    mock_eval = MagicMock()
+    mock_eval.big_o = "O(n)"
+    mock_eval.big_o_reason = "Single loop."
+    mock_eval.duplicates = []
+
+    with patch(
+        "services.gemini_evaluate.evaluate_code",
+        return_value=mock_eval,
+    ):
+        response = authed_client.post(
+            "/evaluate",
+            json={
+                "problem_id": 1,
+                "language": "python",
+                "code": "for i in range(n):\n    break\n",
+                "samples_passed": True,
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["big_o"] == "O(n)"
+    assert any(h["rule"] == "break" for h in body["forbidden_hints"])

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,5 +1,12 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
 from fastapi.testclient import TestClient
+
+from auth import AuthUser, require_member_plus
 from main import app
+from services import judge0, rate_limit
 
 client = TestClient(app)
 
@@ -8,3 +15,334 @@ def test_health():
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+@pytest.fixture
+def authed_client(monkeypatch):
+    monkeypatch.setenv("JUDGE0_RAPIDAPI_KEY", "test-key")
+    rate_limit.reset_for_tests()
+    app.dependency_overrides[require_member_plus] = lambda: AuthUser(
+        id="user-1",
+        role="member",
+    )
+    yield client
+    app.dependency_overrides.clear()
+    rate_limit.reset_for_tests()
+
+
+def test_execute_requires_auth():
+    response = client.post(
+        "/execute",
+        json={"language": "python", "code": "print(1)"},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Unauthorized"
+
+
+def test_execute_unsupported_language(authed_client):
+    response = authed_client.post(
+        "/execute",
+        json={"language": "ruby", "code": "puts 1"},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Language not supported"
+
+
+def test_execute_code_too_large(authed_client):
+    huge = "x" * (judge0.MAX_CODE_BYTES + 1)
+    response = authed_client.post(
+        "/execute",
+        json={"language": "python", "code": huge},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Code size limit exceeded"
+
+
+def test_execute_success(authed_client):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "stdout": "Hello, World!\n",
+        "stderr": "",
+        "compile_output": "",
+        "time": "0.023",
+        "status": {"id": 3, "description": "Accepted"},
+    }
+
+    with patch("services.judge0.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute",
+            json={"language": "python", "code": "print('Hello, World!')"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["stdout"] == "Hello, World!\n"
+    assert body["stderr"] == ""
+    assert body["exit_code"] == 0
+    assert body["runtime"] == 0.023
+
+
+def test_execute_runtime_error_returns_200(authed_client):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "stdout": "",
+        "stderr": "NameError: name 'x' is not defined",
+        "compile_output": "",
+        "time": "0.011",
+        "status": {"id": 11, "description": "Runtime Error (NZEC)"},
+    }
+
+    with patch("services.judge0.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute",
+            json={"language": "python", "code": "print(x)"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 1
+    assert "NameError" in body["stderr"]
+
+
+def test_execute_compile_error_returns_200(authed_client):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "stdout": None,
+        "stderr": None,
+        "compile_output": "error: expected ';'",
+        "time": None,
+        "status": {"id": 6, "description": "Compilation Error"},
+    }
+
+    with patch("services.judge0.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute",
+            json={"language": "cpp", "code": "int main() {"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 1
+    assert "expected" in body["stderr"]
+
+
+def test_execute_timeout(authed_client):
+    with patch("services.judge0.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.post.side_effect = httpx.TimeoutException("timed out")
+        mock_client_cls.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute",
+            json={"language": "python", "code": "while True: pass"},
+        )
+
+    assert response.status_code == 408
+    assert response.json()["detail"] == "Execution timed out"
+
+
+def test_execute_judge0_unavailable(authed_client):
+    with patch("services.judge0.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+        mock_client_cls.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute",
+            json={"language": "python", "code": "print(1)"},
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Code execution service unavailable"
+
+
+def test_judge0_maps_python_language_id(monkeypatch):
+    monkeypatch.setenv("JUDGE0_RAPIDAPI_KEY", "test-key")
+    captured = {}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "stdout": "ok\n",
+        "stderr": "",
+        "compile_output": "",
+        "time": "0.01",
+        "status": {"id": 3, "description": "Accepted"},
+    }
+
+    with patch("services.judge0.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+
+        def capture_post(url, params=None, headers=None, json=None):
+            captured["url"] = url
+            captured["params"] = params
+            captured["headers"] = headers
+            captured["json"] = json
+            return mock_response
+
+        mock_client.post.side_effect = capture_post
+        mock_client_cls.return_value = mock_client
+
+        result = judge0.execute_code("python", "print('ok')")
+
+    assert result.exit_code == 0
+    assert captured["json"]["language_id"] == 100
+    assert captured["params"]["wait"] == "true"
+    assert captured["headers"]["X-RapidAPI-Key"] == "test-key"
+
+
+def test_execute_daily_limit(authed_client, monkeypatch):
+    monkeypatch.setattr(rate_limit, "DAILY_EXECUTE_LIMIT", 2)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "stdout": "1\n",
+        "stderr": "",
+        "compile_output": "",
+        "time": "0.01",
+        "status": {"id": 3, "description": "Accepted"},
+    }
+
+    with patch("services.judge0.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        assert (
+            authed_client.post(
+                "/execute",
+                json={"language": "python", "code": "print(1)"},
+            ).status_code
+            == 200
+        )
+        assert (
+            authed_client.post(
+                "/execute",
+                json={"language": "python", "code": "print(1)"},
+            ).status_code
+            == 200
+        )
+        limited = authed_client.post(
+            "/execute",
+            json={"language": "python", "code": "print(1)"},
+        )
+
+    assert limited.status_code == 429
+    assert "Daily execute limit" in limited.json()["detail"]
+
+
+def test_submissions_requires_auth():
+    response = client.post(
+        "/submissions",
+        json={"problem_id": 1, "language": "python", "code": "print(1)"},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Unauthorized"
+
+
+def test_submissions_unsupported_language(authed_client):
+    response = authed_client.post(
+        "/submissions",
+        json={"problem_id": 1, "language": "ruby", "code": "puts 1"},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Language not supported"
+
+
+def test_submissions_code_too_large(authed_client):
+    huge = "x" * (judge0.MAX_CODE_BYTES + 1)
+    response = authed_client.post(
+        "/submissions",
+        json={"problem_id": 1, "language": "python", "code": huge},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Code size limit exceeded"
+
+
+def test_submissions_problem_not_found(authed_client):
+    problem_response = MagicMock()
+    problem_response.status_code = 200
+    problem_response.json.return_value = []
+
+    with patch("services.submissions.rest_client") as mock_rest:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.get.return_value = problem_response
+        mock_rest.return_value = mock_client
+
+        response = authed_client.post(
+            "/submissions",
+            json={"problem_id": 999, "language": "python", "code": "print(1)"},
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Problem not found"
+
+
+def test_submissions_upsert_success(authed_client, monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-key")
+
+    problem_response = MagicMock()
+    problem_response.status_code = 200
+    problem_response.json.return_value = [{"id": 1}]
+
+    upsert_response = MagicMock()
+    upsert_response.status_code = 201
+    upsert_response.json.return_value = [
+        {
+            "id": 42,
+            "updated_at": "2026-07-23T12:00:00+00:00",
+            "created_at": "2026-07-23T11:00:00+00:00",
+        }
+    ]
+
+    with patch("services.submissions.rest_client") as mock_rest:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.get.return_value = problem_response
+        mock_client.post.return_value = upsert_response
+        mock_rest.return_value = mock_client
+
+        response = authed_client.post(
+            "/submissions",
+            json={"problem_id": 1, "language": "python", "code": "print(1)"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["message"] == "Solution submitted!"
+    assert body["submission_id"] == 42
+    assert body["submitted_at"] == "2026-07-23T12:00:00+00:00"

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -346,3 +346,89 @@ def test_submissions_upsert_success(authed_client, monkeypatch):
     assert body["message"] == "Solution submitted!"
     assert body["submission_id"] == 42
     assert body["submitted_at"] == "2026-07-23T12:00:00+00:00"
+
+
+def test_normalize_stdout_trims_lines():
+    from services.samples import normalize_stdout, outputs_match, parse_sample_tests
+
+    assert normalize_stdout("a  \n b \n\n") == "a\n b"
+    assert outputs_match("4 1\n", "4 1")
+    assert parse_sample_tests([
+        {"stdin": "a 1", "expected_stdout": "4 1"},
+        {"stdin": "  ", "expected_stdout": ""},
+        {"stdin": "b 0", "expected_stdout": "8 8"},
+    ]) == [
+        {"stdin": "a 1", "expected_stdout": "4 1"},
+        {"stdin": "b 0", "expected_stdout": "8 8"},
+    ]
+
+
+def test_execute_samples_success(authed_client, monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-key")
+
+    problem_response = MagicMock()
+    problem_response.status_code = 200
+    problem_response.json.return_value = [{
+        "sample_tests": [
+            {"stdin": "a 1 5 6", "expected_stdout": "4 1"},
+            {"stdin": "b 0", "expected_stdout": "8 8"},
+        ],
+    }]
+
+    mock_run = MagicMock()
+    mock_run.stdout = "4 1\n"
+    mock_run.stderr = ""
+    mock_run.runtime = 0.01
+    mock_run.exit_code = 0
+
+    mock_run_fail = MagicMock()
+    mock_run_fail.stdout = "0 0\n"
+    mock_run_fail.stderr = ""
+    mock_run_fail.runtime = 0.02
+    mock_run_fail.exit_code = 0
+
+    with patch("routers.execute_samples.rest_client") as mock_rest, \
+            patch("services.judge0.execute_code", side_effect=[mock_run, mock_run_fail]) as mock_exec:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.get.return_value = problem_response
+        mock_rest.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute/samples",
+            json={"problem_id": 5, "language": "python", "code": "print(1)"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["passed"] == 1
+    assert body["total"] == 2
+    assert body["results"][0]["passed"] is True
+    assert body["results"][1]["passed"] is False
+    assert mock_exec.call_count == 2
+
+
+def test_execute_samples_no_samples(authed_client, monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-key")
+
+    problem_response = MagicMock()
+    problem_response.status_code = 200
+    problem_response.json.return_value = [{"sample_tests": []}]
+
+    with patch("routers.execute_samples.rest_client") as mock_rest:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.get.return_value = problem_response
+        mock_rest.return_value = mock_client
+
+        response = authed_client.post(
+            "/execute/samples",
+            json={"problem_id": 5, "language": "python", "code": "print(1)"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "No sample tests configured for this problem"

--- a/docs/design/page-specs/solutions.md
+++ b/docs/design/page-specs/solutions.md
@@ -148,26 +148,21 @@
 ### [▶ Run]
 ```
 Style: Primary — bg #C0392B, text white, radius 6px
-Action: Sends code to Piston API for execution
-        Shows Output panel below editor
-        Output: stdout, stderr, runtime
-        Running state: button shows spinner, disabled
+Action:
+  - If samples exist: run each sample via Judge0 → Pass/Fail vs expected
+  - If Custom input is filled: also run with that stdin → Custom output (raw, no Pass/Fail)
+  - If no samples and no custom: single run with empty stdin
+Docs link: language official docs (syntax help; no AI)
 ```
 
-### [✦ Evaluate] — ⚠️ P3 / Post-MVP (deferred from W3)
-> AI Evaluate is excluded from MVP scope. Run + Submit only for W3.
-> Tracked in GitHub issue #60.
+### [Evaluate] — #60
 ```
 Style: Secondary outline
-Action: Sends code to Gemma 4 API for evaluation
-        Returns two sections:
-          1. Forbidden Patterns — checklist per rule
-             ✅ rule name — "not used"
-             ❌ rule name — "detected — Line N"
-          2. Time Complexity
-             Estimated Big-O + Score out of 10
-        Does NOT reveal the answer or solution approach
-        Loading state: button shows spinner, disabled
+Enabled only when the latest Run has all samples Pass
+Action: soft forbidden regex hints + Gemini 3.5 Flash-Lite (Big O + duplication)
+Forbidden hints are NOT failures ("contests often disallow… try another approach")
+Does NOT reveal the answer or rewrite the solution
+No AI syntax hints (use stderr + Docs)
 ```
 
 ### [⬆ Submit]
@@ -183,16 +178,10 @@ Action: Saves current editor code as member's official submission
 
 ## Evaluation Rules Config
 ```
-Forbidden patterns are configurable per problem (not global).
-Admin sets rules when creating a problem.
-Examples:
-  - break statement
-  - STL containers (map, set, sort, etc.)
-  - built-in sort functions
-  - recursion (if iterative solution required)
-
-Gemma 4 receives: { code, language, forbidden_rules[] }
-Returns: { patterns: [{rule, detected, line}], complexity: {big_o, score} }
+MVP: global soft-forbidden preset (break, builtin sort, C++ map/set/priority_queue).
+Per-problem toggles: later (#31).
+Gemini receives: { code, language } only (no problem statement / answers).
+Returns: { forbidden_hints[], big_o, big_o_reason, duplicates[] }
 ```
 
 ---

--- a/docs/guidelines/judge0-rapidapi-setup.md
+++ b/docs/guidelines/judge0-rapidapi-setup.md
@@ -1,0 +1,59 @@
+# Judge0 CE (RapidAPI) for code execution
+
+Used by FastAPI `POST /execute` instead of self-hosted Piston.
+
+## Why RapidAPI
+
+- Public Piston (`emkc.org`) is whitelist-only
+- Always Free Oracle Ampere (ARM) cannot run the official Piston amd64 image reliably
+- Club volume is low (~10 runs/week); RapidAPI Basic pay-per-use is effectively free at that scale
+
+## Setup
+
+1. Create a RapidAPI account: https://rapidapi.com/
+2. Subscribe to **Judge0 CE** Basic: https://rapidapi.com/judge0-official/api/judge0-ce
+3. Copy the `X-RapidAPI-Key` from the playground / app keys page
+4. Our API enforces **20 executes per member per UTC day** (`EXECUTE_DAILY_LIMIT`).  
+   RapidAPI plan "Hard Limit" is configured by Judge0 (provider), not by subscribers.
+
+### Local `backend/.env`
+
+```
+JUDGE0_RAPIDAPI_KEY=...
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=...
+```
+
+### Heroku Config Vars
+
+Same keys as above (`JUDGE0_RAPIDAPI_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`).
+
+## Language mapping
+
+| Frontend | Judge0 language_id |
+|----------|--------------------|
+| python | 100 (Python 3.12.5) |
+| java | 91 (JDK 17) |
+| c | 103 (GCC 14.1.0) |
+| cpp | 105 (GCC 14.1.0) |
+| javascript | 93 (Node.js 18.15.0) |
+| typescript | 101 (TypeScript 5.6.2) |
+
+## Smoke test
+
+With backend running and a member JWT:
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/execute \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"language":"python","code":"print(1+1)"}'
+```
+
+Expect `"stdout":"2\n"` and `"exit_code":0`.
+
+## Ops notes
+
+- Rotate the RapidAPI key in the password manager if an exec leaves
+- Do not commit keys to git
+- Oracle Piston experiments are optional/legacy; see `piston-oracle-setup.md` only if revisiting self-host later

--- a/docs/guidelines/piston-oracle-setup.md
+++ b/docs/guidelines/piston-oracle-setup.md
@@ -1,0 +1,202 @@
+# Piston on Oracle Cloud (codeXperts)
+
+> **Status (2026-07):** Superseded for MVP by **Judge0 CE on RapidAPI**.  
+> See [`judge0-rapidapi-setup.md`](./judge0-rapidapi-setup.md).  
+> Keep this doc only if revisiting self-hosted Piston (requires **x86/AMD**, not Ampere ARM).
+
+Self-hosted Piston for `/execute`. Replaces the public `emkc.org` API (whitelist-only as of 2026-02-15).
+
+**Owner:** club Oracle tenancy (not a personal gaming account)  
+**Region:** Canada Southeast (Toronto) `ca-toronto-1` preferred  
+**Consumers:** Heroku FastAPI (`PISTON_API_URL`) and local `backend/.env`
+
+---
+
+## Architecture
+
+```
+Browser → Heroku FastAPI POST /execute → Oracle VM Piston :2000
+                (auth + limits)              (sandbox only)
+```
+
+- Do **not** colocated this with a game server (e.g. Palworld). Separate Always Free instance.
+- Frontend never calls Piston directly.
+
+`PISTON_API_URL` must be the API **prefix** (no trailing slash):
+
+| Host | `PISTON_API_URL` | Full execute URL |
+|------|------------------|------------------|
+| Self-hosted | `http://<PUBLIC_IP>:2000/api/v2` | `.../api/v2/execute` |
+| Public (legacy) | `https://emkc.org/api/v2/piston` | `.../piston/execute` |
+
+---
+
+## Phase 0 — Club Oracle account
+
+1. Create / use a **club** Oracle Cloud account (shared mailbox + 2FA with execs).
+2. Do **not** reuse a personal tenancy that already runs unrelated workloads.
+3. Complete identity verification if Always Free signup requires it.
+4. Store: tenancy OCID, home region, admin user emails in the club password manager (not in git).
+
+---
+
+## Phase 1 — Always Free VM (Toronto)
+
+**Console:** Compute → Instances → Create instance
+
+Suggested shape (Always Free eligible; exact labels vary by console UI):
+
+| Setting | Value |
+|---------|--------|
+| Name | `codexperts-piston` |
+| Compartment | root (or `codexperts`) |
+| Placement | `ca-toronto-1` (or nearest Free-eligible AD) |
+| Image | Ubuntu 22.04 or 24.04 |
+| Shape | Ampere **VM.Standard.A1.Flex** (Always Free) |
+| OCPUs | 2 (enough for MVP; raise later within free quota) |
+| Memory | 12 GB (or split quota with other Free VMs) |
+| Networking | New VCN or existing; assign **public IP** |
+| SSH | Upload club public key; keep private key in password manager |
+
+After create:
+
+1. Note **Public IP**.
+2. Security List / NSG ingress:
+   - SSH `22` from admin IPs only (preferred), or temporarily `0.0.0.0/0` then lock down
+   - Piston `2000/tcp` from **Heroku egress** if known; otherwise `0.0.0.0/0` for MVP and plan IP allowlist later
+3. SSH in:
+
+```bash
+ssh -i ~/.ssh/codexperts_oracle ubuntu@<PUBLIC_IP>
+```
+
+(Username may be `ubuntu` or `opc` depending on image.)
+
+---
+
+## Phase 2 — Docker + Piston
+
+On the VM:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo usermod -aG docker "$USER"
+# log out / back in so docker group applies
+```
+
+Run Piston (official image; needs `--privileged` for Isolate):
+
+```bash
+sudo mkdir -p /opt/piston && cd /opt/piston
+sudo docker run \
+  --privileged \
+  -v /opt/piston/data:/piston \
+  -d \
+  --restart unless-stopped \
+  -p 2000:2000 \
+  --name piston_api \
+  ghcr.io/engineer-man/piston
+```
+
+Smoke check (from your laptop):
+
+```bash
+curl -s "http://<PUBLIC_IP>:2000/api/v2/runtimes" | head
+```
+
+Empty list `[]` is OK until languages are installed.
+
+---
+
+## Phase 3 — Install MVP languages
+
+On a machine with Node 15+ (laptop or the VM):
+
+```bash
+git clone https://github.com/engineer-man/piston.git
+cd piston/cli && npm i && cd ../..
+```
+
+Install against the remote API (`-u`):
+
+```bash
+# From the piston repo root
+./cli/index.js -u "http://<PUBLIC_IP>:2000" ppman install python=3.10.0
+./cli/index.js -u "http://<PUBLIC_IP>:2000" ppman install java=15.0.2
+./cli/index.js -u "http://<PUBLIC_IP>:2000" ppman install gcc=10.2.0   # provides c++
+./cli/index.js -u "http://<PUBLIC_IP>:2000" ppman install node=15.10.0 # javascript
+```
+
+If a exact version string fails, run `ppman list` and pick the closest matching versions, then update `backend/services/piston.py` `SUPPORTED_LANGUAGES` to match.
+
+Verify:
+
+```bash
+curl -s -X POST "http://<PUBLIC_IP>:2000/api/v2/execute" \
+  -H "Content-Type: application/json" \
+  -d '{"language":"python","version":"3.10.0","files":[{"name":"a.py","content":"print(1+1)"}]}'
+```
+
+Expect `"stdout":"2\n"`.
+
+---
+
+## Phase 4 — Point FastAPI at Oracle
+
+**Local** `backend/.env`:
+
+```
+PISTON_API_URL=http://<PUBLIC_IP>:2000/api/v2
+```
+
+**Heroku** Config Vars (same key). Restart/redeploy backend after set.
+
+Then:
+
+```bash
+curl -s -X POST "http://127.0.0.1:8000/execute" \
+  -H "Authorization: Bearer <member access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"language":"python","code":"print(1+1)"}'
+```
+
+---
+
+## Ops / handoff checklist
+
+- [ ] Club Oracle login + 2FA documented
+- [ ] SSH key in password manager; at least two execs can access
+- [ ] Instance name `codexperts-piston`, public IP recorded
+- [ ] `docker ps` shows `piston_api` with `--restart unless-stopped`
+- [ ] Languages installed; `/api/v2/runtimes` lists python/java/c++/javascript
+- [ ] `PISTON_API_URL` set on Heroku + local
+- [ ] Security list locked down when Heroku egress IPs are known
+- [ ] This doc kept up to date when IP or versions change
+
+### Useful commands
+
+```bash
+sudo docker logs -f piston_api
+sudo docker restart piston_api
+curl -s "http://127.0.0.1:2000/api/v2/runtimes"
+```
+
+### Cost note
+
+Always Free Ampere shape: **$0** within Oracle Always Free quotas. Watch OCPU/memory quota if other Free VMs exist on the same tenancy.
+
+### Out of scope here
+
+- Gemma / LLM hosting (use a managed API for Evaluate #60; do not put GPUs on this box for MVP)
+- Sharing this VM with game servers

--- a/docs/schema/tables/problems.sql
+++ b/docs/schema/tables/problems.sql
@@ -3,6 +3,7 @@ CREATE TABLE problems (
   id BIGSERIAL PRIMARY KEY,
   title TEXT NOT NULL, -- Title of the problem
   description TEXT NOT NULL,
-  file_url TEXT NOT NULL,
-  created_at TIMESTAMP DEFAULT NOW()
+  file_url TEXT,
+  created_at TIMESTAMP DEFAULT NOW(),
+  sample_tests JSONB NOT NULL DEFAULT '[]'::jsonb -- [{stdin, expected_stdout}, ...] max 10 in app
 );

--- a/docs/schema/tables/submissions.sql
+++ b/docs/schema/tables/submissions.sql
@@ -6,5 +6,6 @@ CREATE TABLE submissions (
   code TEXT NOT NULL,
   language TEXT NOT NULL,
   ai_feedback TEXT,
-  created_at TIMESTAMP DEFAULT NOW()
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE (profile_id, problem_id)
 );

--- a/docs/sprints/overview.md
+++ b/docs/sprints/overview.md
@@ -31,7 +31,7 @@ Public (Unauthenticated)
 | **Kai** | Frontend (CSS) |
 | **Andra** | Frontend (CSS) |
 | **Gary** | Backend (Supabase / DB) |
-| **Dave** | Backend (FastAPI / Railway / Deployment) |
+| **Dave** | Backend (FastAPI / Heroku / Deployment) |
 
 **Onboarding flow:**
 ```
@@ -171,10 +171,10 @@ Central management dashboard for admins and executives.
 | Layer | Technology | Platform |
 |-------|-----------|----------|
 | Frontend | Next.js 15 + React + Tailwind CSS | Vercel |
-| Backend | FastAPI (Python) | Railway |
+| Backend | FastAPI (Python) | Heroku |
 | Database & Auth | Supabase (PostgreSQL + Google OAuth) | Managed |
 | Code Editor | Monaco Editor | In-browser |
-| Code Execution | Piston API (via FastAPI proxy) | External |
+| Code Execution | Judge0 CE (RapidAPI) via FastAPI `/execute` | External |
 | Social Feed | Elfsight embed (Instagram) | External |
 | Schedule | Google Calendar embed | External |
 

--- a/docs/sprints/sprint-plan.md
+++ b/docs/sprints/sprint-plan.md
@@ -14,7 +14,7 @@
 | Kai | `naik26m3` | Frontend |
 | Andra | `kazzledazz` | Frontend / Backend (Supabase) |
 | Gary | `GarySkywalker-droid` | Backend (Supabase / DB & Auth) |
-| Dave | `SystemProgrammerWizzard` | Backend (FastAPI / Railway / Deployment) / Frontend |
+| Dave | `SystemProgrammerWizzard` | Backend (FastAPI / Heroku / Deployment) / Frontend |
 
 > **FS** = Full Stack task — requires both FE and BE collaboration
 

--- a/docs/sprints/w6.md
+++ b/docs/sprints/w6.md
@@ -35,7 +35,7 @@ This sprint is about stability and delivery, not new features.
 
 ### Production Deployment
 - **Vercel `main` branch** — connected to production environment; custom domain configured
-- **Railway FastAPI** — production environment variables set, CORS updated for `codexperts.ca`
+- **Heroku FastAPI** — production environment variables set, CORS updated for `codexperts.ca`
 - **Domain connection** — `codexperts.ca` pointed to Vercel production deployment
 
 ### Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
+        "@monaco-editor/react": "^4.7.0",
         "@supabase/supabase-js": "^2.101.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -23,6 +24,7 @@
         "lucide-react": "^1.14.0",
         "next": "^16.2.3",
         "nodemailer": "^8.0.7",
+        "pdfjs-dist": "^4.10.38",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-easy-crop": "^5.5.7",
@@ -828,6 +830,279 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
@@ -1260,6 +1535,14 @@
       "dependencies": {
         "csstype": "^3.2.2"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1921,6 +2204,16 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
@@ -2646,6 +2939,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -3514,6 +3820,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.4.8",
+        "marked": "14.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3750,6 +4067,18 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4546,6 +4875,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
+    "@monaco-editor/react": "^4.7.0",
     "@supabase/supabase-js": "^2.101.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
@@ -18,6 +19,7 @@
     "lucide-react": "^1.14.0",
     "next": "^16.2.3",
     "nodemailer": "^8.0.7",
+    "pdfjs-dist": "^4.10.38",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-easy-crop": "^5.5.7",

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -4,7 +4,7 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { Upload } from 'lucide-react'
+import { Plus, Upload, X } from 'lucide-react'
 
 const PdfViewer = dynamic(() => import('@/components/problems/PdfViewer'), { ssr: false })
 import { uploadImage } from '@/services/cloudinaryService'
@@ -13,8 +13,11 @@ import { extractFilesFromZip, isZipFile } from '@/utils/zipImport'
 import {
   CONTENT_TYPE,
   FILE_FORMAT,
+  MAX_SAMPLE_TESTS,
   detectProblemFileType,
   downloadProblemDocument,
+  emptySamplePair,
+  normalizeSampleTests,
   previewDocxAsPdf,
 } from '@/services/problemsService'
 
@@ -73,10 +76,12 @@ export function emptyProblemForm() {
     sourceFileUrl: null,
     documentName: null,
     pendingImageFiles: [],
+    sampleTests: [emptySamplePair()],
   }
 }
 
 export function problemToForm(problem) {
+  const samples = normalizeSampleTests(problem.sample_tests)
   return {
     title: problem.title ?? '',
     week: problem.week != null ? String(problem.week) : '',
@@ -90,6 +95,7 @@ export function problemToForm(problem) {
     sourceFileUrl: problem.source_file_url ?? null,
     documentName: problem.file_url ? problem.file_url.split('/').pop() : null,
     pendingImageFiles: [],
+    sampleTests: samples.length > 0 ? samples : [emptySamplePair()],
   }
 }
 
@@ -654,6 +660,96 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
       {fileError && (
         <p className="text-sm font-inter text-accent">{fileError}</p>
       )}
+
+      <div className="border border-border rounded-md bg-bg-base p-4 space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-inter text-sm font-medium text-text-primary">Sample tests</p>
+            <p className="font-inter text-xs text-text-secondary mt-1">
+              Used when members click Run on Solutions. Start with one pair; add up to {MAX_SAMPLE_TESTS}.
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={(form.sampleTests?.length ?? 0) >= MAX_SAMPLE_TESTS}
+            onClick={() => onChange((prev) => ({
+              ...prev,
+              sampleTests: [...(prev.sampleTests ?? [emptySamplePair()]), emptySamplePair()]
+                .slice(0, MAX_SAMPLE_TESTS),
+            }))}
+            className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 font-inter text-sm text-text-primary hover:bg-bg-surface disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Plus size={14} />
+            Add
+          </button>
+        </div>
+
+        {(form.sampleTests?.length ? form.sampleTests : [emptySamplePair()]).map((sample, index) => (
+          <div key={index} className="space-y-2 border-t border-border pt-4 first:border-t-0 first:pt-0">
+            <div className="flex items-center justify-between gap-2">
+              <p className="font-inter text-sm font-medium text-text-primary">
+                Sample
+                {' '}
+                {index + 1}
+              </p>
+              {(form.sampleTests?.length ?? 0) > 1 && (
+                <button
+                  type="button"
+                  onClick={() => onChange((prev) => {
+                    const next = [...(prev.sampleTests ?? [])]
+                    next.splice(index, 1)
+                    return {
+                      ...prev,
+                      sampleTests: next.length > 0 ? next : [emptySamplePair()],
+                    }
+                  })}
+                  className="inline-flex items-center gap-1 font-inter text-xs text-text-secondary hover:text-accent"
+                  aria-label={`Remove sample ${index + 1}`}
+                >
+                  <X size={14} />
+                  Remove
+                </button>
+              )}
+            </div>
+            <label className="block space-y-1">
+              <span className="font-inter text-xs text-text-secondary">
+                Sample Input
+                {' '}
+                {index + 1}
+              </span>
+              <textarea
+                value={sample.stdin}
+                onChange={(e) => onChange((prev) => {
+                  const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
+                  next[index] = { ...next[index], stdin: e.target.value }
+                  return { ...prev, sampleTests: next }
+                })}
+                rows={3}
+                spellCheck={false}
+                className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+              />
+            </label>
+            <label className="block space-y-1">
+              <span className="font-inter text-xs text-text-secondary">
+                Sample Output
+                {' '}
+                {index + 1}
+              </span>
+              <textarea
+                value={sample.expected_stdout}
+                onChange={(e) => onChange((prev) => {
+                  const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
+                  next[index] = { ...next[index], expected_stdout: e.target.value }
+                  return { ...prev, sampleTests: next }
+                })}
+                rows={3}
+                spellCheck={false}
+                className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+              />
+            </label>
+          </div>
+        ))}
+      </div>
 
       <input
         ref={fileInputRef}

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -5,6 +5,8 @@ import dynamic from 'next/dynamic'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Upload } from 'lucide-react'
+
+const PdfViewer = dynamic(() => import('@/components/problems/PdfViewer'), { ssr: false })
 import { uploadImage } from '@/services/cloudinaryService'
 import { resolveMarkdownWithAssets, pickMarkdownFile, countUnresolvedImageRefs, prepareMarkdownForDisplay, buildPendingImageMap, guessTitleFromImport, guessTitleFromFilename, applyLocalImagesForPreview } from '@/utils/markdownImport'
 import { extractFilesFromZip, isZipFile } from '@/utils/zipImport'
@@ -13,7 +15,6 @@ import {
   FILE_FORMAT,
   detectProblemFileType,
   downloadProblemDocument,
-  getDocumentSignedUrl,
   previewDocxAsPdf,
 } from '@/services/problemsService'
 
@@ -148,7 +149,14 @@ function MarkdownBody({ children, pendingImageMap }) {
   )
 }
 
-export function DocumentViewer({ storagePath, fileFormat, accessToken, className = '' }) {
+export function DocumentViewer({
+  storagePath,
+  fileFormat,
+  accessToken,
+  className = '',
+  fill = false,
+  title = 'Problem document',
+}) {
   const containerRef = useRef(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -163,6 +171,7 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
     }
 
     let cancelled = false
+    let objectUrl = ''
 
     async function load() {
       setLoading(true)
@@ -171,8 +180,9 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
       setDocxBuffer(null)
       try {
         if (isPdfStorage) {
-          const url = await getDocumentSignedUrl(storagePath, accessToken)
-          if (!cancelled) setPdfUrl(url)
+          const blob = await downloadProblemDocument(storagePath, accessToken)
+          objectUrl = URL.createObjectURL(blob)
+          if (!cancelled) setPdfUrl(objectUrl)
         } else if (fileFormat === FILE_FORMAT.DOCX) {
           const blob = await downloadProblemDocument(storagePath, accessToken)
           if (!cancelled) setDocxBuffer(await blob.arrayBuffer())
@@ -185,7 +195,10 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
     }
 
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
   }, [storagePath, fileFormat, accessToken, isPdfStorage])
 
   useEffect(() => {
@@ -213,10 +226,11 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
 
   if (isPdfStorage && pdfUrl) {
     return (
-      <iframe
-        title="Problem document"
-        src={pdfUrl}
-        className={`w-full min-h-[70vh] border border-border rounded-md bg-bg-base ${className}`}
+      <PdfViewer
+        url={pdfUrl}
+        title={title}
+        fill={fill}
+        className={className}
       />
     )
   }
@@ -224,7 +238,9 @@ export function DocumentViewer({ storagePath, fileFormat, accessToken, className
   return (
     <div
       ref={containerRef}
-      className={`overflow-x-auto border border-border rounded-md bg-bg-base p-2 sm:p-4 min-h-[50vh] ${className}`}
+      className={`overflow-x-auto border border-border rounded-md bg-bg-base p-2 sm:p-4 ${
+        fill ? 'h-full min-h-0' : 'min-h-[50vh]'
+      } ${className}`}
     />
   )
 }
@@ -282,10 +298,10 @@ function PendingDocumentPreview({ file, fileFormat, accessToken }) {
 
   if (pdfUrl) {
     return (
-      <iframe
+      <PdfViewer
+        url={pdfUrl}
         title="Document preview"
-        src={pdfUrl}
-        className="w-full min-h-[50vh] border border-border rounded-md bg-bg-base"
+        className="w-full"
       />
     )
   }
@@ -668,23 +684,27 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
   )
 }
 
-export function ProblemBody({ problem, accessToken }) {
+export function ProblemBody({ problem, accessToken, fill = false }) {
   if (problem.content_type === CONTENT_TYPE.DOCUMENT && problem.file_url) {
     return (
       <DocumentViewer
         storagePath={problem.file_url}
         fileFormat={problem.file_format}
         accessToken={accessToken}
-        className="mb-8"
+        fill={fill}
+        title={problem.title || 'Problem document'}
+        className={fill ? 'h-full min-h-0' : 'mb-8'}
       />
     )
   }
 
   return (
-    <div className="font-inter text-base text-text-primary leading-[1.7] prose max-w-none mb-8
+    <div className={`font-inter text-base text-text-primary leading-[1.7] prose max-w-none
       prose-headings:font-montserrat prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
       prose-code:font-mono prose-code:text-sm prose-code:bg-bg-elevated prose-code:px-1 prose-code:py-0.5 prose-code:rounded
-      prose-pre:bg-bg-elevated prose-pre:p-4 prose-pre:rounded-lg prose-pre:font-mono prose-pre:text-sm">
+      prose-pre:bg-bg-elevated prose-pre:p-4 prose-pre:rounded-lg prose-pre:font-mono prose-pre:text-sm ${
+        fill ? 'h-full min-h-0' : 'mb-8'
+      }`}>
       <MarkdownBody>{problem.description || '_No content._'}</MarkdownBody>
     </div>
   )

--- a/src/app/problems/_shared.js
+++ b/src/app/problems/_shared.js
@@ -661,12 +661,12 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
         <p className="text-sm font-inter text-accent">{fileError}</p>
       )}
 
-      <div className="border border-border rounded-md bg-bg-base p-4 space-y-4">
+      <div className="border border-border rounded-md bg-bg-base p-4 space-y-3">
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="font-inter text-sm font-medium text-text-primary">Sample tests</p>
             <p className="font-inter text-xs text-text-secondary mt-1">
-              Used when members click Run on Solutions. Start with one pair; add up to {MAX_SAMPLE_TESTS}.
+              Used on Solutions Run. Up to {MAX_SAMPLE_TESTS} pairs.
             </p>
           </div>
           <button
@@ -685,9 +685,9 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
         </div>
 
         {(form.sampleTests?.length ? form.sampleTests : [emptySamplePair()]).map((sample, index) => (
-          <div key={index} className="space-y-2 border-t border-border pt-4 first:border-t-0 first:pt-0">
+          <div key={index} className="space-y-2 border-t border-border pt-3 first:border-t-0 first:pt-0">
             <div className="flex items-center justify-between gap-2">
-              <p className="font-inter text-sm font-medium text-text-primary">
+              <p className="font-inter text-xs font-medium text-text-secondary">
                 Sample
                 {' '}
                 {index + 1}
@@ -711,42 +711,30 @@ export function ProblemForm({ form, onChange, onSubmit, onCancel, submitting, ed
                 </button>
               )}
             </div>
-            <label className="block space-y-1">
-              <span className="font-inter text-xs text-text-secondary">
-                Sample Input
-                {' '}
-                {index + 1}
-              </span>
-              <textarea
-                value={sample.stdin}
-                onChange={(e) => onChange((prev) => {
-                  const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
-                  next[index] = { ...next[index], stdin: e.target.value }
-                  return { ...prev, sampleTests: next }
-                })}
-                rows={3}
-                spellCheck={false}
-                className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
-              />
-            </label>
-            <label className="block space-y-1">
-              <span className="font-inter text-xs text-text-secondary">
-                Sample Output
-                {' '}
-                {index + 1}
-              </span>
-              <textarea
-                value={sample.expected_stdout}
-                onChange={(e) => onChange((prev) => {
-                  const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
-                  next[index] = { ...next[index], expected_stdout: e.target.value }
-                  return { ...prev, sampleTests: next }
-                })}
-                rows={3}
-                spellCheck={false}
-                className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
-              />
-            </label>
+            <input
+              type="text"
+              value={sample.stdin}
+              onChange={(e) => onChange((prev) => {
+                const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
+                next[index] = { ...next[index], stdin: e.target.value }
+                return { ...prev, sampleTests: next }
+              })}
+              spellCheck={false}
+              placeholder={`Sample Input ${index + 1}`}
+              className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+            />
+            <input
+              type="text"
+              value={sample.expected_stdout}
+              onChange={(e) => onChange((prev) => {
+                const next = [...(prev.sampleTests?.length ? prev.sampleTests : [emptySamplePair()])]
+                next[index] = { ...next[index], expected_stdout: e.target.value }
+                return { ...prev, sampleTests: next }
+              })}
+              spellCheck={false}
+              placeholder={`Sample Output ${index + 1}`}
+              className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+            />
           </div>
         ))}
       </div>

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -477,6 +477,7 @@ function ProblemsContent() {
           dueDate,
           school,
           contentType: CONTENT_TYPE.DOCUMENT,
+          sampleTests: form.sampleTests,
           createdBy: user?.id,
         })
         createdId = row.id
@@ -486,6 +487,7 @@ function ProblemsContent() {
           sourceFileUrl: sourcePath,
           fileFormat,
           contentType: CONTENT_TYPE.DOCUMENT,
+          sampleTests: form.sampleTests,
         })
         cancelForm()
         await loadProblems()
@@ -502,6 +504,7 @@ function ProblemsContent() {
         dueDate,
         school,
         contentType: CONTENT_TYPE.MARKDOWN,
+        sampleTests: form.sampleTests,
         createdBy: user?.id,
       })
       cancelForm()
@@ -550,6 +553,7 @@ function ProblemsContent() {
           sourceFileUrl,
           fileFormat,
           description: '',
+          sampleTests: form.sampleTests,
         })
       } else {
         if (existing?.content_type === CONTENT_TYPE.DOCUMENT) {
@@ -567,6 +571,7 @@ function ProblemsContent() {
           fileFormat: null,
           fileUrl: null,
           sourceFileUrl: null,
+          sampleTests: form.sampleTests,
         })
       }
 

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -141,7 +141,7 @@ function PostView({
               <ProblemBody problem={problem} accessToken={accessToken} />
 
               <button
-                onClick={() => router.push(`/solutions?problem=${problem.id}`)}
+                onClick={() => router.push(`/solutions/${problem.id}`)}
                 className="w-full py-3 rounded-md bg-accent hover:bg-accent-hover text-white font-inter font-medium text-sm flex items-center justify-center gap-2 transition-colors"
               >
                 <PenLine size={14} />

--- a/src/app/solutions/[id]/page.js
+++ b/src/app/solutions/[id]/page.js
@@ -16,9 +16,11 @@ import {
 import {
   SOLUTION_LANGUAGES,
   executeCode,
+  executeSamples,
   languageLabel,
   submitSolution,
 } from '@/services/solutionService'
+import { normalizeSampleTests } from '@/services/problemsService'
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), { ssr: false })
 
@@ -196,18 +198,36 @@ function SolutionWorkspace() {
     setRunning(true)
     setOutput({ pending: true })
     try {
-      const result = await executeCode({
-        accessToken,
-        language,
-        code,
-      })
-      setOutput({
-        pending: false,
-        stdout: result.stdout || '',
-        stderr: result.stderr || '',
-        runtime: result.runtime,
-        exitCode: result.exit_code,
-      })
+      const samples = normalizeSampleTests(problem?.sample_tests)
+      if (samples.length > 0) {
+        const result = await executeSamples({
+          accessToken,
+          problemId,
+          language,
+          code,
+        })
+        setOutput({
+          pending: false,
+          mode: 'samples',
+          passed: result.passed,
+          total: result.total,
+          results: result.results || [],
+        })
+      } else {
+        const result = await executeCode({
+          accessToken,
+          language,
+          code,
+        })
+        setOutput({
+          pending: false,
+          mode: 'raw',
+          stdout: result.stdout || '',
+          stderr: result.stderr || '',
+          runtime: result.runtime,
+          exitCode: result.exit_code,
+        })
+      }
     } catch (err) {
       setOutput(null)
       setError(err.message || 'Run failed')
@@ -478,16 +498,66 @@ function SolutionWorkspace() {
                 </div>
 
                 {output && (
-                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-40 overflow-y-auto">
-                    <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
-                    <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
-                      {output.pending && '> Running...\n'}
-                      {!output.pending && output.stdout ? `${output.stdout}` : ''}
-                      {!output.pending && output.stderr ? `\n${output.stderr}` : ''}
-                      {!output.pending && typeof output.runtime === 'number'
-                        ? `\nRuntime: ${output.runtime}s`
-                        : ''}
-                    </pre>
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-64 overflow-y-auto">
+                    {output.pending && (
+                      <>
+                        <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
+                        <pre className="font-mono text-[13px] text-text-primary">{'> Running...\n'}</pre>
+                      </>
+                    )}
+                    {!output.pending && output.mode === 'samples' && (
+                      <div className="space-y-3">
+                        <p className="font-inter text-sm font-medium text-text-primary">
+                          Samples
+                          {' '}
+                          {output.passed}
+                          /
+                          {output.total}
+                          {' '}
+                          passed
+                        </p>
+                        {(output.results || []).map((row) => (
+                          <div key={row.index} className="border border-border rounded-md bg-bg-base p-3 space-y-1">
+                            <p className={`font-inter text-sm font-medium ${
+                              row.passed ? 'text-success' : 'text-accent'
+                            }`}
+                            >
+                              Sample
+                              {' '}
+                              {row.index}
+                              {': '}
+                              {row.passed ? 'Pass' : 'Fail'}
+                            </p>
+                            {!row.passed && (
+                              <pre className="font-mono text-[12px] text-text-primary whitespace-pre-wrap break-words">
+                                {`expected:\n${row.expected_stdout || '(empty)'}\n\ngot:\n${row.stdout || '(empty)'}`}
+                                {row.stderr ? `\n\nstderr:\n${row.stderr}` : ''}
+                              </pre>
+                            )}
+                            {row.passed && typeof row.runtime === 'number' && (
+                              <p className="font-inter text-xs text-text-secondary">
+                                Runtime:
+                                {' '}
+                                {row.runtime}
+                                s
+                              </p>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    {!output.pending && output.mode !== 'samples' && (
+                      <>
+                        <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
+                        <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
+                          {output.stdout ? `${output.stdout}` : ''}
+                          {output.stderr ? `\n${output.stderr}` : ''}
+                          {typeof output.runtime === 'number'
+                            ? `\nRuntime: ${output.runtime}s`
+                            : ''}
+                        </pre>
+                      </>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/app/solutions/[id]/page.js
+++ b/src/app/solutions/[id]/page.js
@@ -4,39 +4,45 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { ChevronDown, ChevronUp, Columns2, Loader2, Rows2 } from 'lucide-react'
+import { BookOpen, ChevronDown, ChevronUp, Columns2, Loader2, Rows2 } from 'lucide-react'
 import RoleGuard from '@/components/auth/RoleGuard'
 import { useAuth } from '@/hooks/useAuth'
 import { ProblemBody } from '@/app/problems/_shared'
-import { fetchProblemById } from '@/services/problemsService'
+import { fetchProblemById, normalizeSampleTests } from '@/services/problemsService'
 import {
   fetchCommunitySubmissions,
   fetchOwnSubmission,
 } from '@/services/submissionsService'
 import {
+  LANGUAGE_DOCS,
   SOLUTION_LANGUAGES,
+  evaluateSolution,
   executeCode,
   executeSamples,
   languageLabel,
   submitSolution,
 } from '@/services/solutionService'
-import { normalizeSampleTests } from '@/services/problemsService'
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), { ssr: false })
 
 const STARTER = {
-  python: 'def solution():\n    pass\n',
-  java: 'public class Main {\n    public static void main(String[] args) {\n        \n    }\n}\n',
-  c: '#include <stdio.h>\n\nint main(void) {\n    return 0;\n}\n',
-  cpp: '#include <iostream>\nusing namespace std;\n\nint main() {\n    return 0;\n}\n',
-  javascript: 'function solution() {\n  \n}\n',
-  typescript: 'function solution(): void {\n  \n}\n',
+  python: 'a, b = map(int, input().split())\n',
+  java: 'import java.util.Scanner;\n\npublic class Main {\n    public static void main(String[] args) {\n        Scanner sc = new Scanner(System.in);\n        int a = sc.nextInt();\n        int b = sc.nextInt();\n    }\n}\n',
+  c: '#include <stdio.h>\n\nint main(void) {\n    int a, b;\n    if (scanf("%d %d", &a, &b) != 2) return 1;\n    return 0;\n}\n',
+  cpp: '#include <iostream>\nusing namespace std;\n\nint main() {\n    int a, b;\n    if (!(cin >> a >> b)) return 1;\n    return 0;\n}\n',
+  javascript: 'const fs = require("fs");\nconst [a, b] = fs.readFileSync(0, "utf8").trim().split(/\\s+/).map(Number);\n',
+  typescript: 'const fs = require("fs");\nconst [a, b] = fs.readFileSync(0, "utf8").trim().split(/\\s+/).map(Number);\n',
 }
 
 const PROBLEM_SIZE_MIN = 22
 const PROBLEM_SIZE_MAX = 78
+const STACK_PROBLEM_VH_MIN = 18
+const STACK_PROBLEM_VH_MAX = 45
 
-function clampProblemSize(value) {
+function clampProblemSize(value, layout = 'split') {
+  if (layout === 'stack') {
+    return Math.min(STACK_PROBLEM_VH_MAX, Math.max(STACK_PROBLEM_VH_MIN, value))
+  }
   return Math.min(PROBLEM_SIZE_MAX, Math.max(PROBLEM_SIZE_MIN, value))
 }
 
@@ -76,6 +82,9 @@ function SolutionWorkspace() {
   const [language, setLanguage] = useState('python')
   const [code, setCode] = useState(STARTER.python)
   const [output, setOutput] = useState(null)
+  const [customInput, setCustomInput] = useState('')
+  const [evaluation, setEvaluation] = useState(null)
+  const [evaluating, setEvaluating] = useState(false)
   const [running, setRunning] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [statusMessage, setStatusMessage] = useState('')
@@ -86,7 +95,7 @@ function SolutionWorkspace() {
   const [communityLoading, setCommunityLoading] = useState(false)
   const [problemOpen, setProblemOpen] = useState(true)
   const [layout, setLayout] = useState('split') // 'split' | 'stack'
-  const [problemSize, setProblemSize] = useState(48) // percent of workspace
+  const [problemSize, setProblemSize] = useState(36) // split: width %, stack: problem vh
   const workspaceRef = useRef(null)
   const draggingRef = useRef(false)
 
@@ -94,6 +103,20 @@ function SolutionWorkspace() {
     () => SOLUTION_LANGUAGES.find((l) => l.value === language)?.monaco || 'python',
     [language],
   )
+
+  const samplesAllPassed = Boolean(
+    output
+    && !output.pending
+    && output.samples
+    && Number(output.samples.total) > 0
+    && Number(output.samples.passed) === Number(output.samples.total),
+  )
+
+  const evaluateDisabledReason = !accessToken
+    ? 'Sign in to evaluate'
+    : !samplesAllPassed
+      ? 'All sample tests must pass before Evaluate'
+      : ''
 
   useEffect(() => {
     let cancelled = false
@@ -155,10 +178,11 @@ function SolutionWorkspace() {
       const rect = workspaceRef.current.getBoundingClientRect()
       if (layout === 'split') {
         const next = ((event.clientX - rect.left) / rect.width) * 100
-        setProblemSize(clampProblemSize(next))
+        setProblemSize(clampProblemSize(next, 'split'))
       } else {
-        const next = ((event.clientY - rect.top) / rect.height) * 100
-        setProblemSize(clampProblemSize(next))
+        // Stack: problem height as vh so the rest of the page can scroll naturally.
+        const next = ((event.clientY - rect.top) / window.innerHeight) * 100
+        setProblemSize(clampProblemSize(next, 'stack'))
       }
     }
 
@@ -185,6 +209,8 @@ function SolutionWorkspace() {
   }
   function handleLanguageChange(next) {
     setLanguage(next)
+    setEvaluation(null)
+    setOutput(null)
     setCode((prev) => {
       const isStarter = Object.values(STARTER).includes(prev)
       if (!prev.trim() || isStarter) return STARTER[next] || ''
@@ -195,10 +221,15 @@ function SolutionWorkspace() {
   async function handleRun() {
     setStatusMessage('')
     setError('')
+    setEvaluation(null)
     setRunning(true)
     setOutput({ pending: true })
     try {
       const samples = normalizeSampleTests(problem?.sample_tests)
+      const hasCustom = customInput.trim() !== ''
+      let sampleBlock = null
+      let customBlock = null
+
       if (samples.length > 0) {
         const result = await executeSamples({
           accessToken,
@@ -206,18 +237,34 @@ function SolutionWorkspace() {
           language,
           code,
         })
-        setOutput({
-          pending: false,
-          mode: 'samples',
-          passed: result.passed,
-          total: result.total,
+        sampleBlock = {
+          passed: Number(result.passed) || 0,
+          total: Number(result.total) || 0,
           results: result.results || [],
-        })
-      } else {
+        }
+      }
+
+      if (hasCustom) {
         const result = await executeCode({
           accessToken,
           language,
           code,
+          stdin: customInput,
+        })
+        customBlock = {
+          stdout: result.stdout || '',
+          stderr: result.stderr || '',
+          runtime: result.runtime,
+          exitCode: result.exit_code,
+        }
+      }
+
+      if (!sampleBlock && !customBlock) {
+        const result = await executeCode({
+          accessToken,
+          language,
+          code,
+          stdin: '',
         })
         setOutput({
           pending: false,
@@ -227,12 +274,60 @@ function SolutionWorkspace() {
           runtime: result.runtime,
           exitCode: result.exit_code,
         })
+        return
       }
+
+      setOutput({
+        pending: false,
+        mode: sampleBlock ? 'samples' : 'custom',
+        samples: sampleBlock,
+        custom: customBlock,
+        passed: sampleBlock?.passed,
+        total: sampleBlock?.total,
+        results: sampleBlock?.results,
+      })
     } catch (err) {
+      const message = err.message || 'Run failed'
       setOutput(null)
-      setError(err.message || 'Run failed')
+      if (/daily .+ limit/i.test(message)) {
+        window.alert(message)
+        setError('')
+      } else {
+        setError(message)
+      }
     } finally {
       setRunning(false)
+    }
+  }
+
+  async function handleEvaluate() {
+    setStatusMessage('')
+    setError('')
+    if (!samplesAllPassed) {
+      setError('All sample tests must pass before Evaluate')
+      return
+    }
+    setEvaluating(true)
+    setEvaluation(null)
+    try {
+      const result = await evaluateSolution({
+        accessToken,
+        problemId,
+        language,
+        code,
+        samplesPassed: true,
+      })
+      setEvaluation(result)
+    } catch (err) {
+      const message = err.message || 'Evaluate failed'
+      if (/daily .+ limit/i.test(message)) {
+        window.alert(message)
+        setError('')
+      } else {
+        setError(message)
+      }
+    } finally {
+      setEvaluating(false)
     }
   }
 
@@ -328,7 +423,7 @@ function SolutionWorkspace() {
         </div>
       </div>
 
-      <section className="max-w-[1400px] mx-auto px-4 sm:px-6 py-8 pb-16">
+      <section className="max-w-[1400px] mx-auto px-4 sm:px-6 py-8 pb-24">
         {error && (
           <p className="font-inter text-sm text-accent mb-4">{error}</p>
         )}
@@ -351,7 +446,10 @@ function SolutionWorkspace() {
                 <div className="inline-flex rounded-md border border-border overflow-hidden">
                   <button
                     type="button"
-                    onClick={() => setLayout('stack')}
+                    onClick={() => {
+                      setLayout('stack')
+                      setProblemSize((size) => clampProblemSize(size, 'stack'))
+                    }}
                     title="Stack vertically"
                     className={`inline-flex items-center gap-1.5 px-3 py-1.5 font-inter text-sm ${
                       layout === 'stack'
@@ -364,7 +462,10 @@ function SolutionWorkspace() {
                   </button>
                   <button
                     type="button"
-                    onClick={() => setLayout('split')}
+                    onClick={() => {
+                      setLayout('split')
+                      setProblemSize((size) => clampProblemSize(size, 'split'))
+                    }}
                     title="Side by side"
                     className={`inline-flex items-center gap-1.5 px-3 py-1.5 font-inter text-sm border-l border-border ${
                       layout === 'split'
@@ -393,11 +494,11 @@ function SolutionWorkspace() {
 
             <div
               ref={workspaceRef}
-              className={`min-h-[560px] h-[calc(100vh-260px)] ${
+              className={
                 problemOpen && layout === 'split'
-                  ? 'flex flex-row'
+                  ? 'min-h-[560px] h-[calc(100vh-260px)] overflow-hidden flex flex-row'
                   : 'flex flex-col'
-              }`}
+              }
             >
               {problemOpen && (
                 <>
@@ -406,7 +507,10 @@ function SolutionWorkspace() {
                     style={
                       layout === 'split'
                         ? { width: `${problemSize}%`, flexShrink: 0 }
-                        : { height: `${problemSize}%`, flexShrink: 0 }
+                        : {
+                          height: `${clampProblemSize(problemSize, 'stack')}vh`,
+                          flexShrink: 0,
+                        }
                     }
                   >
                     <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-bg-surface shrink-0">
@@ -450,14 +554,33 @@ function SolutionWorkspace() {
                 </>
               )}
 
-              <div className="flex-1 min-w-0 min-h-0 flex flex-col gap-3">
-                <div className="border border-border rounded-md overflow-hidden bg-white flex-1 min-h-[200px]">
+              <div
+                className={
+                  layout === 'split'
+                    ? 'flex-1 min-w-0 min-h-0 flex flex-col gap-3 overflow-y-auto'
+                    : 'w-full flex flex-col gap-3'
+                }
+              >
+                <div
+                  className={
+                    layout === 'split'
+                      ? 'border border-border rounded-md overflow-hidden bg-white flex-1 min-h-[200px]'
+                      : 'border border-border rounded-md overflow-hidden bg-white h-[360px] shrink-0'
+                  }
+                >
                   <MonacoEditor
                     height="100%"
                     language={monacoLanguage}
                     theme="vs-dark"
                     value={code}
-                    onChange={(value) => setCode(value ?? '')}
+                    onChange={(value) => {
+                      const next = value ?? ''
+                      if (next !== code) {
+                        setEvaluation(null)
+                        setOutput(null)
+                      }
+                      setCode(next)
+                    }}
                     options={{
                       minimap: { enabled: false },
                       fontSize: 14,
@@ -468,7 +591,21 @@ function SolutionWorkspace() {
                   />
                 </div>
 
-                <div className="flex flex-col sm:flex-row gap-3 shrink-0">
+                <label className="block shrink-0 space-y-1">
+                  <span className="font-inter text-xs text-text-secondary">
+                    Custom input
+                  </span>
+                  <input
+                    type="text"
+                    value={customInput}
+                    onChange={(e) => setCustomInput(e.target.value)}
+                    spellCheck={false}
+                    placeholder="Optional stdin for a raw run"
+                    className="w-full border border-border rounded-md px-3 py-2 font-mono text-sm text-text-primary bg-bg-base focus:outline-none focus:border-border-strong"
+                  />
+                </label>
+
+                <div className="flex flex-col sm:flex-row gap-3 shrink-0 flex-wrap">
                   <button
                     type="button"
                     onClick={handleRun}
@@ -478,14 +615,27 @@ function SolutionWorkspace() {
                     {running && <Loader2 size={16} className="animate-spin" />}
                     {running ? 'Running…' : 'Run'}
                   </button>
-                  <button
-                    type="button"
-                    disabled
-                    title="Evaluate is deferred to a later release"
-                    className="inline-flex items-center justify-center rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-hint cursor-not-allowed"
-                  >
-                    Evaluate
-                  </button>
+                  <span className="relative inline-flex group">
+                    <button
+                      type="button"
+                      onClick={handleEvaluate}
+                      disabled={evaluating || !accessToken || !samplesAllPassed}
+                      className={`inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-primary hover:bg-bg-surface disabled:opacity-60 disabled:cursor-not-allowed${
+                        evaluateDisabledReason ? ' pointer-events-none' : ''
+                      }`}
+                    >
+                      {evaluating && <Loader2 size={16} className="animate-spin" />}
+                      {evaluating ? 'Evaluating…' : 'Evaluate'}
+                    </button>
+                    {evaluateDisabledReason && (
+                      <span
+                        role="tooltip"
+                        className="pointer-events-none absolute left-0 top-full z-30 mt-1.5 max-w-[min(280px,70vw)] rounded-md bg-bg-elevated px-2.5 py-1.5 font-inter text-xs text-bg-base opacity-0 group-hover:opacity-100"
+                      >
+                        {evaluateDisabledReason}
+                      </span>
+                    )}
+                  </span>
                   <button
                     type="button"
                     onClick={handleSubmit}
@@ -495,58 +645,145 @@ function SolutionWorkspace() {
                     {submitting && <Loader2 size={16} className="animate-spin" />}
                     {submitting ? 'Submitting…' : 'Submit'}
                   </button>
+                  {LANGUAGE_DOCS[language] && (
+                    <a
+                      href={LANGUAGE_DOCS[language].href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-secondary hover:bg-bg-surface"
+                    >
+                      <BookOpen size={16} />
+                      Docs
+                    </a>
+                  )}
                 </div>
 
+                {evaluation && (
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 space-y-4 border border-border">
+                    <p className="font-inter text-sm font-medium text-text-primary">Evaluation</p>
+                    {(evaluation.forbidden_hints || []).length > 0 && (
+                      <div className="space-y-2">
+                        <p className="font-inter text-xs font-medium text-text-secondary uppercase tracking-wide">
+                          Style hints (not failures)
+                        </p>
+                        {evaluation.forbidden_hints.map((hint) => (
+                          <div
+                            key={`${hint.rule}-${hint.line}`}
+                            className="rounded-md border border-border bg-bg-base p-3"
+                          >
+                            <p className="font-inter text-sm text-text-primary">
+                              {hint.rule}
+                              {hint.line != null ? ` (line ${hint.line})` : ''}
+                            </p>
+                            <p className="font-inter text-xs text-text-secondary mt-1">
+                              {hint.hint}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div>
+                      <p className="font-inter text-xs font-medium text-text-secondary uppercase tracking-wide mb-1">
+                        Big O (estimate)
+                      </p>
+                      <p className="font-inter text-sm font-medium text-text-primary">
+                        {evaluation.big_o}
+                      </p>
+                      {evaluation.big_o_reason && (
+                        <p className="font-inter text-xs text-text-secondary mt-1">
+                          {evaluation.big_o_reason}
+                        </p>
+                      )}
+                    </div>
+                    <div>
+                      <p className="font-inter text-xs font-medium text-text-secondary uppercase tracking-wide mb-1">
+                        Duplication
+                      </p>
+                      {(evaluation.duplicates || []).length === 0 ? (
+                        <p className="font-inter text-sm text-text-secondary">None noted.</p>
+                      ) : (
+                        <ul className="list-disc pl-5 space-y-1">
+                          {evaluation.duplicates.map((note) => (
+                            <li key={note} className="font-inter text-sm text-text-primary">
+                              {note}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                )}
+
                 {output && (
-                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-64 overflow-y-auto">
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 space-y-4">
                     {output.pending && (
                       <>
                         <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
                         <pre className="font-mono text-[13px] text-text-primary">{'> Running...\n'}</pre>
                       </>
                     )}
-                    {!output.pending && output.mode === 'samples' && (
+                    {!output.pending && output.samples && (
                       <div className="space-y-3">
                         <p className="font-inter text-sm font-medium text-text-primary">
                           Samples
                           {' '}
-                          {output.passed}
+                          {output.samples.passed}
                           /
-                          {output.total}
+                          {output.samples.total}
                           {' '}
                           passed
                         </p>
-                        {(output.results || []).map((row) => (
-                          <div key={row.index} className="border border-border rounded-md bg-bg-base p-3 space-y-1">
-                            <p className={`font-inter text-sm font-medium ${
-                              row.passed ? 'text-success' : 'text-accent'
-                            }`}
-                            >
-                              Sample
-                              {' '}
-                              {row.index}
-                              {': '}
-                              {row.passed ? 'Pass' : 'Fail'}
-                            </p>
-                            {!row.passed && (
-                              <pre className="font-mono text-[12px] text-text-primary whitespace-pre-wrap break-words">
-                                {`expected:\n${row.expected_stdout || '(empty)'}\n\ngot:\n${row.stdout || '(empty)'}`}
-                                {row.stderr ? `\n\nstderr:\n${row.stderr}` : ''}
-                              </pre>
-                            )}
-                            {row.passed && typeof row.runtime === 'number' && (
-                              <p className="font-inter text-xs text-text-secondary">
-                                Runtime:
+                        {(output.samples.results || []).map((row) => {
+                          const stdin = (row.stdin ?? '').trim() || '(empty)'
+                          const got = (row.stdout ?? '').trim() || '(empty)'
+                          const expected = (row.expected_stdout ?? '').trim() || '(empty)'
+                          return (
+                            <div key={row.index} className="border border-border rounded-md bg-bg-base p-3 space-y-1">
+                              <p className={`font-inter text-sm font-medium ${
+                                row.passed ? 'text-success' : 'text-accent'
+                              }`}
+                              >
+                                Sample
                                 {' '}
-                                {row.runtime}
-                                s
+                                {row.index}
+                                {': '}
+                                {row.passed ? 'Pass' : 'Fail'}
                               </p>
-                            )}
-                          </div>
-                        ))}
+                              <pre className="font-mono text-[12px] text-text-secondary whitespace-pre-wrap break-words">
+                                {`in:  ${stdin}\nout: ${got}`}
+                                {!row.passed ? `\nexp: ${expected}` : ''}
+                                {!row.passed && row.stderr ? `\nerr: ${row.stderr}` : ''}
+                              </pre>
+                              {typeof row.runtime === 'number' && (
+                                <p className="font-inter text-xs text-text-hint">
+                                  {row.runtime}
+                                  s
+                                </p>
+                              )}
+                            </div>
+                          )
+                        })}
                       </div>
                     )}
-                    {!output.pending && output.mode !== 'samples' && (
+                    {!output.pending && output.custom && (
+                      <div className="space-y-2">
+                        <p className="font-inter text-sm font-medium text-text-primary">
+                          Custom output
+                        </p>
+                        <p className="font-inter text-xs text-text-secondary">
+                          Experimental run only (no Pass/Fail).
+                        </p>
+                        <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words bg-bg-base border border-border rounded-md p-3">
+                          {output.custom.stdout ? `${output.custom.stdout}` : ''}
+                          {output.custom.stderr ? `\n${output.custom.stderr}` : ''}
+                          {typeof output.custom.runtime === 'number'
+                            ? `\nRuntime: ${output.custom.runtime}s`
+                            : ''}
+                          {!output.custom.stdout && !output.custom.stderr ? '(empty)' : ''}
+                        </pre>
+                      </div>
+                    )}
+                    {!output.pending && output.mode === 'raw' && (
                       <>
                         <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
                         <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
@@ -556,6 +793,11 @@ function SolutionWorkspace() {
                             ? `\nRuntime: ${output.runtime}s`
                             : ''}
                         </pre>
+                        {output.stderr && (
+                          <p className="font-inter text-xs text-text-secondary mt-2">
+                            Use the error message and Docs to fix syntax or runtime issues.
+                          </p>
+                        )}
                       </>
                     )}
                   </div>

--- a/src/app/solutions/[id]/page.js
+++ b/src/app/solutions/[id]/page.js
@@ -1,0 +1,600 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { ChevronDown, ChevronUp, Columns2, Loader2, Rows2 } from 'lucide-react'
+import RoleGuard from '@/components/auth/RoleGuard'
+import { useAuth } from '@/hooks/useAuth'
+import { ProblemBody } from '@/app/problems/_shared'
+import { fetchProblemById } from '@/services/problemsService'
+import {
+  fetchCommunitySubmissions,
+  fetchOwnSubmission,
+} from '@/services/submissionsService'
+import {
+  SOLUTION_LANGUAGES,
+  executeCode,
+  languageLabel,
+  submitSolution,
+} from '@/services/solutionService'
+
+const MonacoEditor = dynamic(() => import('@monaco-editor/react'), { ssr: false })
+
+const STARTER = {
+  python: 'def solution():\n    pass\n',
+  java: 'public class Main {\n    public static void main(String[] args) {\n        \n    }\n}\n',
+  c: '#include <stdio.h>\n\nint main(void) {\n    return 0;\n}\n',
+  cpp: '#include <iostream>\nusing namespace std;\n\nint main() {\n    return 0;\n}\n',
+  javascript: 'function solution() {\n  \n}\n',
+  typescript: 'function solution(): void {\n  \n}\n',
+}
+
+const PROBLEM_SIZE_MIN = 22
+const PROBLEM_SIZE_MAX = 78
+
+function clampProblemSize(value) {
+  return Math.min(PROBLEM_SIZE_MAX, Math.max(PROBLEM_SIZE_MIN, value))
+}
+
+function formatDue(dateStr) {
+  if (!dateStr) return null
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function formatSubmitted(dateStr) {
+  if (!dateStr) return '—'
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function memberInitials(name) {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() || '')
+    .join('') || '?'
+}
+
+function SolutionWorkspace() {
+  const params = useParams()
+  const problemId = Number(params?.id)
+  const { profile, accessToken } = useAuth()
+
+  const [problem, setProblem] = useState(null)
+  const [tab, setTab] = useState('mine')
+  const [language, setLanguage] = useState('python')
+  const [code, setCode] = useState(STARTER.python)
+  const [output, setOutput] = useState(null)
+  const [running, setRunning] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [statusMessage, setStatusMessage] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [community, setCommunity] = useState([])
+  const [expandedId, setExpandedId] = useState(null)
+  const [communityLoading, setCommunityLoading] = useState(false)
+  const [problemOpen, setProblemOpen] = useState(true)
+  const [layout, setLayout] = useState('split') // 'split' | 'stack'
+  const [problemSize, setProblemSize] = useState(48) // percent of workspace
+  const workspaceRef = useRef(null)
+  const draggingRef = useRef(false)
+
+  const monacoLanguage = useMemo(
+    () => SOLUTION_LANGUAGES.find((l) => l.value === language)?.monaco || 'python',
+    [language],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      if (!Number.isFinite(problemId) || problemId <= 0) {
+        setError('Invalid problem id')
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+      setError('')
+      try {
+        const row = await fetchProblemById(problemId)
+        if (cancelled) return
+        setProblem(row)
+
+        if (profile?.id) {
+          const own = await fetchOwnSubmission(profile.id, problemId)
+          if (cancelled) return
+          if (own?.code) {
+            setCode(own.code)
+            if (own.language) setLanguage(own.language)
+          }
+        }
+      } catch (err) {
+        if (!cancelled) setError(err.message || 'Failed to load problem')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => { cancelled = true }
+  }, [problemId, profile?.id])
+
+  const loadCommunity = useCallback(async () => {
+    setCommunityLoading(true)
+    try {
+      const rows = await fetchCommunitySubmissions(problemId)
+      setCommunity(rows)
+    } catch (err) {
+      setError(err.message || 'Failed to load community solutions')
+    } finally {
+      setCommunityLoading(false)
+    }
+  }, [problemId])
+
+  useEffect(() => {
+    if (tab === 'community') {
+      loadCommunity()
+    }
+  }, [tab, loadCommunity])
+
+  useEffect(() => {
+    function onPointerMove(event) {
+      if (!draggingRef.current || !workspaceRef.current) return
+      const rect = workspaceRef.current.getBoundingClientRect()
+      if (layout === 'split') {
+        const next = ((event.clientX - rect.left) / rect.width) * 100
+        setProblemSize(clampProblemSize(next))
+      } else {
+        const next = ((event.clientY - rect.top) / rect.height) * 100
+        setProblemSize(clampProblemSize(next))
+      }
+    }
+
+    function onPointerUp() {
+      if (!draggingRef.current) return
+      draggingRef.current = false
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+    }
+  }, [layout])
+
+  function startResize(event) {
+    event.preventDefault()
+    draggingRef.current = true
+    document.body.style.cursor = layout === 'split' ? 'col-resize' : 'row-resize'
+    document.body.style.userSelect = 'none'
+  }
+  function handleLanguageChange(next) {
+    setLanguage(next)
+    setCode((prev) => {
+      const isStarter = Object.values(STARTER).includes(prev)
+      if (!prev.trim() || isStarter) return STARTER[next] || ''
+      return prev
+    })
+  }
+
+  async function handleRun() {
+    setStatusMessage('')
+    setError('')
+    setRunning(true)
+    setOutput({ pending: true })
+    try {
+      const result = await executeCode({
+        accessToken,
+        language,
+        code,
+      })
+      setOutput({
+        pending: false,
+        stdout: result.stdout || '',
+        stderr: result.stderr || '',
+        runtime: result.runtime,
+        exitCode: result.exit_code,
+      })
+    } catch (err) {
+      setOutput(null)
+      setError(err.message || 'Run failed')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  async function handleSubmit() {
+    setStatusMessage('')
+    setError('')
+    setSubmitting(true)
+    try {
+      const result = await submitSolution({
+        accessToken,
+        problemId,
+        language,
+        code,
+      })
+      setStatusMessage(result.message || 'Solution submitted!')
+      if (tab === 'community') {
+        await loadCommunity()
+      }
+    } catch (err) {
+      setError(err.message || 'Submit failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="min-h-screen bg-bg-base">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-16">
+          <p className="font-inter text-sm text-text-secondary">Loading workspace…</p>
+        </div>
+      </main>
+    )
+  }
+
+  if (!problem) {
+    return (
+      <main className="min-h-screen bg-bg-base">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-16">
+          <p className="font-inter text-sm text-accent">{error || 'Problem not found'}</p>
+          <Link href="/solutions" className="font-inter text-sm text-text-secondary underline mt-4 inline-block">
+            Back to Solutions
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  const titleBits = [
+    problem.week != null ? `Week ${problem.week}` : null,
+    problem.title,
+  ].filter(Boolean)
+
+  return (
+    <main className="min-h-screen bg-bg-base">
+      <div className="bg-bg-surface border-b border-border">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6 md:py-8">
+          <p className="font-inter text-sm text-text-secondary mb-2">
+            <Link href="/solutions" className="hover:text-text-primary">Solutions</Link>
+            <span className="mx-2">/</span>
+            <span className="text-text-primary">{titleBits.join(' — ')}</span>
+          </p>
+          <div className="font-inter text-sm text-text-secondary flex flex-wrap gap-x-2 gap-y-1">
+            <span>Due {formatDue(problem.due_date) ?? '—'}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-6">
+        <div className="flex gap-6 border-b border-border">
+          <button
+            type="button"
+            onClick={() => setTab('mine')}
+            className={`font-inter text-sm pb-3 -mb-px border-b-2 transition-colors ${
+              tab === 'mine'
+                ? 'border-accent font-bold text-text-primary'
+                : 'border-transparent text-text-secondary'
+            }`}
+          >
+            My Solution
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab('community')}
+            className={`font-inter text-sm pb-3 -mb-px border-b-2 transition-colors ${
+              tab === 'community'
+                ? 'border-accent font-bold text-text-primary'
+                : 'border-transparent text-text-secondary'
+            }`}
+          >
+            Community Solutions
+          </button>
+        </div>
+      </div>
+
+      <section className="max-w-[1400px] mx-auto px-4 sm:px-6 py-8 pb-16">
+        {error && (
+          <p className="font-inter text-sm text-accent mb-4">{error}</p>
+        )}
+        {statusMessage && (
+          <p className="font-inter text-sm text-success mb-4">{statusMessage}</p>
+        )}
+
+        {tab === 'mine' && (
+          <div className="space-y-4">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setProblemOpen((open) => !open)}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 font-inter text-sm text-text-primary hover:bg-bg-surface"
+                >
+                  {problemOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                  {problemOpen ? 'Hide problem' : 'Show problem'}
+                </button>
+                <div className="inline-flex rounded-md border border-border overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setLayout('stack')}
+                    title="Stack vertically"
+                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 font-inter text-sm ${
+                      layout === 'stack'
+                        ? 'bg-bg-surface text-text-primary'
+                        : 'text-text-secondary hover:bg-bg-surface'
+                    }`}
+                  >
+                    <Rows2 size={16} />
+                    Stack
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setLayout('split')}
+                    title="Side by side"
+                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 font-inter text-sm border-l border-border ${
+                      layout === 'split'
+                        ? 'bg-bg-surface text-text-primary'
+                        : 'text-text-secondary hover:bg-bg-surface'
+                    }`}
+                  >
+                    <Columns2 size={16} />
+                    Split
+                  </button>
+                </div>
+              </div>
+              <label className="font-inter text-sm text-text-secondary flex items-center gap-2">
+                Language
+                <select
+                  value={language}
+                  onChange={(e) => handleLanguageChange(e.target.value)}
+                  className="border border-border rounded-md px-3 py-1.5 bg-bg-base text-text-primary"
+                >
+                  {SOLUTION_LANGUAGES.map((lang) => (
+                    <option key={lang.value} value={lang.value}>{lang.label}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <div
+              ref={workspaceRef}
+              className={`min-h-[560px] h-[calc(100vh-260px)] ${
+                problemOpen && layout === 'split'
+                  ? 'flex flex-row'
+                  : 'flex flex-col'
+              }`}
+            >
+              {problemOpen && (
+                <>
+                  <aside
+                    className="border border-border rounded-md bg-white flex flex-col min-h-0 min-w-0 overflow-hidden"
+                    style={
+                      layout === 'split'
+                        ? { width: `${problemSize}%`, flexShrink: 0 }
+                        : { height: `${problemSize}%`, flexShrink: 0 }
+                    }
+                  >
+                    <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-bg-surface shrink-0">
+                      <p className="font-inter text-sm font-medium text-text-primary">Problem</p>
+                      <button
+                        type="button"
+                        onClick={() => setProblemOpen(false)}
+                        className="font-inter text-xs text-text-secondary hover:text-text-primary"
+                      >
+                        Collapse
+                      </button>
+                    </div>
+                    <div
+                      className={`flex-1 min-h-0 ${
+                        problem.content_type === 'document' ? 'overflow-hidden' : 'overflow-y-auto'
+                      }`}
+                    >
+                      <ProblemBody problem={problem} accessToken={accessToken} fill />
+                    </div>
+                  </aside>
+
+                  <div
+                    role="separator"
+                    aria-orientation={layout === 'split' ? 'vertical' : 'horizontal'}
+                    aria-label="Resize problem panel"
+                    onPointerDown={startResize}
+                    className={
+                      layout === 'split'
+                        ? 'w-2 shrink-0 cursor-col-resize flex items-stretch justify-center group'
+                        : 'h-2 shrink-0 cursor-row-resize flex items-center justify-center group'
+                    }
+                  >
+                    <span
+                      className={
+                        layout === 'split'
+                          ? 'w-0.5 rounded-full bg-border-strong group-hover:bg-accent group-active:bg-accent h-12'
+                          : 'h-0.5 rounded-full bg-border-strong group-hover:bg-accent group-active:bg-accent w-12'
+                      }
+                    />
+                  </div>
+                </>
+              )}
+
+              <div className="flex-1 min-w-0 min-h-0 flex flex-col gap-3">
+                <div className="border border-border rounded-md overflow-hidden bg-white flex-1 min-h-[200px]">
+                  <MonacoEditor
+                    height="100%"
+                    language={monacoLanguage}
+                    theme="vs-dark"
+                    value={code}
+                    onChange={(value) => setCode(value ?? '')}
+                    options={{
+                      minimap: { enabled: false },
+                      fontSize: 14,
+                      fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+                      scrollBeyondLastLine: false,
+                      automaticLayout: true,
+                    }}
+                  />
+                </div>
+
+                <div className="flex flex-col sm:flex-row gap-3 shrink-0">
+                  <button
+                    type="button"
+                    onClick={handleRun}
+                    disabled={running || !accessToken}
+                    className="inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-inter text-sm font-medium bg-accent text-white hover:bg-accent-hover disabled:opacity-60"
+                  >
+                    {running && <Loader2 size={16} className="animate-spin" />}
+                    {running ? 'Running…' : 'Run'}
+                  </button>
+                  <button
+                    type="button"
+                    disabled
+                    title="Evaluate is deferred to a later release"
+                    className="inline-flex items-center justify-center rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-hint cursor-not-allowed"
+                  >
+                    Evaluate
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={submitting || !accessToken}
+                    className="inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-inter text-sm font-medium border border-border-strong text-text-primary hover:bg-bg-surface disabled:opacity-60"
+                  >
+                    {submitting && <Loader2 size={16} className="animate-spin" />}
+                    {submitting ? 'Submitting…' : 'Submit'}
+                  </button>
+                </div>
+
+                {output && (
+                  <div className="bg-bg-surface rounded-md p-4 shrink-0 max-h-40 overflow-y-auto">
+                    <p className="font-inter text-sm font-medium text-text-primary mb-2">Output</p>
+                    <pre className="font-mono text-[13px] text-text-primary whitespace-pre-wrap break-words">
+                      {output.pending && '> Running...\n'}
+                      {!output.pending && output.stdout ? `${output.stdout}` : ''}
+                      {!output.pending && output.stderr ? `\n${output.stderr}` : ''}
+                      {!output.pending && typeof output.runtime === 'number'
+                        ? `\nRuntime: ${output.runtime}s`
+                        : ''}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {tab === 'community' && (
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setProblemOpen((open) => !open)}
+                className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 font-inter text-sm text-text-primary hover:bg-bg-surface"
+              >
+                {problemOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                {problemOpen ? 'Hide problem' : 'Show problem'}
+              </button>
+            </div>
+
+            {problemOpen && (
+              <aside className="border border-border rounded-md bg-white max-h-[40vh] overflow-y-auto">
+                <div className="px-4 py-3 border-b border-border bg-bg-surface sticky top-0">
+                  <p className="font-inter text-sm font-medium text-text-primary">Problem</p>
+                </div>
+                <div className="px-4 py-4">
+                  <ProblemBody problem={problem} accessToken={accessToken} />
+                </div>
+              </aside>
+            )}
+
+            <div className="space-y-2">
+            {communityLoading && (
+              <p className="font-inter text-sm text-text-secondary">Loading submissions…</p>
+            )}
+            {!communityLoading && community.length === 0 && (
+              <p className="font-inter text-sm text-text-secondary py-8 text-center">
+                No community solutions yet.
+              </p>
+            )}
+            {community.map((row) => {
+              const open = expandedId === row.id
+              return (
+                <div key={row.id} className="border border-border rounded-md overflow-hidden bg-white">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedId(open ? null : row.id)}
+                    className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-bg-surface"
+                  >
+                    {row.avatarUrl ? (
+                      <img
+                        src={row.avatarUrl}
+                        alt=""
+                        className="w-8 h-8 rounded-full object-cover"
+                      />
+                    ) : (
+                      <span className="w-8 h-8 rounded-full bg-bg-layer1 text-text-secondary text-xs font-inter flex items-center justify-center">
+                        {memberInitials(row.name)}
+                      </span>
+                    )}
+                    <span className="font-inter text-sm font-medium text-text-primary flex-1">
+                      {row.name}
+                    </span>
+                    <span className="font-inter text-sm text-text-secondary">
+                      {languageLabel(row.language)}
+                    </span>
+                    <span className="font-inter text-sm text-text-hint">
+                      {formatSubmitted(row.submittedAt)}
+                    </span>
+                  </button>
+                  {open && (
+                    <div className="border-t border-border">
+                      <MonacoEditor
+                        height="300px"
+                        language={
+                          SOLUTION_LANGUAGES.find((l) => l.value === row.language)?.monaco
+                          || 'plaintext'
+                        }
+                        theme="vs-dark"
+                        value={row.code || ''}
+                        options={{
+                          readOnly: true,
+                          minimap: { enabled: false },
+                          fontSize: 14,
+                          fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+                          scrollBeyondLastLine: false,
+                          automaticLayout: true,
+                          domReadOnly: true,
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+            </div>
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}
+
+export default function SolutionWorkspacePage() {
+  return (
+    <RoleGuard>
+      <SolutionWorkspace />
+    </RoleGuard>
+  )
+}

--- a/src/app/solutions/page.js
+++ b/src/app/solutions/page.js
@@ -1,20 +1,132 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Check, Minus } from 'lucide-react'
 import RoleGuard from '@/components/auth/RoleGuard'
+import { useAuth } from '@/hooks/useAuth'
+import { fetchProblems } from '@/services/problemsService'
+import { fetchUserSubmissions } from '@/services/submissionsService'
+
+function formatDue(dateStr) {
+  if (!dateStr) return null
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function SolutionsListContent() {
+  const router = useRouter()
+  const { profile } = useAuth()
+  const [problems, setProblems] = useState([])
+  const [userSubmissions, setUserSubmissions] = useState(new Set())
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      setError('')
+      try {
+        const [problemRows, submitted] = await Promise.all([
+          fetchProblems(),
+          profile?.id ? fetchUserSubmissions(profile.id) : Promise.resolve(new Set()),
+        ])
+        if (cancelled) return
+        setProblems(problemRows)
+        setUserSubmissions(submitted)
+      } catch (err) {
+        if (!cancelled) setError(err.message || 'Failed to load problems')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => { cancelled = true }
+  }, [profile?.id])
+
+  return (
+    <main className="min-h-screen bg-bg-base">
+      <div className="bg-bg-surface">
+        <div className="max-w-[900px] mx-auto px-4 sm:px-6 pt-10 md:pt-12 pb-8">
+          <h1 className="font-montserrat font-bold text-4xl md:text-5xl mb-3 text-text-primary">
+            Solutions
+          </h1>
+          <p className="font-inter text-text-secondary">
+            Pick a problem to solve or review
+          </p>
+        </div>
+      </div>
+
+      <section className="max-w-[900px] mx-auto px-4 sm:px-6 py-10 md:py-12 pb-16">
+        {loading && (
+          <p className="font-inter text-sm text-text-secondary">Loading problems…</p>
+        )}
+        {error && (
+          <p className="font-inter text-sm text-accent mb-4">{error}</p>
+        )}
+        {!loading && !error && problems.length === 0 && (
+          <p className="font-inter text-text-secondary text-center py-16">
+            No problems found.
+          </p>
+        )}
+        {!loading && problems.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse min-w-[520px]">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left font-inter text-sm font-medium text-text-secondary py-3 pr-4 w-16">Week</th>
+                  <th className="text-left font-inter text-sm font-medium text-text-secondary py-3 pr-4">Title</th>
+                  <th className="text-left font-inter text-sm font-medium text-text-secondary py-3 pr-4">Lang</th>
+                  <th className="text-left font-inter text-sm font-medium text-text-secondary py-3 pr-4">Due</th>
+                  <th className="text-center font-inter text-sm font-medium text-text-secondary py-3 w-10">✓</th>
+                </tr>
+              </thead>
+              <tbody>
+                {problems.map((p) => {
+                  const solved = userSubmissions.has(p.id)
+                  return (
+                    <tr
+                      key={p.id}
+                      onClick={() => router.push(`/solutions/${p.id}`)}
+                      className="border-b border-border cursor-pointer transition-colors hover:bg-bg-surface"
+                    >
+                      <td className="font-inter text-sm text-text-primary py-3.5 pr-4">
+                        {p.week != null ? p.week : '—'}
+                      </td>
+                      <td className="font-inter text-sm text-text-primary py-3.5 pr-4 font-medium">
+                        {p.title}
+                      </td>
+                      <td className="font-inter text-sm text-text-secondary py-3.5 pr-4">—</td>
+                      <td className="font-inter text-sm text-text-secondary py-3.5 pr-4">
+                        {formatDue(p.due_date) ?? '—'}
+                      </td>
+                      <td className="text-center py-3.5">
+                        {solved
+                          ? <Check size={15} className="text-success mx-auto" />
+                          : <Minus size={15} className="text-text-hint mx-auto" />}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}
 
 export default function SolutionsPage() {
   return (
     <RoleGuard>
-      <main className="min-h-screen bg-bg-base">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-10 md:pt-16 pb-8 md:pb-12">
-          <h1 className="font-montserrat font-bold text-4xl md:text-5xl mb-3 text-text-primary">Solutions</h1>
-          <p className="text-text-secondary">Weekly problem solutions · Monaco Editor · Piston API</p>
-        </div>
-        <section className="max-w-6xl mx-auto px-4 sm:px-6 pb-16">
-          <div className="border border-border rounded-lg p-10 flex flex-col items-center justify-center text-center gap-3">
-            <p className="font-montserrat font-semibold text-text-primary">Coming soon</p>
-            <p className="text-sm text-text-secondary">Solutions with Monaco Editor integration are in development.</p>
-          </div>
-        </section>
-      </main>
+      <SolutionsListContent />
     </RoleGuard>
   )
 }

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -265,16 +265,16 @@ export default function Navbar() {
             {socialIconsRow}
             <div className="w-px h-5 bg-border mx-1" />
             {user ? (
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1.5 xl:gap-2 shrink-0">
                 <Link href={profileHref}><UserChip user={user} profile={profile} /></Link>
                 <button type="button" onClick={signOut}
-                  className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
+                  className="shrink-0 whitespace-nowrap px-2.5 xl:px-4 py-1.5 rounded-md text-xs xl:text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors">
                   Log out
                 </button>
               </div>
             ) : (
               <button type="button" onClick={handleLogIn} disabled={loggingIn}
-                className="px-4 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed">
+                className="shrink-0 whitespace-nowrap px-2.5 xl:px-4 py-1.5 rounded-md text-xs xl:text-sm font-medium bg-accent text-white hover:bg-accent-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed">
                 {loggingIn ? 'Redirecting…' : 'Get Started'}
               </button>
             )}

--- a/src/components/problems/PdfViewer.js
+++ b/src/components/problems/PdfViewer.js
@@ -1,0 +1,236 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Minus, Plus } from 'lucide-react'
+import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist'
+
+GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString()
+
+const MIN_SCALE = 0.5
+const MAX_SCALE = 2.5
+const SCALE_STEP = 0.1
+
+function ThumbnailPanelIcon({ size = 18 }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <path d="M9 4v16" />
+    </svg>
+  )
+}
+async function renderPageToCanvas(page, canvas, scale) {
+  const viewport = page.getViewport({ scale })
+  const context = canvas.getContext('2d')
+  canvas.width = viewport.width
+  canvas.height = viewport.height
+  await page.render({ canvasContext: context, viewport }).promise
+}
+
+export default function PdfViewer({ url, title = 'Problem document', className = '', fill = false }) {
+  const mainCanvasRef = useRef(null)
+  const thumbCanvasRefs = useRef([])
+  const [pdf, setPdf] = useState(null)
+  const [pageCount, setPageCount] = useState(0)
+  const [pageNumber, setPageNumber] = useState(1)
+  const [scale, setScale] = useState(1)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    let loadingTask
+
+    async function load() {
+      setLoading(true)
+      setError('')
+      setPdf(null)
+      setPageCount(0)
+      setPageNumber(1)
+      try {
+        loadingTask = getDocument(url)
+        const doc = await loadingTask.promise
+        if (cancelled) {
+          doc.destroy()
+          return
+        }
+        setPdf(doc)
+        setPageCount(doc.numPages)
+      } catch {
+        if (!cancelled) setError('Failed to load PDF.')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+      loadingTask?.destroy?.()
+    }
+  }, [url])
+
+  useEffect(() => {
+    if (!pdf || !mainCanvasRef.current) return
+    let cancelled = false
+
+    async function draw() {
+      const page = await pdf.getPage(pageNumber)
+      if (cancelled || !mainCanvasRef.current) return
+      await renderPageToCanvas(page, mainCanvasRef.current, scale)
+    }
+
+    draw().catch(() => {
+      if (!cancelled) setError('Failed to render page.')
+    })
+
+    return () => { cancelled = true }
+  }, [pdf, pageNumber, scale])
+
+  useEffect(() => {
+    if (!pdf || !sidebarOpen) return
+    let cancelled = false
+
+    async function drawThumbs() {
+      for (let i = 1; i <= pdf.numPages; i += 1) {
+        const canvas = thumbCanvasRefs.current[i - 1]
+        if (!canvas) continue
+        const page = await pdf.getPage(i)
+        if (cancelled) return
+        await renderPageToCanvas(page, canvas, 0.2)
+      }
+    }
+
+    drawThumbs().catch(() => {})
+    return () => { cancelled = true }
+  }, [pdf, sidebarOpen])
+
+  const zoomOut = useCallback(() => {
+    setScale((s) => Math.max(MIN_SCALE, Math.round((s - SCALE_STEP) * 10) / 10))
+  }, [])
+
+  const zoomIn = useCallback(() => {
+    setScale((s) => Math.min(MAX_SCALE, Math.round((s + SCALE_STEP) * 10) / 10))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className={`flex items-center justify-center py-16 ${className}`}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return <p className={`text-text-secondary font-inter text-sm ${className}`}>{error}</p>
+  }
+
+  return (
+    <div
+      className={`flex flex-col border border-border rounded-md overflow-hidden bg-bg-elevated ${
+        fill ? 'h-full min-h-0' : 'min-h-[70vh]'
+      } ${className}`}
+    >
+      <div className="flex items-center gap-2 px-2 py-1.5 bg-bg-elevated text-bg-base shrink-0 border-b border-border-strong">
+        <button
+          type="button"
+          onClick={() => setSidebarOpen((open) => !open)}
+          title={sidebarOpen ? 'Hide thumbnails' : 'Show thumbnails'}
+          aria-label={sidebarOpen ? 'Hide thumbnails' : 'Show thumbnails'}
+          aria-pressed={sidebarOpen}
+          className={`p-1.5 rounded hover:bg-white/10 ${sidebarOpen ? 'bg-white/10' : ''}`}
+        >
+          <ThumbnailPanelIcon size={18} />
+        </button>
+        <p className="font-inter text-xs truncate flex-1 min-w-0 opacity-90">{title}</p>
+        <div className="flex items-center gap-1 font-inter text-xs shrink-0">
+          <button
+            type="button"
+            disabled={pageNumber <= 1}
+            onClick={() => setPageNumber((n) => Math.max(1, n - 1))}
+            className="px-1.5 py-0.5 rounded hover:bg-white/10 disabled:opacity-40"
+          >
+            ‹
+          </button>
+          <span>
+            {pageNumber}
+            {' / '}
+            {pageCount}
+          </span>
+          <button
+            type="button"
+            disabled={pageNumber >= pageCount}
+            onClick={() => setPageNumber((n) => Math.min(pageCount, n + 1))}
+            className="px-1.5 py-0.5 rounded hover:bg-white/10 disabled:opacity-40"
+          >
+            ›
+          </button>
+        </div>
+        <div className="flex items-center gap-0.5 shrink-0">
+          <button
+            type="button"
+            onClick={zoomOut}
+            disabled={scale <= MIN_SCALE}
+            className="p-1 rounded hover:bg-white/10 disabled:opacity-40"
+            aria-label="Zoom out"
+          >
+            <Minus size={14} />
+          </button>
+          <span className="font-inter text-xs w-10 text-center">{Math.round(scale * 100)}%</span>
+          <button
+            type="button"
+            onClick={zoomIn}
+            disabled={scale >= MAX_SCALE}
+            className="p-1 rounded hover:bg-white/10 disabled:opacity-40"
+            aria-label="Zoom in"
+          >
+            <Plus size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-1 min-h-0 bg-bg-layer1">
+        {sidebarOpen && (
+          <aside className="w-28 shrink-0 overflow-y-auto border-r border-border-strong bg-bg-elevated p-2 space-y-2">
+            {Array.from({ length: pageCount }, (_, i) => (
+              <button
+                key={i + 1}
+                type="button"
+                onClick={() => setPageNumber(i + 1)}
+                className={`block w-full rounded border p-1 ${
+                  pageNumber === i + 1
+                    ? 'border-accent'
+                    : 'border-transparent hover:border-border'
+                }`}
+              >
+                <canvas
+                  ref={(el) => { thumbCanvasRefs.current[i] = el }}
+                  className="w-full h-auto bg-white rounded-sm"
+                />
+                <span className="block text-center font-inter text-[10px] text-bg-base mt-1 opacity-80">
+                  {i + 1}
+                </span>
+              </button>
+            ))}
+          </aside>
+        )}
+        <div className="flex-1 overflow-auto p-3 flex justify-center items-start">
+          <canvas ref={mainCanvasRef} className="bg-white shadow-sm max-w-full h-auto" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/backendApi.js
+++ b/src/lib/backendApi.js
@@ -1,0 +1,46 @@
+const DEFAULT_API_URL = ''
+
+export function getBackendApiUrl() {
+  const url = (process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL).replace(/\/$/, '')
+  return url
+}
+
+export async function backendFetch(path, { accessToken, method = 'GET', body } = {}) {
+  const base = getBackendApiUrl()
+  if (!base) {
+    throw new Error('Backend API URL is not configured (NEXT_PUBLIC_API_URL)')
+  }
+  if (!accessToken) {
+    throw new Error('Unauthorized')
+  }
+
+  const response = await fetch(`${base}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: body != null ? JSON.stringify(body) : undefined,
+  })
+
+  let data = null
+  try {
+    data = await response.json()
+  } catch {
+    data = null
+  }
+
+  if (!response.ok) {
+    const detail = data?.detail
+    const message = typeof detail === 'string'
+      ? detail
+      : Array.isArray(detail)
+        ? detail.map((d) => d.msg || JSON.stringify(d)).join(', ')
+        : data?.error || `Request failed (${response.status})`
+    const error = new Error(message)
+    error.status = response.status
+    throw error
+  }
+
+  return data
+}

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -13,6 +13,24 @@ export const FILE_FORMAT = {
   PDF: 'pdf',
 }
 
+export const MAX_SAMPLE_TESTS = 10
+
+export function emptySamplePair() {
+  return { stdin: '', expected_stdout: '' }
+}
+
+/** Keep up to 10 pairs that have any non-whitespace content. */
+export function normalizeSampleTests(samples) {
+  if (!Array.isArray(samples)) return []
+  return samples
+    .slice(0, MAX_SAMPLE_TESTS)
+    .map((s) => ({
+      stdin: String(s?.stdin ?? ''),
+      expected_stdout: String(s?.expected_stdout ?? ''),
+    }))
+    .filter((s) => s.stdin.trim() !== '' || s.expected_stdout.trim() !== '')
+}
+
 const SELECT_FIELDS = '*'
 
 function mapProblem(row) {
@@ -27,6 +45,7 @@ function mapProblem(row) {
     file_format: row.file_format,
     file_url: row.file_url,
     source_file_url: row.source_file_url ?? null,
+    sample_tests: normalizeSampleTests(row.sample_tests),
     created_at: row.created_at,
     created_by: row.created_by,
   }
@@ -97,6 +116,7 @@ export async function createProblem({
   fileFormat = null,
   fileUrl = null,
   sourceFileUrl = null,
+  sampleTests = [],
   createdBy,
 }) {
   const { data, error } = await supabase
@@ -111,6 +131,7 @@ export async function createProblem({
       file_format: fileFormat,
       file_url: fileUrl,
       source_file_url: sourceFileUrl,
+      sample_tests: normalizeSampleTests(sampleTests),
       created_by: createdBy ?? null,
     })
     .select(SELECT_FIELDS)
@@ -131,6 +152,9 @@ export async function updateProblem(id, fields) {
   if (fields.fileFormat !== undefined) payload.file_format = fields.fileFormat
   if (fields.fileUrl !== undefined) payload.file_url = fields.fileUrl
   if (fields.sourceFileUrl !== undefined) payload.source_file_url = fields.sourceFileUrl
+  if (fields.sampleTests !== undefined) {
+    payload.sample_tests = normalizeSampleTests(fields.sampleTests)
+  }
 
   const { data, error } = await supabase
     .from('problems')

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -77,6 +77,16 @@ export async function fetchProblems(schoolFilter) {
   return (data ?? []).map(mapProblem)
 }
 
+export async function fetchProblemById(id) {
+  const { data, error } = await supabase
+    .from('problems')
+    .select(SELECT_FIELDS)
+    .eq('id', id)
+    .single()
+  if (error) throw error
+  return mapProblem(data)
+}
+
 export async function createProblem({
   title,
   description = '',

--- a/src/services/solutionService.js
+++ b/src/services/solutionService.js
@@ -1,0 +1,34 @@
+import { backendFetch } from '@/lib/backendApi'
+
+export const SOLUTION_LANGUAGES = [
+  { value: 'python', label: 'Python', monaco: 'python' },
+  { value: 'java', label: 'Java', monaco: 'java' },
+  { value: 'c', label: 'C', monaco: 'c' },
+  { value: 'cpp', label: 'C++', monaco: 'cpp' },
+  { value: 'javascript', label: 'JavaScript', monaco: 'javascript' },
+  { value: 'typescript', label: 'TypeScript', monaco: 'typescript' },
+]
+
+export function languageLabel(value) {
+  return SOLUTION_LANGUAGES.find((l) => l.value === value)?.label ?? value
+}
+
+export async function executeCode({ accessToken, language, code, stdin = '' }) {
+  return backendFetch('/execute', {
+    accessToken,
+    method: 'POST',
+    body: { language, code, stdin },
+  })
+}
+
+export async function submitSolution({ accessToken, problemId, language, code }) {
+  return backendFetch('/submissions', {
+    accessToken,
+    method: 'POST',
+    body: {
+      problem_id: problemId,
+      language,
+      code,
+    },
+  })
+}

--- a/src/services/solutionService.js
+++ b/src/services/solutionService.js
@@ -33,6 +33,53 @@ export async function executeSamples({ accessToken, problemId, language, code })
   })
 }
 
+export async function evaluateSolution({
+  accessToken,
+  problemId,
+  language,
+  code,
+  samplesPassed,
+}) {
+  return backendFetch('/evaluate', {
+    accessToken,
+    method: 'POST',
+    body: {
+      problem_id: problemId,
+      language,
+      code,
+      samples_passed: samplesPassed,
+    },
+  })
+}
+
+/** Official docs for syntax help (no AI). */
+export const LANGUAGE_DOCS = {
+  python: {
+    label: 'Python docs',
+    href: 'https://docs.python.org/3/tutorial/datastructures.html',
+  },
+  java: {
+    label: 'Java SE API',
+    href: 'https://docs.oracle.com/en/java/javase/17/docs/api/',
+  },
+  c: {
+    label: 'C reference',
+    href: 'https://en.cppreference.com/w/c',
+  },
+  cpp: {
+    label: 'C++ reference',
+    href: 'https://en.cppreference.com/w/cpp',
+  },
+  javascript: {
+    label: 'MDN JavaScript',
+    href: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide',
+  },
+  typescript: {
+    label: 'TypeScript handbook',
+    href: 'https://www.typescriptlang.org/docs/handbook/intro.html',
+  },
+}
+
 export async function submitSolution({ accessToken, problemId, language, code }) {
   return backendFetch('/submissions', {
     accessToken,

--- a/src/services/solutionService.js
+++ b/src/services/solutionService.js
@@ -21,6 +21,18 @@ export async function executeCode({ accessToken, language, code, stdin = '' }) {
   })
 }
 
+export async function executeSamples({ accessToken, problemId, language, code }) {
+  return backendFetch('/execute/samples', {
+    accessToken,
+    method: 'POST',
+    body: {
+      problem_id: problemId,
+      language,
+      code,
+    },
+  })
+}
+
 export async function submitSolution({ accessToken, problemId, language, code }) {
   return backendFetch('/submissions', {
     accessToken,

--- a/src/services/submissionsService.js
+++ b/src/services/submissionsService.js
@@ -6,5 +6,55 @@ export async function fetchUserSubmissions(profileId) {
     .select('problem_id')
     .eq('profile_id', profileId)
   if (error) throw error
-  return new Set((data ?? []).map(s => s.problem_id))
+  return new Set((data ?? []).map((s) => s.problem_id))
+}
+
+export async function fetchOwnSubmission(profileId, problemId) {
+  const { data, error } = await supabase
+    .from('submissions')
+    .select('id, code, language, created_at, updated_at')
+    .eq('profile_id', profileId)
+    .eq('problem_id', problemId)
+    .maybeSingle()
+  if (error) throw error
+  return data
+}
+
+export async function fetchCommunitySubmissions(problemId) {
+  const { data, error } = await supabase
+    .from('submissions')
+    .select(`
+      id,
+      code,
+      language,
+      created_at,
+      updated_at,
+      profile_id,
+      profiles:profile_id (
+        first_name,
+        last_name,
+        avatar_url
+      )
+    `)
+    .eq('problem_id', problemId)
+    .order('updated_at', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false })
+
+  if (error) throw error
+
+  return (data ?? []).map((row) => {
+    const profile = row.profiles ?? {}
+    const first = profile.first_name?.trim() || ''
+    const last = profile.last_name?.trim() || ''
+    const name = `${first} ${last}`.trim() || 'Member'
+    return {
+      id: row.id,
+      code: row.code,
+      language: row.language,
+      submittedAt: row.updated_at || row.created_at,
+      profileId: row.profile_id,
+      name,
+      avatarUrl: profile.avatar_url || null,
+    }
+  })
 }

--- a/supabase/migrations/20260723120000_submissions_profile_problem_unique.sql
+++ b/supabase/migrations/20260723120000_submissions_profile_problem_unique.sql
@@ -1,0 +1,3 @@
+-- One submission per member per problem (upsert target for POST /submissions).
+CREATE UNIQUE INDEX IF NOT EXISTS submissions_profile_id_problem_id_uidx
+ON public.submissions (profile_id, problem_id);

--- a/supabase/migrations/20260723160000_add_problem_sample_tests.sql
+++ b/supabase/migrations/20260723160000_add_problem_sample_tests.sql
@@ -1,0 +1,6 @@
+-- Sample stdin/stdout pairs for Solutions Run pass/fail checks (max 10 enforced in app).
+ALTER TABLE public.problems
+  ADD COLUMN IF NOT EXISTS sample_tests JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN public.problems.sample_tests IS
+  'Ordered sample I/O pairs: [{ "stdin": string, "expected_stdout": string }, ...]';


### PR DESCRIPTION
## Summary
- Ship the Solutions coding workspace with Monaco editor, Judge0 execute, and submissions (#198)
- Add problem sample I/O and Run Pass/Fail results (#199 / #200)
- Add Evaluate (Gemini Big O + duplication + soft forbidden hints), custom input, and language Docs (#60 / #201)

## Test plan
- [ ] Open `/solutions` and a problem workspace; confirm editor, problem panel (Split/Stack), Run, Submit
- [ ] Run sample tests: Pass/Fail cards show `in` / `out` (and `exp` on Fail)
- [ ] Evaluate stays disabled until all samples Pass; tooltip and Evaluation panel render above samples
- [ ] Custom input runs without Pass/Fail; Docs link opens language docs
- [ ] Confirm Heroku has `GEMINI_API_KEY` and Judge0 env vars before/after deploy
- [ ] Spot-check navbar Log out at mid widths (no two-line wrap)