### PR TITLE
fix: prevent page load hangs with timeouts and lighter fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ codexperts-web/
 │   └── utils/               # Helper functions, constants
 ├── docs/
 │   ├── design/              # Design system, sitemap, page-level specs
-│   ├── guidelines/          # code-conventions, git-workflow, judge0-rapidapi-setup
+│   ├── guidelines/          # code-conventions, git-workflow, data-loading, judge0-rapidapi-setup
 │   ├── meeting-notes/       # Sprint meeting records
 │   ├── sprints/             # Sprint plan + weekly specs
 │   └── schema/              # Database schema definitions

--- a/docs/guidelines/code-conventions.md
+++ b/docs/guidelines/code-conventions.md
@@ -175,3 +175,11 @@ if (user.status === 'pending') return <PendingScreen />;
 - No `console.log` in commits — remove all debug logs before pushing
 - No hardcoded role strings — use the `ROLES` constant from `constants.js`
 - No direct Supabase calls inside components — always go through the `services/` layer
+
+---
+
+## 9. Client Data Loading
+
+All client-side page/data loaders must abort on unmount, time out (15s), and show errors instead of hanging on a spinner.
+
+See **`docs/guidelines/data-loading.md`** for the required pattern (`createLoadGuard`, `fetchWithTimeout`, `withTimeout`) and the new-page checklist.

--- a/docs/guidelines/data-loading.md
+++ b/docs/guidelines/data-loading.md
@@ -1,0 +1,110 @@
+# Client Data Loading
+
+> Rules for fetching data in client components so pages never hang on a spinner.
+> Follow this for every new page and when editing existing loaders.
+
+---
+
+## Why loads hang
+
+Most list/detail pages are `'use client'` and do this on mount:
+
+1. `loading = true` (full-page spinner)
+2. Await Supabase / API
+3. `loading = false`
+
+If the network stalls, auth session never resolves, or the user navigates away mid-request, step 3 may never run cleanly. That feels like an infinite load even when there is little data.
+
+First visit to `codexperts.ca` is often slower for separate reasons:
+
+- Cold start (Vercel + browser cache empty)
+- `AuthProvider` waits on Supabase `getSession` / profile before navbar settles
+- Home loads hero from Supabase and Elfsight social widgets from a third party
+
+Timeouts do not remove network latency, but they stop the UI from spinning forever.
+
+---
+
+## Required pattern
+
+Every client `useEffect` data load must:
+
+1. **Abort on unmount** (do not update state after leave)
+2. **Timeout at 15s** (then show an error, clear spinner)
+3. **Surface errors** (never swallow failures into an endless spinner)
+
+### Prefer these helpers
+
+| Helper | When |
+|--------|------|
+| `createLoadGuard()` from `src/utils/loadGuard.js` | Supabase queries that accept `{ signal }` |
+| `fetchWithTimeout()` from `src/utils/fetchWithTimeout.js` | `fetch()` / Next.js API routes |
+| `withTimeout()` from `src/utils/withTimeout.js` | Promises without AbortSignal |
+
+### Example (Supabase / service layer)
+
+```js
+import { createLoadGuard } from '@/utils/loadGuard'
+import { fetchThings } from '@/services/thingsService'
+
+useEffect(() => {
+  const guard = createLoadGuard()
+
+  async function load() {
+    setLoading(true)
+    setError('')
+    try {
+      const data = await fetchThings({ signal: guard.signal })
+      if (!guard.isCancelled()) setThings(data)
+    } catch (err) {
+      if (!guard.isCancelled()) setError(guard.loadError(err, 'Failed to load things'))
+    } finally {
+      if (!guard.isCancelled()) setLoading(false)
+    }
+  }
+
+  load()
+  return () => guard.cleanup()
+}, [])
+```
+
+### Service functions
+
+Accept an optional `{ signal }` and pass it through:
+
+```js
+export async function fetchThings({ signal } = {}) {
+  let query = supabase.from('things').select('*')
+  if (signal) query = query.abortSignal(signal)
+  const { data, error } = await query
+  if (error) throw error
+  return data
+}
+```
+
+### Detail pages
+
+Do **not** download the full list only to render one item.
+
+- Fetch the single record by id
+- If prev/next is needed, fetch a light id/date list — not every row’s body/media
+
+---
+
+## Checklist for new pages
+
+- [ ] Loader uses `createLoadGuard`, `fetchWithTimeout`, or `withTimeout`
+- [ ] Unmount cleanup aborts in-flight work
+- [ ] Timeout shows a user-visible error and clears the spinner
+- [ ] Detail routes use single-item fetch (+ light nav if needed)
+- [ ] No `console.log` left in the loader
+- [ ] Components call `services/` — no direct Supabase in JSX beyond existing exceptions being migrated
+
+---
+
+## Related
+
+- `docs/guidelines/code-conventions.md` — services layer, async style
+- `src/utils/loadGuard.js`
+- `src/utils/fetchWithTimeout.js`
+- `src/utils/withTimeout.js`

--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { getCurrentExecutives } from '@/services/executiveService'
 import AboutCTA from '@/components/common/AboutCTA'
 import { IconLinkedIn, IconGitHub } from '@/components/ui/SocialIcons'
