### PR TITLE
Release: mentor CTA flow and global Back button

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,6 +1,7 @@
 import './globals.css'
 import { Montserrat, Inter, JetBrains_Mono } from 'next/font/google'
 import Navbar from '@/components/common/Navbar'
+import BackButton from '@/components/common/BackButton'
 import JoinModal from '@/components/common/JoinModal'
 import Footer from '@/components/common/Footer'
 import { AuthProvider } from '@/contexts/AuthContext'
@@ -38,6 +39,7 @@ export default function RootLayout({ children }) {
             <Navbar />
             <JoinModal />
             <div className="pt-14">
+              <BackButton />
               {children}
             </div>
             <Footer />

--- a/src/app/mentor/page.js
+++ b/src/app/mentor/page.js
@@ -58,8 +58,8 @@ export default function MentorPage() {
         </p>
       </div>
 
-      <section className="bg-bg-surface py-10 md:py-14 px-4 sm:px-6">
-        <div className="max-w-3xl mx-auto">
+      <section className="bg-bg-surface py-10 md:py-14">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <h2 className="font-montserrat font-semibold text-2xl md:text-3xl text-text-primary mb-8">
             Welcome to codeXperts
           </h2>

--- a/src/app/mentor/page.js
+++ b/src/app/mentor/page.js
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { getOptimizedUrl } from '@/services/cloudinaryService'
 import { getSiteSetting } from '@/services/siteSettingsService'
 import MentorPhotoEditor from '@/components/mentor/MentorPhotoEditor'
+import PageCTA from '@/components/common/PageCTA'
 
 const FALLBACK_PHOTO = '/mentor.png'
 
@@ -105,6 +106,12 @@ export default function MentorPage() {
           </div>
         </div>
       </section>
+
+      <PageCTA
+        heading="See what's happening"
+        href="/announcements"
+        label="Announcements"
+      />
     </main>
   )
 }

--- a/src/components/common/AboutCTA.js
+++ b/src/components/common/AboutCTA.js
@@ -1,23 +1,13 @@
 'use client'
 
-import Link from 'next/link'
+import PageCTA from '@/components/common/PageCTA'
 
 export default function AboutCTA() {
   return (
-    <section className="w-full bg-bg-base py-12 md:py-16">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 flex flex-col md:flex-row items-center gap-6 md:gap-0">
-        <div className="flex-[2] text-center md:text-left">
-          <p className="font-montserrat font-semibold text-2xl md:text-3xl text-text-primary">A word from our mentor</p>
-        </div>
-        <div className="flex-[0.5] w-full md:w-auto flex justify-center md:justify-end">
-          <Link
-            href="/mentor"
-            className="w-full sm:w-auto justify-center px-8 py-4 flex items-center gap-2 rounded-md text-sm font-medium font-inter transition-colors bg-accent hover:bg-accent-hover text-white"
-          >
-            Our Mentor <span>→</span>
-          </Link>
-        </div>
-      </div>
-    </section>
+    <PageCTA
+      heading="A word from our mentor"
+      href="/mentor"
+      label="Our Mentor"
+    />
   )
 }

--- a/src/components/common/AboutCTA.js
+++ b/src/components/common/AboutCTA.js
@@ -1,26 +1,21 @@
 'use client'
 
-import { useAuth } from '@/hooks/useAuth'
-import JoinUsButton from '@/components/ui/JoinUsButton'
+import Link from 'next/link'
 
 export default function AboutCTA() {
-  const { user, profile, loading } = useAuth()
-  const isLoggedIn = !loading && !!user && !!profile?.first_name
-
-  const heading = isLoggedIn ? 'See what\'s happening' : 'Ready to contribute?'
-  const subtext = isLoggedIn
-    ? 'Check out the latest announcements from codeXperts.'
-    : 'Join our community or meet the minds behind the code.'
-
   return (
     <section className="w-full bg-bg-base py-12 md:py-16">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 flex flex-col md:flex-row items-center gap-6 md:gap-0">
         <div className="flex-[2] text-center md:text-left">
-          <p className="font-montserrat font-semibold text-2xl md:text-3xl text-text-primary mb-2">{heading}</p>
-          <p className="text-text-secondary">{subtext}</p>
+          <p className="font-montserrat font-semibold text-2xl md:text-3xl text-text-primary">A word from our mentor</p>
         </div>
         <div className="flex-[0.5] w-full md:w-auto flex justify-center md:justify-end">
-          <JoinUsButton className="w-full sm:w-auto justify-center px-8 py-4 flex items-center gap-2" />
+          <Link
+            href="/mentor"
+            className="w-full sm:w-auto justify-center px-8 py-4 flex items-center gap-2 rounded-md text-sm font-medium font-inter transition-colors bg-accent hover:bg-accent-hover text-white"
+          >
+            Our Mentor <span>→</span>
+          </Link>
         </div>
       </div>
     </section>

--- a/src/components/common/BackButton.js
+++ b/src/components/common/BackButton.js
@@ -1,0 +1,22 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+
+export default function BackButton() {
+  const pathname = usePathname()
+  const router = useRouter()
+
+  if (pathname === '/' || pathname.startsWith('/auth')) return null
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-4">
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className="text-sm font-inter text-text-secondary hover:text-text-primary transition-colors"
+      >
+        ← Back
+      </button>
+    </div>
+  )
+}

--- a/src/components/common/PageCTA.js
+++ b/src/components/common/PageCTA.js
@@ -1,0 +1,23 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function PageCTA({ heading, href, label }) {
+  return (
+    <section className="w-full bg-bg-base py-12 md:py-16">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 flex flex-col md:flex-row items-center gap-6 md:gap-0">
+        <div className="flex-[2] text-center md:text-left">
+          <p className="font-montserrat font-semibold text-2xl md:text-3xl text-text-primary">{heading}</p>
+        </div>
+        <div className="flex-[0.5] w-full md:w-auto flex justify-center md:justify-end">
+          <Link
+            href={href}
+            className="w-full sm:w-auto justify-center px-8 py-4 flex items-center gap-2 rounded-md text-sm font-medium font-inter transition-colors bg-accent hover:bg-accent-hover text-white"
+          >
+            {label} <span>→</span>
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- Align Our Mentor page gutters with About Us / Our Team
- About CTA links to Our Mentor; Mentor CTA links to Announcements
- Add global browser Back button (hidden on Home and auth routes)

## Test plan
- [ ] Production About → Mentor → Announcements CTA flow works
- [ ] Mentor page spacing matches About
- [ ] Back button appears on inner pages and returns to previous page
- [ ] Back button hidden on Home