### PR TITLE
feat: add admin member CSV export for Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Public (Unauthenticated)
 | **Public** | Landing, public announcements, events |
 | **Member** | Dashboard, member directory, problem submissions |
 | **Executive** | Post problems, manage sessions, events CRUD |
-| **Admin** | User approval, role management, executive position assignment for Our Team, full access |
+| **Admin** | User approval, role management, executive position assignment for Our Team, member CSV export for Excel, full access |
 
 **Onboarding flow:** `Google Sign-In → pending → Admin approval → member`
 

--- a/src/app/admin/_components/MemberTable.js
+++ b/src/app/admin/_components/MemberTable.js
@@ -2,7 +2,9 @@
 
 import { useMemo, useState } from 'react'
 import UserAvatar from '@/components/common/UserAvatar'
+import Button from '@/components/ui/Button'
 import { cohortLabel } from '@/utils/cohort'
+import { downloadMembersCsv } from '@/utils/membersCsv'
 import { isPendingApplicant } from '@/services/adminService'
 import {
   compareNumberLike,
@@ -126,7 +128,20 @@ export default function MemberTable({
             )}
           </p>
           {isAdmin && (
-            <p className="text-xs text-text-hint font-inter hidden sm:block">Click a name to edit · click headers to sort</p>
+            <div className="flex items-center gap-3">
+              <p className="text-xs text-text-hint font-inter hidden sm:block">
+                Click a name to edit · click headers to sort
+              </p>
+              <Button
+                type="button"
+                variant="secondary"
+                className="px-3 py-1.5 text-xs shrink-0"
+                disabled={members.length === 0}
+                onClick={() => downloadMembersCsv(members)}
+              >
+                Export CSV
+              </Button>
+            </div>
           )}
         </div>
 

--- a/src/app/api/admin/members/route.js
+++ b/src/app/api/admin/members/route.js
@@ -8,7 +8,9 @@ export async function GET(request) {
 
   const { data, error } = await serviceClient
     .from('profiles')
-    .select('id, first_name, last_name, email, avatar_url, school, cohort, phone, status, role, application_status, created_at')
+    .select(
+      'id, first_name, last_name, nickname, email, avatar_url, school, cohort, phone, status, role, application_status, occupation, company, linkedin, github, bio, created_at, updated_at'
+    )
     .neq('application_status', 'rejected')
     .order('first_name', { ascending: true })
 

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -30,6 +30,7 @@ function mapMember(row) {
     id: row.id,
     firstName: row.first_name,
     lastName: row.last_name,
+    nickname: row.nickname ?? null,
     email: row.email,
     avatarUrl: row.avatar_url,
     school: row.school,
@@ -38,7 +39,13 @@ function mapMember(row) {
     status: row.status,
     role: row.role,
     applicationStatus: row.application_status,
+    occupation: row.occupation ?? null,
+    company: row.company ?? null,
+    linkedin: row.linkedin ?? null,
+    github: row.github ?? null,
+    bio: row.bio ?? null,
     createdAt: row.created_at,
+    updatedAt: row.updated_at ?? null,
     executiveTitle: row.executive_title ?? null,
   }
 }

--- a/src/utils/membersCsv.js
+++ b/src/utils/membersCsv.js
@@ -1,0 +1,52 @@
+const CSV_COLUMNS = [
+  { key: 'id', header: 'ID' },
+  { key: 'firstName', header: 'First Name' },
+  { key: 'lastName', header: 'Last Name' },
+  { key: 'nickname', header: 'Nickname' },
+  { key: 'email', header: 'Email' },
+  { key: 'phone', header: 'Phone' },
+  { key: 'school', header: 'School' },
+  { key: 'cohort', header: 'Cohort' },
+  { key: 'status', header: 'Status' },
+  { key: 'role', header: 'Role' },
+  { key: 'executiveTitle', header: 'Executive Title' },
+  { key: 'applicationStatus', header: 'Application Status' },
+  { key: 'occupation', header: 'Occupation' },
+  { key: 'company', header: 'Company' },
+  { key: 'linkedin', header: 'LinkedIn' },
+  { key: 'github', header: 'GitHub' },
+  { key: 'bio', header: 'Bio' },
+  { key: 'avatarUrl', header: 'Avatar URL' },
+  { key: 'createdAt', header: 'Created At' },
+  { key: 'updatedAt', header: 'Updated At' },
+]
+
+function escapeCsvCell(value) {
+  if (value == null) return ''
+  const str = String(value)
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export function buildMembersCsv(members) {
+  const header = CSV_COLUMNS.map(col => col.header).join(',')
+  const rows = members.map(member =>
+    CSV_COLUMNS.map(col => escapeCsvCell(member[col.key])).join(',')
+  )
+  // UTF-8 BOM so Excel opens Korean / special characters correctly
+  return `\uFEFF${[header, ...rows].join('\n')}`
+}
+
+export function downloadMembersCsv(members, filename) {
+  const csv = buildMembersCsv(members)
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  const stamp = new Date().toISOString().slice(0, 10)
+  link.href = url
+  link.download = filename ?? `codexperts-members-${stamp}.csv`
+  link.click()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
- Add an admin-only **Export CSV** button on `/admin` so the full member roster can be opened in Excel
- Expand the admin members API/select to include all profile fields used in the export (nickname, occupation, company, socials, bio, timestamps)
- Use UTF-8 BOM CSV so Excel handles special characters correctly

## Test plan
- [ ] Log in as admin and open `/admin`
- [ ] Confirm **Export CSV** appears and downloads `codexperts-members-YYYY-MM-DD.csv`
- [ ] Open the file in Excel and verify columns (name, email, phone, school, cohort, role, status, occupation, company, LinkedIn, GitHub, bio, etc.)
- [ ] Confirm non-admin (executive) does not see the export button
- [ ] Confirm export is disabled when the member list is empty