+import { createLoadGuard } from '@/utils/loadGuard'
 
 const TITLE_ORDER = ['President', 'Vice President', 'Treasurer']
 const SCHOOLS = [
@@ -56,8 +57,12 @@ const AboutPage = () => {
   const [executivesBySchool, setExecutivesBySchool] = useState({})
 
   useEffect(() => {
-    getCurrentExecutives()
-      .then((data) => {
+    const guard = createLoadGuard()
+
+    async function load() {
+      try {
+        const data = await getCurrentExecutives({ signal: guard.signal })
+        if (guard.isCancelled()) return
         const grouped = {}
         for (const school of SCHOOLS) {
           const schoolExecs = data.filter((e) => e.school === school.key)
@@ -66,8 +71,13 @@ const AboutPage = () => {
           )
         }
         setExecutivesBySchool(grouped)
-      })
-      .catch(() => {})
+      } catch {
+        // Keep empty TBD placeholders on timeout/error
+      }
+    }
+
+    load()
+    return () => guard.cleanup()
   }, [])
 
   return (

--- a/src/app/announcements/[id]/page.js
+++ b/src/app/announcements/[id]/page.js
@@ -6,12 +6,15 @@ import { useAuth } from '@/hooks/useAuth'
 import { canAccessAdminRoutes } from '@/utils/constants'
 import { formatRequestError } from '@/utils/requestErrors'
 import {
-  fetchAnnouncements,
+  fetchAnnouncement,
+  fetchAnnouncementIds,
   createAnnouncement,
   updateAnnouncement,
   deleteAnnouncement,
 } from '@/services/announcementService'
 import { PageHeader, PostContent, NavRow, PostForm } from '../_shared'
+
+const FETCH_TIMEOUT_MS = 15000
 
 export default function AnnouncementPostPage() {
   const { id } = useParams()
@@ -19,8 +22,10 @@ export default function AnnouncementPostPage() {
   const { user, profile } = useAuth()
   const isAdmin = canAccessAdminRoutes(profile?.role)
 
-  const [announcements, setAnnouncements] = useState([])
+  const [post, setPost] = useState(null)
+  const [ids, setIds] = useState([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
   const [showForm, setShowForm] = useState(false)
   const [editMode, setEditMode] = useState(false)
   const [form, setForm] = useState({ title: '', content: '' })
@@ -28,15 +33,56 @@ export default function AnnouncementPostPage() {
   const [formError, setFormError] = useState('')
   const [actionError, setActionError] = useState('')
 
-  useEffect(() => {
-    fetchAnnouncements()
-      .then(setAnnouncements)
-      .finally(() => setLoading(false))
-  }, [])
-
   const numId = Number(id)
-  const idx = announcements.findIndex(a => a.id === numId)
-  const post = idx !== -1 ? announcements[idx] : null
+
+  useEffect(() => {
+    if (!Number.isFinite(numId)) {
+      setPost(null)
+      setIds([])
+      setLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      setLoadError('')
+      try {
+        const [detail, idList] = await Promise.all([
+          fetchAnnouncement(numId, { signal: controller.signal }),
+          fetchAnnouncementIds({ signal: controller.signal }),
+        ])
+        if (cancelled) return
+        setPost(detail)
+        setIds(idList)
+      } catch (err) {
+        if (cancelled) return
+        if (!cancelled) {
+          setPost(null)
+          setIds([])
+          setLoadError(
+            err?.name === 'AbortError'
+              ? 'Request timed out. Refresh the page and try again.'
+              : (formatRequestError(err) || 'Failed to load announcement')
+          )
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    }
+  }, [numId])
+
+  const idx = ids.findIndex((itemId) => itemId === numId)
 
   function openNew() {
     setEditMode(false)
@@ -69,7 +115,6 @@ export default function AnnouncementPostPage() {
     setFormError('')
     try {
       const created = await createAnnouncement(form.title.trim(), form.content, user.id)
-      setAnnouncements(prev => [created, ...prev])
       cancelForm()
       router.push(`/announcements/${created.id}`)
     } catch (err) {
@@ -89,7 +134,7 @@ export default function AnnouncementPostPage() {
     setFormError('')
     try {
       const updated = await updateAnnouncement(numId, form.title.trim(), form.content)
-      setAnnouncements(prev => prev.map(a => a.id === numId ? updated : a))
+      setPost(updated)
       cancelForm()
     } catch (err) {
       setFormError(formatRequestError(err))
@@ -106,10 +151,10 @@ export default function AnnouncementPostPage() {
     setActionError('')
     try {
       await deleteAnnouncement(numId)
-      const remaining = announcements.filter(a => a.id !== numId)
-      setAnnouncements(remaining)
+      const remaining = ids.filter((itemId) => itemId !== numId)
       if (remaining.length > 0) {
-        router.push(`/announcements/${remaining[0].id}`)
+        const nextId = idx > 0 ? remaining[Math.min(idx, remaining.length - 1)] : remaining[0]
+        router.push(`/announcements/${nextId}`)
       } else {
         router.push('/announcements')
       }
@@ -127,7 +172,7 @@ export default function AnnouncementPostPage() {
     )
   }
 
-  if (!post) {
+  if (loadError || !post) {
     return (
       <main className="min-h-screen bg-bg-base">
         <div className="bg-bg-surface py-8 px-4 sm:px-6">
@@ -136,7 +181,9 @@ export default function AnnouncementPostPage() {
           </div>
         </div>
         <div className="bg-bg-base py-20 px-4 text-center">
-          <p className="text-text-hint font-inter">Announcement not found.</p>
+          <p className="text-text-hint font-inter">
+            {loadError || 'Announcement not found.'}
+          </p>
           <button
             onClick={() => router.push('/announcements')}
             className="mt-4 text-sm font-inter text-link hover:underline"
@@ -148,8 +195,8 @@ export default function AnnouncementPostPage() {
     )
   }
 
-  const isNewest = idx === 0
-  const isOldest = idx === announcements.length - 1
+  const isNewest = idx <= 0
+  const isOldest = idx === -1 || idx >= ids.length - 1
 
   return (
     <main className="min-h-screen bg-bg-base">
@@ -184,8 +231,8 @@ export default function AnnouncementPostPage() {
       <NavRow
         prevDisabled={isOldest}
         nextDisabled={isNewest}
-        onPrev={() => router.push(`/announcements/${announcements[idx + 1].id}`)}
-        onNext={() => router.push(`/announcements/${announcements[idx - 1].id}`)}
+        onPrev={() => router.push(`/announcements/${ids[idx + 1]}`)}
+        onNext={() => router.push(`/announcements/${ids[idx - 1]}`)}
         onList={() => router.push('/announcements?view=list')}
         onDelete={handleDelete}
         onEdit={openEdit}

--- a/src/app/announcements/page.js
+++ b/src/app/announcements/page.js
@@ -130,6 +130,7 @@ function AnnouncementsContent() {
 
   const [announcements, setAnnouncements] = useState([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
   const [showForm, setShowForm] = useState(false)
   const [editMode, setEditMode] = useState(false)
   const [form, setForm] = useState({ title: '', content: '' })
@@ -140,9 +141,37 @@ function AnnouncementsContent() {
   const view = searchParams.get('view')
 
   useEffect(() => {
-    fetchAnnouncements()
-      .then(setAnnouncements)
-      .finally(() => setLoading(false))
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      setLoadError('')
+      try {
+        const data = await fetchAnnouncements({ signal: controller.signal })
+        if (!cancelled) setAnnouncements(data)
+      } catch (err) {
+        if (cancelled) return
+        if (!cancelled) {
+          setAnnouncements([])
+          setLoadError(
+            err?.name === 'AbortError'
+              ? 'Request timed out. Refresh the page and try again.'
+              : (formatRequestError(err) || 'Failed to load announcements')
+          )
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    }
   }, [])
 
   function openNew() {
@@ -231,6 +260,17 @@ function AnnouncementsContent() {
       <div className="flex justify-center items-center py-32">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-text-primary" />
       </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <>
+        <PageHeader isAdmin={isAdmin} onNew={openNew} />
+        <div className="bg-bg-base py-20 px-4 text-center">
+          <p className="text-error font-inter text-sm">{loadError}</p>
+        </div>
+      </>
     )
   }
 

--- a/src/app/events/[id]/page.js
+++ b/src/app/events/[id]/page.js
@@ -9,8 +9,8 @@ import { canAccessAdminRoutes } from '@/utils/constants'
 import { isEventUpcoming, formatEventDate } from '@/lib/events'
 import Gallery from '@/components/gallery'
 import {
-  fetchEvents,
   fetchEventById,
+  fetchEventNavItems,
   createEvent,
   updateEvent,
   deleteEvent,
@@ -58,7 +58,7 @@ export default function EventDetailPage({ params }) {
   const isAdmin = canAccessAdminRoutes(profile?.role)
 
   const [event, setEvent] = useState(null)
-  const [allEvents, setAllEvents] = useState([])
+  const [navEvents, setNavEvents] = useState([])
   const [categoryOptions, setCategoryOptions] = useState([])
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
@@ -69,28 +69,45 @@ export default function EventDetailPage({ params }) {
   const [error, setError] = useState('')
 
   useEffect(() => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
     let cancelled = false
+
     async function load() {
       setLoading(true)
       setNotFound(false)
+      setError('')
       try {
-        const [detail, list, cats] = await Promise.all([
-          fetchEventById(id),
-          fetchEvents(),
+        const [detail, nav, cats] = await Promise.all([
+          fetchEventById(id, { signal: controller.signal }),
+          fetchEventNavItems({ signal: controller.signal }),
           fetchEventCategories(),
         ])
         if (cancelled) return
         setEvent(detail)
-        setAllEvents(list)
+        setNavEvents(nav)
         setCategoryOptions(cats)
-      } catch {
-        if (!cancelled) setNotFound(true)
+      } catch (err) {
+        if (cancelled) return
+        if (!cancelled) {
+          setNotFound(true)
+          setError(
+            err?.name === 'AbortError'
+              ? 'Request timed out. Refresh the page and try again.'
+              : (err?.message || 'Failed to load event')
+          )
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
+
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    }
   }, [id])
 
   function openNew() {
@@ -136,7 +153,13 @@ export default function EventDetailPage({ params }) {
     try {
       const updated = await updateEvent(event.id, formToPayload(form))
       setEvent(updated)
-      setAllEvents((prev) => prev.map((e) => (e.id === updated.id ? updated : e)))
+      setNavEvents((prev) =>
+        prev.map((e) =>
+          e.id === updated.id
+            ? { id: updated.id, date: updated.date, endDate: updated.endDate }
+            : e
+        )
+      )
       if (updated.category) {
         setCategoryOptions((prev) => [...new Set([...prev, updated.category])])
       }
@@ -185,8 +208,8 @@ export default function EventDetailPage({ params }) {
 
   const isPast = !isEventUpcoming(event)
   const siblings = isPast
-    ? sortPast(allEvents.filter((e) => !isEventUpcoming(e)))
-    : sortUpcoming(allEvents.filter(isEventUpcoming))
+    ? sortPast(navEvents.filter((e) => !isEventUpcoming(e)))
+    : sortUpcoming(navEvents.filter(isEventUpcoming))
   const { previous, next } = getAdjacent(siblings, event.id)
 
   const btnBase = 'px-4 py-2 border rounded-md text-sm font-inter transition-colors'

--- a/src/app/events/page.js
+++ b/src/app/events/page.js
@@ -49,13 +49,41 @@ export default function EventsPage() {
   const [error, setError] = useState('')
 
   useEffect(() => {
-    Promise.all([fetchEvents(), fetchEventCategories()])
-      .then(([list, cats]) => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      setError('')
+      try {
+        const [list, cats] = await Promise.all([
+          fetchEvents({ signal: controller.signal }),
+          fetchEventCategories(),
+        ])
+        if (cancelled) return
         setEvents(list)
         setCategoryOptions(cats)
-      })
-      .catch((err) => setError(err.message || 'Failed to load events'))
-      .finally(() => setLoading(false))
+      } catch (err) {
+        if (cancelled) return
+        if (!cancelled) {
+          setError(
+            err?.name === 'AbortError'
+              ? 'Request timed out. Refresh the page and try again.'
+              : (err.message || 'Failed to load events')
+          )
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    }
   }, [])
 
   function openNew() {

--- a/src/app/members/[id]/page.js
+++ b/src/app/members/[id]/page.js
@@ -346,19 +346,36 @@ export default function ProfilePage({ params }) {
   const initializedRef = useRef(false)
 
   useEffect(() => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
     let cancelled = false
+
     async function load() {
+      setLoading(true)
+      setError(null)
       try {
-        const data = await fetchMemberById(id)
+        const data = await fetchMemberById(id, { signal: controller.signal })
         if (!cancelled) setMember(data)
       } catch (err) {
-        if (!cancelled) setError(err)
+        if (cancelled) return
+        if (!cancelled) {
+          setError(
+            err?.name === 'AbortError'
+              ? new Error('Request timed out. Refresh the page and try again.')
+              : err
+          )
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
+
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    }
   }, [id])
 
   useEffect(() => {

--- a/src/app/members/page.js
+++ b/src/app/members/page.js
@@ -87,19 +87,34 @@ export default function MembersPage() {
   const [sort, setSort] = useState('name-asc')
 
   useEffect(() => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
     let cancelled = false
+
     async function load() {
       try {
-        const data = await fetchMembers()
+        const data = await fetchMembers({ signal: controller.signal })
         if (!cancelled) setMembers(data)
       } catch (err) {
-        if (!cancelled) setError(err)
+        if (cancelled) return
+        if (!cancelled) {
+          setError(
+            err?.name === 'AbortError'
+              ? new Error('Request timed out. Refresh the page and try again.')
+              : err
+          )
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
+
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    }
   }, [])
 
   const cohortOptions = useMemo(() => {

--- a/src/app/mentor/page.js
+++ b/src/app/mentor/page.js
@@ -6,6 +6,7 @@ import { getOptimizedUrl } from '@/services/cloudinaryService'
 import { getSiteSetting } from '@/services/siteSettingsService'
 import MentorPhotoEditor from '@/components/mentor/MentorPhotoEditor'
 import PageCTA from '@/components/common/PageCTA'
+import { createLoadGuard } from '@/utils/loadGuard'
 
 const FALLBACK_PHOTO = '/mentor.png'
 
@@ -30,19 +31,21 @@ export default function MentorPage() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    let cancelled = false
+    const guard = createLoadGuard()
+
     async function load() {
       try {
-        const url = await getSiteSetting('mentor_photo_url')
-        if (!cancelled) setPhotoUrl(url)
+        const url = await getSiteSetting('mentor_photo_url', { signal: guard.signal })
+        if (!guard.isCancelled()) setPhotoUrl(url)
       } catch {
-        if (!cancelled) setPhotoUrl(null)
+        if (!guard.isCancelled()) setPhotoUrl(null)
       } finally {
-        if (!cancelled) setLoading(false)
+        if (!guard.isCancelled()) setLoading(false)
       }
     }
+
     load()
-    return () => { cancelled = true }
+    return () => guard.cleanup()
   }, [])
 
   const src = getOptimizedUrl(photoUrl) ?? FALLBACK_PHOTO

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -8,7 +8,8 @@ import Button from '@/components/ui/Button'
 import JoinUsButton from '@/components/ui/JoinUsButton'
 import HeroImageEditor from '@/components/home/HeroImageEditor'
 import { getOptimizedUrl } from '@/services/cloudinaryService'
-import { supabase } from '@/lib/supabase'
+import { getSiteSetting } from '@/services/siteSettingsService'
+import { createLoadGuard } from '@/utils/loadGuard'
 
 const FALLBACK_HERO = '/hero.jpg'
 
@@ -16,14 +17,19 @@ export default function HomePage() {
   const [heroUrl, setHeroUrl] = useState(null)
 
   useEffect(() => {
-    supabase
-      .from('site_settings')
-      .select('value')
-      .eq('key', 'hero_image_url')
-      .single()
-      .then(({ data }) => {
-        if (data?.value) setHeroUrl(data.value)
-      })
+    const guard = createLoadGuard()
+
+    async function load() {
+      try {
+        const url = await getSiteSetting('hero_image_url', { signal: guard.signal })
+        if (!guard.isCancelled() && url) setHeroUrl(url)
+      } catch {
+        // Keep fallback hero on timeout/error
+      }
+    }
+
+    load()
+    return () => guard.cleanup()
   }, [])
 
   const src = getOptimizedUrl(heroUrl) ?? FALLBACK_HERO

--- a/src/app/problems/page.js
+++ b/src/app/problems/page.js
@@ -370,31 +370,53 @@ function ProblemsContent() {
     if (idx !== -1) setCurrentIdx(idx)
   }, [problems, searchParams])
 
-  const loadProblems = useCallback(async () => {
+  const loadProblems = useCallback(async (signal) => {
     setLoading(true)
     setError(null)
     try {
-      const data = await fetchProblems(schoolFilter)
+      const data = await fetchProblems(schoolFilter, { signal })
       setProblems(data)
-    } catch {
-      setError('Failed to load problems. Please try again.')
+    } catch (err) {
+      if (err?.name === 'AbortError') {
+        setError('Request timed out. Refresh the page and try again.')
+      } else {
+        setError('Failed to load problems. Please try again.')
+      }
     } finally {
       setLoading(false)
     }
   }, [schoolFilter])
 
-  const loadSubmissions = useCallback(async () => {
+  const loadSubmissions = useCallback(async (signal) => {
     if (!profile?.id) return
     try {
-      const solved = await fetchUserSubmissions(profile.id)
+      const solved = await fetchUserSubmissions(profile.id, { signal })
       setUserSubmissions(solved)
     } catch {
       // Non-critical
     }
   }, [profile?.id])
 
-  useEffect(() => { loadProblems() }, [loadProblems])
-  useEffect(() => { loadSubmissions() }, [loadSubmissions])
+  useEffect(() => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
+    loadProblems(controller.signal)
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
+    }
+  }, [loadProblems])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
+    loadSubmissions(controller.signal)
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
+    }
+  }, [loadSubmissions])
+
   useEffect(() => { setCurrentIdx(0) }, [schoolFilter])
 
   function navigateTo(idx) {

--- a/src/app/schedule/page.js
+++ b/src/app/schedule/page.js
@@ -140,31 +140,39 @@ export default function SchedulePage() {
   const [hasError, setHasError] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState(null);
 
-  const fetchEvents = useCallback(async (y, m, signal) => {
-    setIsLoading(true);
-    setHasError(false);
-    try {
-      const res = await fetch(`/api/calendar?year=${y}&month=${m}`, {
-        cache: 'no-store',
-        signal,
-      });
-      if (!res.ok) throw new Error('Network error');
-      const data = await res.json();
-      setEvents(data.events ?? []);
-      setIsLoading(false);
-    } catch (err) {
-      if (err.name === 'AbortError') return; // newer request is in flight — ignore
-      setHasError(true);
-      setEvents([]);
-      setIsLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
     const controller = new AbortController();
-    fetchEvents(year, month, controller.signal);
-    return () => controller.abort();
-  }, [year, month, fetchEvents]);
+    const timer = setTimeout(() => controller.abort(), 15000);
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setHasError(false);
+      try {
+        const res = await fetch(`/api/calendar?year=${year}&month=${month}`, {
+          cache: 'no-store',
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error('Network error');
+        const data = await res.json();
+        if (cancelled) return;
+        setEvents(data.events ?? []);
+        setIsLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setHasError(true);
+        setEvents([]);
+        setIsLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [year, month]);
 
   const handleCloseModal = useCallback(() => setSelectedEvent(null), []);
 

--- a/src/app/solutions/[id]/page.js
+++ b/src/app/solutions/[id]/page.js
@@ -119,6 +119,8 @@ function SolutionWorkspace() {
       : ''
 
   useEffect(() => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
     let cancelled = false
 
     async function load() {
@@ -131,12 +133,14 @@ function SolutionWorkspace() {
       setLoading(true)
       setError('')
       try {
-        const row = await fetchProblemById(problemId)
+        const row = await fetchProblemById(problemId, { signal: controller.signal })
         if (cancelled) return
         setProblem(row)
 
         if (profile?.id) {
-          const own = await fetchOwnSubmission(profile.id, problemId)
+          const own = await fetchOwnSubmission(profile.id, problemId, {
+            signal: controller.signal,
+          })
           if (cancelled) return
           if (own?.code) {
             setCode(own.code)
@@ -144,24 +148,42 @@ function SolutionWorkspace() {
           }
         }
       } catch (err) {
-        if (!cancelled) setError(err.message || 'Failed to load problem')
+        if (cancelled) return
+        if (!cancelled) {
+          setError(
+            err?.name === 'AbortError'
+              ? 'Request timed out. Refresh the page and try again.'
+              : (err.message || 'Failed to load problem')
+          )
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
 
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    }
   }, [problemId, profile?.id])
 
   const loadCommunity = useCallback(async () => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
     setCommunityLoading(true)
     try {
-      const rows = await fetchCommunitySubmissions(problemId)
+      const rows = await fetchCommunitySubmissions(problemId, { signal: controller.signal })
       setCommunity(rows)
     } catch (err) {
-      setError(err.message || 'Failed to load community solutions')
+      if (err?.name !== 'AbortError') {
+        setError(err.message || 'Failed to load community solutions')
+      } else {
+        setError('Request timed out. Refresh the page and try again.')
+      }
     } finally {
+      clearTimeout(timer)
       setCommunityLoading(false)
     }
   }, [problemId])

--- a/src/app/solutions/page.js
+++ b/src/app/solutions/page.js
@@ -26,6 +26,8 @@ function SolutionsListContent() {
   const [error, setError] = useState('')
 
   useEffect(() => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 15000)
     let cancelled = false
 
     async function load() {
@@ -33,21 +35,34 @@ function SolutionsListContent() {
       setError('')
       try {
         const [problemRows, submitted] = await Promise.all([
-          fetchProblems(),
-          profile?.id ? fetchUserSubmissions(profile.id) : Promise.resolve(new Set()),
+          fetchProblems(undefined, { signal: controller.signal }),
+          profile?.id
+            ? fetchUserSubmissions(profile.id, { signal: controller.signal })
+            : Promise.resolve(new Set()),
         ])
         if (cancelled) return
         setProblems(problemRows)
         setUserSubmissions(submitted)
       } catch (err) {
-        if (!cancelled) setError(err.message || 'Failed to load problems')
+        if (cancelled) return
+        if (!cancelled) {
+          setError(
+            err?.name === 'AbortError'
+              ? 'Request timed out. Refresh the page and try again.'
+              : (err.message || 'Failed to load problems')
+          )
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
 
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    }
   }, [profile?.id])
 
   return (

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -3,6 +3,7 @@
 import { createContext, useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import { getSession, fetchProfile, signOut as authSignOut } from '@/services/authService'
+import { withTimeout } from '@/utils/withTimeout'
 
 export const AuthContext = createContext(null)
 
@@ -17,22 +18,33 @@ export function AuthProvider({ children }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     let initialized = false
+    let cancelled = false
 
     async function init() {
       // Clear any stale OAuth flag left from a previous abandoned flow
       // (covers the full-remount case where pageshow doesn't reload).
       sessionStorage.removeItem('oauth_pending')
       try {
-        const session = await getSession()
+        const session = await withTimeout(getSession())
+        if (cancelled) return
         setUser(session?.user ?? null)
         setAccessToken(session?.access_token ?? null)
         if (session?.user) {
-          const p = await fetchProfile(session.user.id)
+          const p = await withTimeout(fetchProfile(session.user.id))
+          if (cancelled) return
           setProfile(p)
         }
+      } catch {
+        if (!cancelled) {
+          setUser(null)
+          setProfile(null)
+          setAccessToken(null)
+        }
       } finally {
-        setLoading(false)
-        initialized = true
+        if (!cancelled) {
+          setLoading(false)
+          initialized = true
+        }
       }
     }
 
@@ -52,7 +64,7 @@ export function AuthProvider({ children }) {
       }
       ;(async () => {
         try {
-          const session = await getSession()
+          const session = await withTimeout(getSession())
           setUser(session?.user ?? null)
           setAccessToken(session?.access_token ?? null)
           if (!session?.user) setProfile(null)
@@ -75,7 +87,7 @@ export function AuthProvider({ children }) {
         setAccessToken(session?.access_token ?? null)
         if (session?.user) {
           try {
-            const p = await fetchProfile(session.user.id)
+            const p = await withTimeout(fetchProfile(session.user.id))
             setProfile(p)
           } catch {
             setProfile(null)
@@ -87,6 +99,7 @@ export function AuthProvider({ children }) {
     )
 
     return () => {
+      cancelled = true
       subscription.unsubscribe()
       window.removeEventListener('pageshow', handlePageShow)
     }

--- a/src/services/announcementService.js
+++ b/src/services/announcementService.js
@@ -18,13 +18,46 @@ function assertLength(title, content) {
   if (error) throw new Error(error)
 }
 
-export async function fetchAnnouncements() {
-  const { data, error } = await supabase
-    .from('announcements')
-    .select(SELECT_FIELDS)
-    .order('created_at', { ascending: false })
+function withSignal(query, signal) {
+  return signal ? query.abortSignal(signal) : query
+}
+
+export async function fetchAnnouncements({ signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('announcements')
+      .select(SELECT_FIELDS)
+      .order('created_at', { ascending: false }),
+    signal
+  )
   if (error) throw error
   return data.map(map)
+}
+
+export async function fetchAnnouncement(id, { signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('announcements')
+      .select(SELECT_FIELDS)
+      .eq('id', id)
+      .single(),
+    signal
+  )
+  if (error) throw error
+  return map(data)
+}
+
+/** Ordered ids only — for prev/next without downloading every post body. */
+export async function fetchAnnouncementIds({ signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('announcements')
+      .select('id')
+      .order('created_at', { ascending: false }),
+    signal
+  )
+  if (error) throw error
+  return (data ?? []).map((row) => row.id)
 }
 
 export async function createAnnouncement(title, content, authorId) {

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -58,6 +58,10 @@ function toRow(payload) {
   }
 }
 
+function withSignal(query, signal) {
+  return signal ? query.abortSignal(signal) : query
+}
+
 export async function fetchEventCategories() {
   const { data, error } = await supabase
     .from('events')
@@ -72,21 +76,44 @@ export async function fetchEventCategories() {
   return [...set].sort((a, b) => a.localeCompare(b))
 }
 
-export async function fetchEvents() {
-  const { data, error } = await supabase
-    .from('events')
-    .select(SELECT_FIELDS)
-    .order('event_date', { ascending: false })
+export async function fetchEvents({ signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('events')
+      .select(SELECT_FIELDS)
+      .order('event_date', { ascending: false }),
+    signal
+  )
   if (error) throw error
   return data.map(map)
 }
 
-export async function fetchEventById(id) {
-  const { data, error } = await supabase
-    .from('events')
-    .select(SELECT_FIELDS)
-    .eq('id', id)
-    .single()
+/** Lightweight list for prev/next (date fields only). */
+export async function fetchEventNavItems({ signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('events')
+      .select('id, event_date, end_date')
+      .order('event_date', { ascending: false }),
+    signal
+  )
+  if (error) throw error
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    date: row.event_date,
+    endDate: row.end_date ?? null,
+  }))
+}
+
+export async function fetchEventById(id, { signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('events')
+      .select(SELECT_FIELDS)
+      .eq('id', id)
+      .single(),
+    signal
+  )
   if (error) throw error
   return map(data)
 }

--- a/src/services/executiveService.js
+++ b/src/services/executiveService.js
@@ -2,8 +2,8 @@ import { supabase } from '@/lib/supabase'
 
 // Returns all currently active executives (end_date IS NULL),
 // joined with their profile. Used by the About page.
-export async function getCurrentExecutives() {
-  const { data, error } = await supabase
+export async function getCurrentExecutives({ signal } = {}) {
+  let query = supabase
     .from('executive_roles')
     .select(`
       id,
@@ -24,6 +24,8 @@ export async function getCurrentExecutives() {
     `)
     .is('end_date', null)
     .order('created_at', { ascending: true })
+  if (signal) query = query.abortSignal(signal)
+  const { data, error } = await query
 
   if (error) throw error
 

--- a/src/services/membersService.js
+++ b/src/services/membersService.js
@@ -23,23 +23,33 @@ function mapMember(row) {
   }
 }
 
-export async function fetchMembers() {
-  const { data, error } = await supabase
-    .from('profiles')
-    .select(MEMBER_FIELDS)
-    .neq('role', 'pending')
-    .order('first_name', { ascending: true })
+function withSignal(query, signal) {
+  return signal ? query.abortSignal(signal) : query
+}
+
+export async function fetchMembers({ signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('profiles')
+      .select(MEMBER_FIELDS)
+      .neq('role', 'pending')
+      .order('first_name', { ascending: true }),
+    signal
+  )
 
   if (error) throw error
   return (data ?? []).map(mapMember)
 }
 
-export async function fetchMemberById(id) {
-  const { data, error } = await supabase
-    .from('profiles')
-    .select(MEMBER_FIELDS)
-    .eq('id', id)
-    .single()
+export async function fetchMemberById(id, { signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('profiles')
+      .select(MEMBER_FIELDS)
+      .eq('id', id)
+      .single(),
+    signal
+  )
   if (error) throw error
   return mapMember(data)
 }

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -80,7 +80,7 @@ export function detectProblemFileType(file) {
   return null
 }
 
-export async function fetchProblems(schoolFilter) {
+export async function fetchProblems(schoolFilter, { signal } = {}) {
   let query = supabase
     .from('problems')
     .select(SELECT_FIELDS)
@@ -91,17 +91,18 @@ export async function fetchProblems(schoolFilter) {
     query = query.eq('school', schoolFilter)
   }
 
-  const { data, error } = await query
+  const { data, error } = await (signal ? query.abortSignal(signal) : query)
   if (error) throw error
   return (data ?? []).map(mapProblem)
 }
 
-export async function fetchProblemById(id) {
-  const { data, error } = await supabase
+export async function fetchProblemById(id, { signal } = {}) {
+  let query = supabase
     .from('problems')
     .select(SELECT_FIELDS)
     .eq('id', id)
     .single()
+  const { data, error } = await (signal ? query.abortSignal(signal) : query)
   if (error) throw error
   return mapProblem(data)
 }

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase'
+import { fetchWithTimeout } from '@/utils/fetchWithTimeout'
 
 export const PROBLEM_BUCKET = 'problem-documents'
 export const MAX_DOCUMENT_BYTES = 50 * 1024 * 1024
@@ -199,13 +200,15 @@ export async function uploadProblemDocument(file, problemId, accessToken) {
   }
 }
 
+import { fetchWithTimeout } from '@/utils/fetchWithTimeout'
+
 export async function previewDocxAsPdf(file, accessToken) {
   if (!accessToken) throw new Error('Not authenticated.')
 
   const formData = new FormData()
   formData.append('file', file)
 
-  const res = await fetch('/api/problems/documents/preview', {
+  const res = await fetchWithTimeout('/api/problems/documents/preview', {
     method: 'POST',
     headers: { Authorization: `Bearer ${accessToken}` },
     body: formData,
@@ -222,7 +225,7 @@ export async function previewDocxAsPdf(file, accessToken) {
 export async function getDocumentSignedUrl(storagePath, accessToken) {
   if (!accessToken) throw new Error('Not authenticated.')
 
-  const res = await fetch(
+  const res = await fetchWithTimeout(
     `/api/problems/documents?path=${encodeURIComponent(storagePath)}`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   )
@@ -239,7 +242,7 @@ export async function downloadProblemDocument(storagePath, accessToken, filename
   })
   if (filename) params.set('filename', filename)
 
-  const res = await fetch(`/api/problems/documents?${params}`, {
+  const res = await fetchWithTimeout(`/api/problems/documents?${params}`, {
     headers: { Authorization: `Bearer ${accessToken}` },
   })
   if (!res.ok) {

--- a/src/services/problemsService.js
+++ b/src/services/problemsService.js
@@ -200,8 +200,6 @@ export async function uploadProblemDocument(file, problemId, accessToken) {
   }
 }
 
-import { fetchWithTimeout } from '@/utils/fetchWithTimeout'
-
 export async function previewDocxAsPdf(file, accessToken) {
   if (!accessToken) throw new Error('Not authenticated.')
 

--- a/src/services/siteSettingsService.js
+++ b/src/services/siteSettingsService.js
@@ -1,11 +1,13 @@
 import { supabase } from '@/lib/supabase'
 
-export async function getSiteSetting(key) {
-  const { data, error } = await supabase
+export async function getSiteSetting(key, { signal } = {}) {
+  let query = supabase
     .from('site_settings')
     .select('value')
     .eq('key', key)
     .maybeSingle()
+  if (signal) query = query.abortSignal(signal)
+  const { data, error } = await query
   if (error) throw error
   return data?.value ?? null
 }

--- a/src/services/submissionsService.js
+++ b/src/services/submissionsService.js
@@ -1,29 +1,40 @@
 import { supabase } from '@/lib/supabase'
 
-export async function fetchUserSubmissions(profileId) {
-  const { data, error } = await supabase
-    .from('submissions')
-    .select('problem_id')
-    .eq('profile_id', profileId)
+function withSignal(query, signal) {
+  return signal ? query.abortSignal(signal) : query
+}
+
+export async function fetchUserSubmissions(profileId, { signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('submissions')
+      .select('problem_id')
+      .eq('profile_id', profileId),
+    signal
+  )
   if (error) throw error
   return new Set((data ?? []).map((s) => s.problem_id))
 }
 
-export async function fetchOwnSubmission(profileId, problemId) {
-  const { data, error } = await supabase
-    .from('submissions')
-    .select('id, code, language, created_at, updated_at')
-    .eq('profile_id', profileId)
-    .eq('problem_id', problemId)
-    .maybeSingle()
+export async function fetchOwnSubmission(profileId, problemId, { signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('submissions')
+      .select('id, code, language, created_at, updated_at')
+      .eq('profile_id', profileId)
+      .eq('problem_id', problemId)
+      .maybeSingle(),
+    signal
+  )
   if (error) throw error
   return data
 }
 
-export async function fetchCommunitySubmissions(problemId) {
-  const { data, error } = await supabase
-    .from('submissions')
-    .select(`
+export async function fetchCommunitySubmissions(problemId, { signal } = {}) {
+  const { data, error } = await withSignal(
+    supabase
+      .from('submissions')
+      .select(`
       id,
       code,
       language,
@@ -36,9 +47,11 @@ export async function fetchCommunitySubmissions(problemId) {
         avatar_url
       )
     `)
-    .eq('problem_id', problemId)
-    .order('updated_at', { ascending: false, nullsFirst: false })
-    .order('created_at', { ascending: false })
+      .eq('problem_id', problemId)
+      .order('updated_at', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false }),
+    signal
+  )
 
   if (error) throw error
 

--- a/src/utils/loadGuard.js
+++ b/src/utils/loadGuard.js
@@ -1,0 +1,47 @@
+const DEFAULT_LOAD_TIMEOUT_MS = 15000
+
+/**
+ * Standard guard for client-side data loads (Supabase queries, parallel fetches).
+ * Use in useEffect: call cleanup() on unmount.
+ *
+ * @example
+ * useEffect(() => {
+ *   const guard = createLoadGuard()
+ *   async function load() {
+ *     try {
+ *       setLoading(true)
+ *       const data = await fetchThings({ signal: guard.signal })
+ *       if (!guard.isCancelled()) setThings(data)
+ *     } catch (err) {
+ *       if (!guard.isCancelled()) setError(guard.loadError(err))
+ *     } finally {
+ *       if (!guard.isCancelled()) setLoading(false)
+ *     }
+ *   }
+ *   load()
+ *   return () => guard.cleanup()
+ * }, [])
+ */
+export function createLoadGuard(ms = DEFAULT_LOAD_TIMEOUT_MS) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), ms)
+  let cancelled = false
+
+  return {
+    signal: controller.signal,
+    isCancelled: () => cancelled,
+    cleanup() {
+      cancelled = true
+      clearTimeout(timer)
+      controller.abort()
+    },
+    loadError(err, fallback = 'Failed to load. Please try again.') {
+      if (err?.name === 'AbortError') {
+        return 'Request timed out. Refresh the page and try again.'
+      }
+      return err?.message || fallback
+    },
+  }
+}
+
+export { DEFAULT_LOAD_TIMEOUT_MS }

--- a/src/utils/requestErrors.js
+++ b/src/utils/requestErrors.js
@@ -1,8 +1,8 @@
 export function formatRequestError(error) {
   const message = error?.message ?? 'Something went wrong. Please try again.'
 
-  if (message.includes('timed out') || message.includes('timeout')) {
-    return `${message} If this keeps happening, refresh the page and log in again.`
+  if (message.includes('timed out') || message.includes('timeout') || error?.name === 'AbortError') {
+    return 'Request timed out. Refresh the page and try again.'
   }
 
   if (message.includes('No active session') || message.includes('Unauthorized')) {


### PR DESCRIPTION
## Summary
- Stop infinite spinners with 15s AbortController timeouts and explicit load errors
- Announcement/Event detail pages no longer re-download full lists for prev/next (single item + light nav)
- Apply the same abort/timeout pattern to Announcements, Events, Members, Problems, and Solutions loaders

## Test plan
- [ ] Navigate quickly between Announcements, Events, Members, Problems, Solutions — no stuck spinner
- [ ] Announcement detail and Event detail load and prev/next still work
- [ ] Force a slow network (or offline mid-request) — timeout message appears within ~15s
- [ ] Problems school filter and Solutions community tab still load