### PR TITLE
fix: align announcements page background with design tokens

### DIFF
--- a/src/app/announcements/[id]/page.js
+++ b/src/app/announcements/[id]/page.js
@@ -121,7 +121,7 @@ export default function AnnouncementPostPage() {
 
   if (loading) {
     return (
-      <main className="min-h-screen bg-white flex justify-center items-center py-32">
+      <main className="min-h-screen bg-bg-base flex justify-center items-center py-32">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-text-primary" />
       </main>
     )
@@ -129,13 +129,13 @@ export default function AnnouncementPostPage() {
 
   if (!post) {
     return (
-      <main className="min-h-screen bg-white">
-        <div className="bg-[#F9F9F9] py-8 px-4 sm:px-6">
+      <main className="min-h-screen bg-bg-base">
+        <div className="bg-bg-surface py-8 px-4 sm:px-6">
           <div className="max-w-[900px] mx-auto">
             <h1 className="font-montserrat font-bold text-4xl text-text-primary">Announcements</h1>
           </div>
         </div>
-        <div className="bg-white py-20 px-4 text-center">
+        <div className="bg-bg-base py-20 px-4 text-center">
           <p className="text-text-hint font-inter">Announcement not found.</p>
           <button
             onClick={() => router.push('/announcements')}
@@ -152,11 +152,11 @@ export default function AnnouncementPostPage() {
   const isOldest = idx === announcements.length - 1
 
   return (
-    <main className="min-h-screen bg-white">
+    <main className="min-h-screen bg-bg-base">
       <PageHeader isAdmin={isAdmin} onNew={openNew} />
 
       {actionError && !showForm && (
-        <div className="bg-white px-4 sm:px-6 pt-4">
+        <div className="bg-bg-base px-4 sm:px-6 pt-4">
           <div className="max-w-[800px] mx-auto">
             <p className="text-sm text-error font-inter">{actionError}</p>
           </div>
@@ -164,7 +164,7 @@ export default function AnnouncementPostPage() {
       )}
 
       {showForm && (
-        <div className="bg-white py-8 px-4 sm:px-6">
+        <div className="bg-bg-base py-8 px-4 sm:px-6">
           <div className="max-w-[800px] mx-auto">
             <PostForm
               form={form}

--- a/src/app/announcements/_shared.js
+++ b/src/app/announcements/_shared.js
@@ -69,7 +69,7 @@ export function AnnouncementMarkdown({ children }) {
 
 export function PageHeader({ isAdmin, onNew }) {
   return (
-    <div className="bg-[#F9F9F9] py-8 px-4 sm:px-6">
+    <div className="bg-bg-surface py-8 px-4 sm:px-6">
       <div className="max-w-[900px] mx-auto flex items-center justify-between">
         <h1 className="font-montserrat font-bold text-4xl text-text-primary">Announcements</h1>
         {isAdmin && (
@@ -204,7 +204,7 @@ export function PostForm({ form, onChange, onSubmit, onCancel, submitting, editM
       <div className="flex gap-3 justify-end">
         <button
           onClick={onCancel}
-          className="px-4 py-2 border border-border-strong rounded-md text-sm font-inter text-text-secondary hover:bg-[#F9F9F9] transition-colors"
+          className="px-4 py-2 border border-border-strong rounded-md text-sm font-inter text-text-secondary hover:bg-bg-layer1 transition-colors"
         >
           Cancel
         </button>
@@ -230,7 +230,7 @@ export function DeleteModal({ onConfirm, onCancel, deleting }) {
         <div className="flex gap-3 justify-end">
           <button
             onClick={onCancel}
-            className="px-4 py-2 border border-border-strong rounded-md text-sm font-inter text-text-secondary hover:bg-[#F9F9F9] transition-colors"
+            className="px-4 py-2 border border-border-strong rounded-md text-sm font-inter text-text-secondary hover:bg-bg-layer1 transition-colors"
           >
             Cancel
           </button>
@@ -249,7 +249,7 @@ export function DeleteModal({ onConfirm, onCancel, deleting }) {
 
 export function PostContent({ post }) {
   return (
-    <div className="bg-white py-12 px-4 sm:px-6">
+    <div className="bg-bg-base py-12 px-4 sm:px-6">
       <div className="max-w-[800px] mx-auto">
         <h2 className="font-montserrat font-bold text-2xl text-text-primary mb-2">{post.title}</h2>
         <p className="text-sm text-text-hint font-inter mb-4">
@@ -281,7 +281,7 @@ export function NavRow({ onPrev, onNext, onList, onDelete, onEdit, prevDisabled,
   }
 
   const btnBase = 'px-4 py-2 border rounded-md text-sm font-inter transition-colors'
-  const btnActive = `${btnBase} border-border-strong text-text-secondary hover:bg-[#F9F9F9]`
+  const btnActive = `${btnBase} border-border-strong text-text-secondary hover:bg-bg-layer1`
   const btnDisabled = `${btnBase} border-border text-border-strong cursor-not-allowed`
 
   return (
@@ -298,7 +298,7 @@ export function NavRow({ onPrev, onNext, onList, onDelete, onEdit, prevDisabled,
             </button>
             {isAdmin && (
               <div className="flex gap-1">
-                <button onClick={onEdit} title="Edit" className="p-1.5 text-text-secondary hover:text-text-primary transition-colors rounded-md hover:bg-[#F9F9F9]">
+                <button onClick={onEdit} title="Edit" className="p-1.5 text-text-secondary hover:text-text-primary transition-colors rounded-md hover:bg-bg-layer1">
                   <IconEdit className="w-4 h-4" />
                 </button>
                 <button onClick={() => setShowDeleteModal(true)} title="Delete" className="p-1.5 text-accent hover:text-accent-hover transition-colors rounded-md hover:bg-accent-bg">

--- a/src/app/announcements/page.js
+++ b/src/app/announcements/page.js
@@ -39,7 +39,7 @@ function ListView({
       <PageHeader isAdmin={isAdmin} onNew={onNew} />
 
       {actionError && !showForm && (
-        <div className="bg-white px-4 sm:px-6 pt-4">
+        <div className="bg-bg-base px-4 sm:px-6 pt-4">
           <div className="max-w-[800px] mx-auto">
             <p className="text-sm text-error font-inter">{actionError}</p>
           </div>
@@ -47,7 +47,7 @@ function ListView({
       )}
 
       {showForm && (
-        <div className="bg-white py-8 px-4 sm:px-6">
+        <div className="bg-bg-base py-8 px-4 sm:px-6">
           <div className="max-w-[800px] mx-auto">
             <PostForm
               form={form}
@@ -61,7 +61,7 @@ function ListView({
         </div>
       )}
 
-      <div className="bg-white py-12 px-4 sm:px-6">
+      <div className="bg-bg-base py-12 px-4 sm:px-6">
         <div className="max-w-[900px] mx-auto">
           {announcements.length === 0 ? (
             <p className="text-center text-text-hint font-inter py-16">No announcements yet.</p>
@@ -83,7 +83,7 @@ function ListView({
                       <tr
                         key={item.id}
                         onClick={() => router.push(`/announcements/${item.id}`)}
-                        className="border-b border-border hover:bg-[#F9F9F9] cursor-pointer transition-colors"
+                        className="border-b border-border hover:bg-bg-layer1 cursor-pointer transition-colors"
                       >
                         <td className="py-3 px-3 text-sm text-text-hint font-inter">{rowNum}</td>
                         <td className="py-3 px-3 text-sm text-text-primary font-inter">{item.title}</td>
@@ -100,7 +100,7 @@ function ListView({
                   <button
                     onClick={() => setPage(p => Math.max(1, p - 1))}
                     disabled={page === 1}
-                    className="px-3 py-1 border border-border-strong rounded-md disabled:text-border-strong disabled:border-border hover:bg-[#F9F9F9] transition-colors"
+                    className="px-3 py-1 border border-border-strong rounded-md disabled:text-border-strong disabled:border-border hover:bg-bg-layer1 transition-colors"
                   >
                     ← Prev
                   </button>
@@ -108,7 +108,7 @@ function ListView({
                   <button
                     onClick={() => setPage(p => Math.min(totalPages, p + 1))}
                     disabled={page === totalPages}
-                    className="px-3 py-1 border border-border-strong rounded-md disabled:text-border-strong disabled:border-border hover:bg-[#F9F9F9] transition-colors"
+                    className="px-3 py-1 border border-border-strong rounded-md disabled:text-border-strong disabled:border-border hover:bg-bg-layer1 transition-colors"
                   >
                     Next →
                   </button>
@@ -259,7 +259,7 @@ function AnnouncementsContent() {
       <PageHeader isAdmin={isAdmin} onNew={openNew} />
 
       {actionError && !showForm && (
-        <div className="bg-white px-4 sm:px-6 pt-4">
+        <div className="bg-bg-base px-4 sm:px-6 pt-4">
           <div className="max-w-[800px] mx-auto">
             <p className="text-sm text-error font-inter">{actionError}</p>
           </div>
@@ -267,7 +267,7 @@ function AnnouncementsContent() {
       )}
 
       {showForm && (
-        <div className="bg-white py-8 px-4 sm:px-6">
+        <div className="bg-bg-base py-8 px-4 sm:px-6">
           <div className="max-w-[800px] mx-auto">
             <PostForm
               form={form}
@@ -297,7 +297,7 @@ function AnnouncementsContent() {
           />
         </>
       ) : (
-        <div className="bg-white py-20 px-4 text-center">
+        <div className="bg-bg-base py-20 px-4 text-center">
           <p className="text-text-hint font-inter">No announcements yet.</p>
         </div>
       )}
@@ -307,7 +307,7 @@ function AnnouncementsContent() {
 
 export default function AnnouncementsPage() {
   return (
-    <main className="min-h-screen bg-white">
+    <main className="min-h-screen bg-bg-base">
       <Suspense
         fallback={
           <div className="flex justify-center items-center py-32">


### PR DESCRIPTION
## Summary
- Replace hardcoded `bg-white` / `#F9F9F9` on Announcements pages with design tokens (`bg-bg-base`, `bg-bg-surface`, `bg-bg-layer1`)
- Match About Us / Schedule page background for visual consistency

## Test plan
- [ ] `/announcements` background matches `/about` (off-white `bg-bg-base`, not pure white)
- [ ] `/announcements/[id]` and list view use the same tokens
- [ ] Editor/modal inputs still readable; hover states still visible